### PR TITLE
Update gitmodules to use read-only git refs instead of the read-write ones.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,39 +1,39 @@
 [submodule "src/services"]
-	path = src/services
-	url = git@github.com:cloudfoundry/vcap-services.git
+  path = src/services
+  url = git://github.com/cloudfoundry/vcap-services.git
 [submodule "src/core"]
-	path = src/core
-	url = git@github.com:cloudfoundry/vcap.git
+  path = src/core
+  url = git://github.com/cloudfoundry/vcap.git
 [submodule "src/tools"]
-	path = src/tools
-	url = git@github.com:cloudfoundry/vcap-tools.git
+  path = src/tools
+  url = git://github.com/cloudfoundry/vcap-tools.git
 [submodule "src/vblob_src"]
-	path = src/vblob_src
-	url = git@github.com:cloudfoundry/vblob.git
+  path = src/vblob_src
+  url = git://github.com/cloudfoundry/vblob.git
 [submodule "src/acm"]
-	path = src/acm
-	url = git@github.com:cloudfoundry/acm.git
+  path = src/acm
+  url = git://github.com/cloudfoundry/acm.git
 [submodule "src/dea"]
-	path = src/dea
-	url = git@github.com:cloudfoundry/dea.git
+  path = src/dea
+  url = git://github.com/cloudfoundry/dea.git
 [submodule "src/dea_next"]
-	path = src/dea_next
-	url = git@github.com:cloudfoundry/dea_ng.git
+  path = src/dea_next
+  url = https://github.com/cloudfoundry/dea_ng.git
 [submodule "src/health_manager_next"]
-	path = src/health_manager_next
-	url = git://github.com/cloudfoundry/health_manager.git
+  path = src/health_manager_next
+  url = git://github.com/cloudfoundry/health_manager.git
 [submodule "src/router"]
-	path = src/router
-	url = git@github.com:cloudfoundry/router.git
+  path = src/router
+  url = git://github.com/cloudfoundry/router.git
 [submodule "src/stager"]
-	path = src/stager
-	url = git@github.com:cloudfoundry/stager.git
+  path = src/stager
+  url = git://github.com/cloudfoundry/stager.git
 [submodule "src/warden"]
-	path = src/warden
-	url = git@github.com:cloudfoundry/warden.git
+  path = src/warden
+  url = git://github.com/cloudfoundry/warden.git
 [submodule "src/cloud_controller"]
-	path = src/cloud_controller
-	url = git@github.com:cloudfoundry/cloud_controller.git
+  path = src/cloud_controller
+  url = git://github.com/cloudfoundry/cloud_controller.git
 [submodule "src/cloud_controller_ng"]
-	path = src/cloud_controller_ng
-	url = git@github.com:cloudfoundry/cloud_controller_ng.git
+  path = src/cloud_controller_ng
+  url = git://github.com/cloudfoundry/cloud_controller_ng.git


### PR DESCRIPTION
If you're installing cf-release on a system without a public_key that is
registered to a github account, `git submodule update` can fail due to
permission denied on the ssh. Updating the submodules to use the
read-only only git URL avoids this.
