### PR TITLE
Remove unixsocket check for warden-server

### DIFF
--- a/jobs/memcached_node_ng/monit
+++ b/jobs/memcached_node_ng/monit
@@ -2,7 +2,6 @@ check process warden
   with pidfile /var/vcap/sys/run/warden/warden.pid
   start program "/var/vcap/jobs/memcached_node_ng/bin/warden_ctl start"
   stop program "/var/vcap/jobs/memcached_node_ng/bin/warden_ctl stop"
-  if failed unixsocket /tmp/warden.sock with timeout 10 seconds then restart
   group vcap
 
 check process memcached_node

--- a/jobs/mongodb_node_ng/monit
+++ b/jobs/mongodb_node_ng/monit
@@ -2,7 +2,6 @@ check process warden
   with pidfile /var/vcap/sys/run/warden/warden.pid
   start program "/var/vcap/jobs/mongodb_node_ng/bin/warden_ctl start"
   stop program "/var/vcap/jobs/mongodb_node_ng/bin/warden_ctl stop"
-  if failed unixsocket /tmp/warden.sock with timeout 10 seconds then restart
   group vcap
 
 check process mongodb_node

--- a/jobs/mysql_node_ng/monit
+++ b/jobs/mysql_node_ng/monit
@@ -27,7 +27,6 @@ check process warden
   with pidfile /var/vcap/sys/run/warden/warden.pid
   start program "/var/vcap/jobs/mysql_node_ng/bin/warden_ctl start"
   stop program "/var/vcap/jobs/mysql_node_ng/bin/warden_ctl stop"
-  if failed unixsocket /tmp/warden.sock with timeout 10 seconds then restart
   group vcap
 <% else %>
 <% supported_versions.each do |version| %>

--- a/jobs/postgresql_node_ng/monit
+++ b/jobs/postgresql_node_ng/monit
@@ -24,7 +24,6 @@ check process warden
   with pidfile /var/vcap/sys/run/warden/warden.pid
   start program "/var/vcap/jobs/postgresql_node_ng/bin/warden_ctl start"
   stop program "/var/vcap/jobs/postgresql_node_ng/bin/warden_ctl stop"
-  if failed unixsocket /tmp/warden.sock with timeout 10 seconds then restart
   group vcap
 <% else %>
 <% supported_versions.each do |version| %>

--- a/jobs/rabbit_node_ng/templates/monit.erb
+++ b/jobs/rabbit_node_ng/templates/monit.erb
@@ -2,7 +2,6 @@ check process warden
   with pidfile /var/vcap/sys/run/warden/warden.pid
   start program "/var/vcap/jobs/rabbit_node_ng/bin/warden_ctl start"
   stop program "/var/vcap/jobs/rabbit_node_ng/bin/warden_ctl stop"
-  if failed unixsocket /tmp/warden.sock with timeout 10 seconds then restart
   group vcap
 
 check process rabbit_node

--- a/jobs/redis_node_ng/monit
+++ b/jobs/redis_node_ng/monit
@@ -2,7 +2,6 @@ check process warden
   with pidfile /var/vcap/sys/run/warden/warden.pid
   start program "/var/vcap/jobs/redis_node_ng/bin/warden_ctl start"
   stop program "/var/vcap/jobs/redis_node_ng/bin/warden_ctl stop"
-  if failed unixsocket /tmp/warden.sock with timeout 10 seconds then restart
   group vcap
 
 check process redis_node

--- a/jobs/vblob_node_ng/monit
+++ b/jobs/vblob_node_ng/monit
@@ -2,7 +2,6 @@ check process warden
   with pidfile /var/vcap/sys/run/warden/warden.pid
   start program "/var/vcap/jobs/vblob_node_ng/bin/warden_ctl start"
   stop program "/var/vcap/jobs/vblob_node_ng/bin/warden_ctl stop"
-  if failed unixsocket /tmp/warden.sock with timeout 10 seconds then restart
   group vcap
 
 check process vblob_node


### PR DESCRIPTION
As core team's suggestion, service node should not use monit to check warden status via unixsocket.
