### PR TITLE
Fix uaa.yml.erb NPE when properties.uaa.scim is not present

### DIFF
--- a/jobs/uaa/templates/uaa.yml.erb
+++ b/jobs/uaa/templates/uaa.yml.erb
@@ -100,7 +100,7 @@ scim:
 <% end %>
 <%
   override = true
-  if properties.uaa.scim.user && properties.uaa.scim.user.override
+  if properties.uaa.scim && properties.uaa.scim.user && properties.uaa.scim.user.override
     override = properties.uaa.scim.user.override
   end
 %>


### PR DESCRIPTION
Change-Id: I326964e513345ae1b18ec2e211999a281d6c1aae
