### PR TITLE
Allow login url to be specified in cc

### DIFF
--- a/jobs/cloud_controller/templates/cloud_controller.yml.erb
+++ b/jobs/cloud_controller/templates/cloud_controller.yml.erb
@@ -98,8 +98,11 @@ database_environment:
 
 <% scheme = properties.uaa.no_ssl ? "http" : "https" %>
 
+<% login_enabled = p("login.enabled", true) %>
+<% if login_enabled %>
 login:
   url: <%= scheme %>://login.<%= properties.domain %>
+<% end %>
 <% if cc_props.uaa && properties.uaa.cc %>
 uaa:
   enabled: <%= cc_props.uaa.enabled %>

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -72,8 +72,11 @@ redis:
 
 <% scheme = properties.uaa.no_ssl ? "http" : "https" %>
 
+<% login_enabled = p("login.enabled", true) %>
+<% if login_enabled %>
 login:
   url: <%= scheme %>://login.<%= p("domain") %>
+<% end %>
 uaa:
   url: <%= scheme %>://uaa.<%= p("domain") %>
   resource_id: <%= p("ccng.uaa_resource_id") %>


### PR DESCRIPTION
Explanation: the UAA used to do everything, then we broke
out authentication into the Login Server quite some time ago.
For backwards compatibility we kept it in the UAA, but we
need to retire that feature.  And the cloud controller needs
to point at the Login Server (if there is one) for anything
that needs user authentication (including vmc).
