### PR TITLE
Cleanup: remove unused config entry in health_manager.yml

### DIFF
--- a/jobs/health_manager_next/templates/health_manager_next.yml.erb
+++ b/jobs/health_manager_next/templates/health_manager_next.yml.erb
@@ -32,4 +32,3 @@ intervals:
   max_restart_delay:     <%= intervals.max_restart_delay     || 480 %>
   giveup_crash_number:   <%= intervals.giveup_crash_number   ||   4 %>
   stable_state:          <%= intervals.stable_state          ||  60 %>
-dequeueing_rate: <%= hm_props.dequeueing_rate || 50 %>


### PR DESCRIPTION
"git grep dequeueing_rate" in health_manager turned up nothing.
