### PR TITLE
Adding uaa.user.override property (matching master branch)

### DIFF
--- a/jobs/uaa/templates/uaa.yml.erb
+++ b/jobs/uaa/templates/uaa.yml.erb
@@ -100,6 +100,13 @@ scim:
 scim:
   userids_enabled: false
 <% end %>
+<%
+  override = true
+  if properties.uaa.scim && properties.uaa.scim.user && !properties.uaa.scim.user.override.nil?
+    override = properties.uaa.scim.user.override
+  end
+%>
+  user.override: <%= override %>
 <% if properties.uaa.scim && properties.uaa.scim.users then %>
   users: <% properties.uaa.scim.users.each do |user| %>
     - <%= user %><% end %>


### PR DESCRIPTION
It has been important for dev environments to be able to override user
account details by changing the uaa.yml.  This change makes that possible by
default (rather than only adding accounts that are missing it updates ones
that are already there as well).
