### PR TITLE
Downloading app by GET fails with nginx 405

### DIFF
--- a/jobs/cloud_controller/templates/nginx.conf.erb
+++ b/jobs/cloud_controller/templates/nginx.conf.erb
@@ -62,6 +62,11 @@ http {
     }
 
     location ~ (/apps/.*/application|/services/v\d+/configurations/.*/serialized/data) {
+      # Bypass for GET requests
+      if ($request_method = GET) {
+        proxy_pass http://cloud_controller;
+      }
+      
       # Pass altered request body to this location
       upload_pass   @cc_uploads;
       upload_pass_args on;


### PR DESCRIPTION
The current cf-release will return nginx 405 Not Allowed when downloading app files by using api of CC as below:

get    'apps/:name/application'    => 'apps#download',        :as => :app_download

So We need to specify GET method when downloading app files as we want to use nginx before cc.
