### PR TITLE
set default value of kill_long_tx to true in mysql_node_ng

### DIFF
--- a/jobs/mysql_node_ng/templates/mysql_node.yml.erb
+++ b/jobs/mysql_node_ng/templates/mysql_node.yml.erb
@@ -47,7 +47,7 @@ default_version: <%= "'#{default_version}'"%>
 max_db_size: <%= plan_enabled && plan_conf.max_db_size || 128 %>
 max_long_query: <%= plan_enabled && plan_conf.max_long_query || 3 %>
 max_long_tx: <%= plan_enabled && plan_conf.max_long_tx || 0 %>
-kill_long_tx: <%= plan_enabled && plan_conf.kill_long_tx || false %>
+kill_long_tx: <%= plan_enabled && !plan_conf.kill_long_tx.nil? ? plan_conf.kill_long_tx : 'true' %>
 max_user_conns: <%= plan_enabled && plan_conf.max_clients || 20 %>
 mysql:
 <% for version in supported_versions %>


### PR DESCRIPTION
The code for handling kill_long_tx in mysql_node_ng is now the same as mysql_node.

yeti passed ( 100  & 200 )

@andl @mflu
