### PR TITLE
[cfid-546] Only "monit start" should be able to stop and start UAA and Login

### DIFF
--- a/jobs/login/templates/tomcat.server.xml.erb
+++ b/jobs/login/templates/tomcat.server.xml.erb
@@ -11,7 +11,7 @@
     <Connector class="org.apache.coyote.http11.Http11NioProtocol" port="<%= (properties.login && properties.login.port) ? properties.login.port : 8080 %>" protocol="HTTP/1.1" connectionTimeout="20000"/>
     <Engine name="Catalina" defaultHost="localhost">
 
-      <Host name="localhost" appBase="webapps" unpackWARs="true" >
+      <Host name="localhost" appBase="webapps" unpackWARs="true" autoDeploy="false">
         <Valve className="org.apache.catalina.valves.RemoteIpValve"
                remoteIpHeader="x-cluster-client-ip"
                protocolHeader="x-forwarded-proto" />

--- a/jobs/uaa/templates/tomcat.server.xml.erb
+++ b/jobs/uaa/templates/tomcat.server.xml.erb
@@ -11,7 +11,7 @@
     <Connector class="org.apache.coyote.http11.Http11NioProtocol" port="<%= (properties.uaa && properties.uaa.port) ? properties.uaa.port : 8080 %>" protocol="HTTP/1.1" connectionTimeout="20000"/>
     <Engine name="Catalina" defaultHost="localhost">
 
-      <Host name="localhost" appBase="webapps" unpackWARs="true" >
+      <Host name="localhost" appBase="webapps" unpackWARs="true" autoDeploy="false">
         <Valve className="org.apache.catalina.valves.RemoteIpValve"
                remoteIpHeader="x-cluster-client-ip"
                protocolHeader="x-forwarded-proto" />


### PR DESCRIPTION
Adds an autoDeploy="false" in the server.xml to stop Tomcat from accidentally
restarting the context if someone touches the war file.

[Fixes #43207895]

Change-Id: Ica708cd2e8b9a31e495cc2d49840c645ed5c6576
