### PR TITLE
Always register api.domain with the router

### DIFF
--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -4,7 +4,9 @@ port: 9022 # external CC port
 pid_filename: /var/vcap/sys/run/cloud_controller_ng/cloud_controller_ng.pid
 nats_uri: nats://<%= p("nats.user") %>:<%= p("nats.password") %>@<%= p("nats.address") %>:<%= p("nats.port") %>
 
-external_domain: <%= p("ccng.external_host", "api2") %>.<%= p("domain") %>
+external_domain:
+  - <%= p("ccng.external_host", "ccng") %>.<%= p("domain") %>
+  - "api.<%= p("domain") %>"
 
 <% system_domains = p("ccng.system_domains", [ p("domain") ]) %>
 system_domains: [ <%= system_domains.join(", ") %> ]


### PR DESCRIPTION
- api.domain will always reach the cloud controller.
- Any existing prefixes will also be registered so they will work too.
- Manifests that use ccng will continue to work with both ccng.domain and
  api.domain with no changes.
- NOTICE: merge this commit after bump the ccng commit with the same name.

https://github.com/cloudfoundry/cloud_controller_ng/pull/34
