### PR TITLE
[services-ng] support postgresql9.2

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -839,3 +839,11 @@ buildpack_cache/npm-1.2.12.tgz:
   object_id: eyJvaWQiOiI0ZTRlNzhiY2E2MWUxMjEwMDRlNGU3ZDUxZDk1MGUwNTE0OGUx%0AMGQ3MDgyOCIsInNpZyI6InJ0SlZibTZXd2E3cFcvek5WRURwTlRlV0RHYz0i%0AfQ==%0A
   sha: 04d39968240e261cb524af75b77cdd537aca931e
   size: 1830939
+postgresql/postgresql-9.2-x86_64.tar.gz:
+  object_id: eyJvaWQiOiI0ZTRlNzhiY2E2MWUxMjIwMDRlNGU4ZWM2YjQ0YjYwNTEzOTU4%0ANmRlZmYzMiIsInNpZyI6IkpOVWRvUkJPYVdBTmN5WG1EU2w0WjNDWWU5ND0i%0AfQ==%0A
+  sha: de2c5f6cb707b9fcb31ff841a9845e2acddfdbb2
+  size: 10516592
+postgresql/postgresql-initdb-9.2-x86_64.tar.gz:
+  object_id: eyJvaWQiOiI0ZTRlNzhiY2ExMWUxMjIwMDRlNGU4ZWM2NDg0MzEwNTEzOTQ2%0AYzFjY2I0OCIsInNpZyI6ImYvenNEZzVNN1ZOdDJSV3JVZGtOSGhGSE9vbz0i%0AfQ==%0A
+  sha: 6f46ff94648219840fa475eb95bfa23a5f4bf905
+  size: 4146878

--- a/jobs/postgresql_node_ng/monit
+++ b/jobs/postgresql_node_ng/monit
@@ -17,6 +17,11 @@ version_configs = {
   '9.1' => {
     'name'    => 'postgresql91',
     'pid'     => '/var/vcap/sys/run/postgresql/postgresql91.pid',
+  },
+
+   '9.2' => {
+    'name'    => 'postgresql92',
+    'pid'     => '/var/vcap/sys/run/postgresql/postgresql92.pid',
   }
 }
 %>

--- a/jobs/postgresql_node_ng/spec
+++ b/jobs/postgresql_node_ng/spec
@@ -15,6 +15,7 @@ templates:
   postgresql_logrotate.cron.erb: config/postgresql_logrotate.cron
   postgresql.conf.erb: config/postgresql.conf
   postgresql91.conf.erb: config/postgresql91.conf
+  postgresql92.conf.erb: config/postgresql92.conf
 
   warden_ctl: bin/warden_ctl
   warden.yml: config/warden.yml
@@ -25,6 +26,7 @@ packages:
   - common
   - postgresql
   - postgresql91
+  - postgresql92
   - postgresql_node_ng
   - ruby
   - ruby_next

--- a/jobs/postgresql_node_ng/templates/postgresql92.conf.erb
+++ b/jobs/postgresql_node_ng/templates/postgresql92.conf.erb
@@ -1,0 +1,586 @@
+<%
+service = "postgresql"
+plan_enabled = properties.service_plans && properties.service_plans.send(service.to_sym)
+plan = properties.plan || "free"
+plan_conf = plan_enabled && properties.service_plans.send(service.to_sym).send(plan.to_sym).configuration
+warden = plan_conf.warden
+use_warden = warden && warden.enable
+log_dir = use_warden ? '/var/vcap/sys/service-log/postgresql92' : '/var/vcap/sys/log/postgresql92'
+%>
+# -----------------------------
+# PostgreSQL configuration file
+# -----------------------------
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# (The "=" is optional.)  Whitespace may be used.  Comments are introduced with
+# "#" anywhere on a line.  The complete list of parameter names and allowed
+# values can be found in the PostgreSQL documentation.
+#
+# The commented-out settings shown in this file represent the default values.
+# Re-commenting a setting is NOT sufficient to revert it to the default value;
+# you need to reload the server.
+#
+# This file is read on server startup and when the server receives a SIGHUP
+# signal.  If you edit the file on a running system, you have to SIGHUP the
+# server for the changes to take effect, or use "pg_ctl reload".  Some
+# parameters, which are marked below, require a server shutdown and restart to
+# take effect.
+#
+# Any parameter can also be given as a command-line option to the server, e.g.,
+# "postgres -c log_connections=on".  Some parameters can be changed at run time
+# with the "SET" SQL command.
+#
+# Memory units:  kB = kilobytes        Time units:  ms  = milliseconds
+#                MB = megabytes                     s   = seconds
+#                GB = gigabytes                     min = minutes
+#                                                   h   = hours
+#                                                   d   = days
+
+
+#------------------------------------------------------------------------------
+# FILE LOCATIONS
+#------------------------------------------------------------------------------
+
+# The default values of these variables are driven from the -D command-line
+# option or PGDATA environment variable, represented here as ConfigDir.
+
+#data_directory = 'ConfigDir'		# use data in another directory
+					# (change requires restart)
+#hba_file = 'ConfigDir/pg_hba.conf'	# host-based authentication file
+					# (change requires restart)
+#ident_file = 'ConfigDir/pg_ident.conf'	# ident configuration file
+					# (change requires restart)
+
+# If external_pid_file is not explicitly set, no extra PID file is written.
+#external_pid_file = ''			# write an extra PID file
+					# (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# CONNECTIONS AND AUTHENTICATION
+#------------------------------------------------------------------------------
+
+# - Connection Settings -
+<% if properties.postgresql_server && properties.postgresql_server.listen_address %>
+listen_addresses = '<%= properties.postgresql_server.listen_address %>'   # what IP address(es) to listen on;
+<% else %>
+listen_addresses = '*'   # what IP address(es) to listen on;
+<% end %>
+					# comma-separated list of addresses;
+					# defaults to 'localhost'; use '*' for all
+					# (change requires restart)
+port =  <%= plan_enabled && plan_conf.port || 5434 %>			# (change requires restart)
+max_connections = <%= plan_enabled && plan_conf.max_connections || 500 %>			# (change requires restart)
+# Note:  Increasing max_connections costs ~400 bytes of shared memory per
+# connection slot, plus lock space (see max_locks_per_transaction).
+#superuser_reserved_connections = 3	# (change requires restart)
+#unix_socket_directory = ''		# (change requires restart)
+#unix_socket_group = ''			# (change requires restart)
+#unix_socket_permissions = 0777		# begin with 0 to use octal notation
+					# (change requires restart)
+#bonjour = off				# advertise server via Bonjour
+					# (change requires restart)
+#bonjour_name = ''			# defaults to the computer name
+					# (change requires restart)
+
+# - Security and Authentication -
+
+#authentication_timeout = 1min		# 1s-600s
+#ssl = off				# (change requires restart)
+#ssl_ciphers = 'ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH'	# allowed SSL ciphers
+					# (change requires restart)
+#ssl_renegotiation_limit = 512MB	# amount of data between renegotiations
+#ssl_cert_file = 'server.crt'		# (change requires restart)
+#ssl_key_file = 'server.key'		# (change requires restart)
+#ssl_ca_file = ''			# (change requires restart)
+#ssl_crl_file = ''			# (change requires restart)
+#password_encryption = on
+#db_user_namespace = off
+
+# Kerberos and GSSAPI
+#krb_server_keyfile = ''
+#krb_srvname = 'postgres'		# (Kerberos only)
+#krb_caseins_users = off
+
+# - TCP Keepalives -
+# see "man 7 tcp" for details
+
+#tcp_keepalives_idle = 0		# TCP_KEEPIDLE, in seconds;
+					# 0 selects the system default
+#tcp_keepalives_interval = 0		# TCP_KEEPINTVL, in seconds;
+					# 0 selects the system default
+#tcp_keepalives_count = 0		# TCP_KEEPCNT;
+					# 0 selects the system default
+
+
+#------------------------------------------------------------------------------
+# RESOURCE USAGE (except WAL)
+#------------------------------------------------------------------------------
+
+# - Memory -
+
+shared_buffers = <%= plan_conf.shared_buffers || 128 %>MB			# min 128kB
+					# (change requires restart)
+temp_buffers = <%= plan_conf.temp_buffers || 1 %>MB			# min 800kB
+max_prepared_transactions = <%= plan_conf.max_prepared_transactions || 0 %>		# zero disables the feature
+					# (change requires restart)
+# Note:  Increasing max_prepared_transactions costs ~600 bytes of shared memory
+# per transaction slot, plus lock space (see max_locks_per_transaction).
+# It is not advisable to set max_prepared_transactions nonzero unless you
+# actively intend to use prepared transactions.
+work_mem = <%= plan_conf.work_mem || 1 %>MB				# min 64kB
+maintenance_work_mem = <%= plan_conf.maintenance_work_mem || 30 %>MB		# min 1MB
+#max_stack_depth = 2MB			# min 100kB
+
+# - Disk -
+
+#temp_file_limit = -1			# limits per-session temp file space
+					# in kB, or -1 for no limit
+
+# - Kernel Resource Usage -
+
+#max_files_per_process = 1000		# min 25
+					# (change requires restart)
+#shared_preload_libraries = ''		# (change requires restart)
+
+# - Cost-Based Vacuum Delay -
+
+#vacuum_cost_delay = 0ms		# 0-100 milliseconds
+#vacuum_cost_page_hit = 1		# 0-10000 credits
+#vacuum_cost_page_miss = 10		# 0-10000 credits
+#vacuum_cost_page_dirty = 20		# 0-10000 credits
+#vacuum_cost_limit = 200		# 1-10000 credits
+
+# - Background Writer -
+
+#bgwriter_delay = 200ms			# 10-10000ms between rounds
+#bgwriter_lru_maxpages = 100		# 0-1000 max buffers written/round
+#bgwriter_lru_multiplier = 2.0		# 0-10.0 multipler on buffers scanned/round
+
+# - Asynchronous Behavior -
+
+#effective_io_concurrency = 1		# 1-1000; 0 disables prefetching
+
+
+#------------------------------------------------------------------------------
+# WRITE AHEAD LOG
+#------------------------------------------------------------------------------
+
+# - Settings -
+
+#wal_level = minimal			# minimal, archive, or hot_standby
+					# (change requires restart)
+#fsync = on				# turns forced synchronization on or off
+#synchronous_commit = on		# synchronization level;
+					# off, local, remote_write, or on
+#wal_sync_method = fsync		# the default is the first option
+					# supported by the operating system:
+					#   open_datasync
+					#   fdatasync (default on Linux)
+					#   fsync
+					#   fsync_writethrough
+					#   open_sync
+#full_page_writes = on			# recover from partial page writes
+wal_buffers = <%= plan_enabled && plan_conf.wal_buffers || 1  %>MB		# min 32kB, -1 sets based on shared_buffers
+					# (change requires restart)
+#wal_writer_delay = 200ms		# 1-10000 milliseconds
+
+#commit_delay = 0			# range 0-100000, in microseconds
+#commit_siblings = 5			# range 1-1000
+
+# - Checkpoints -
+
+checkpoint_segments = <%= plan_enabled && plan_conf.checkpoint_segments || 16 %>		# in logfile segments, min 1, 16MB each
+#checkpoint_timeout = 5min		# range 30s-1h
+checkpoint_completion_target = 0.9	# checkpoint target duration, 0.0 - 1.0
+#checkpoint_warning = 30s		# 0 disables
+# OSS postgresql does not have checkpoint_segments_max
+
+# - Archiving -
+
+#archive_mode = off		# allows archiving to be done
+				# (change requires restart)
+#archive_command = ''		# command to use to archive a logfile segment
+				# placeholders: %p = path of file to archive
+				#               %f = file name only
+				# e.g. 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'
+#archive_timeout = 0		# force a logfile segment switch after this
+				# number of seconds; 0 disables
+
+
+#------------------------------------------------------------------------------
+# REPLICATION
+#------------------------------------------------------------------------------
+
+# - Sending Server(s) -
+
+# Set these on the master and on any standby that will send replication data.
+
+#max_wal_senders = 0		# max number of walsender processes
+				# (change requires restart)
+#wal_keep_segments = 0		# in logfile segments, 16MB each; 0 disables
+#replication_timeout = 60s	# in milliseconds; 0 disables
+
+# - Master Server -
+
+# These settings are ignored on a standby server.
+
+#synchronous_standby_names = ''	# standby servers that provide sync rep
+				# comma-separated list of application_name
+				# from standby(s); '*' = all
+#vacuum_defer_cleanup_age = 0	# number of xacts by which cleanup is delayed
+
+# - Standby Servers -
+
+# These settings are ignored on a master server.
+
+#hot_standby = off			# "on" allows queries during recovery
+					# (change requires restart)
+#max_standby_archive_delay = 30s	# max delay before canceling queries
+					# when reading WAL from archive;
+					# -1 allows indefinite delay
+#max_standby_streaming_delay = 30s	# max delay before canceling queries
+					# when reading streaming WAL;
+					# -1 allows indefinite delay
+#wal_receiver_status_interval = 10s	# send replies at least this often
+					# 0 disables
+#hot_standby_feedback = off		# send info from standby to prevent
+					# query conflicts
+
+
+#------------------------------------------------------------------------------
+# QUERY TUNING
+#------------------------------------------------------------------------------
+
+# - Planner Method Configuration -
+
+#enable_bitmapscan = on
+#enable_hashagg = on
+#enable_hashjoin = on
+#enable_indexscan = on
+#enable_indexonlyscan = on
+#enable_material = on
+#enable_mergejoin = on
+#enable_nestloop = on
+#enable_seqscan = on
+#enable_sort = on
+#enable_tidscan = on
+
+# - Planner Cost Constants -
+
+#seq_page_cost = 1.0			# measured on an arbitrary scale
+#random_page_cost = 4.0			# same scale as above
+#cpu_tuple_cost = 0.01			# same scale as above
+#cpu_index_tuple_cost = 0.005		# same scale as above
+#cpu_operator_cost = 0.0025		# same scale as above
+effective_cache_size = <%= plan_enabled && plan_conf.effective_cache_size || 128 %>MB
+
+# - Genetic Query Optimizer -
+
+#geqo = on
+#geqo_threshold = 12
+#geqo_effort = 5			# range 1-10
+#geqo_pool_size = 0			# selects default based on effort
+#geqo_generations = 0			# selects default based on effort
+#geqo_selection_bias = 2.0		# range 1.5-2.0
+#geqo_seed = 0.0			# range 0.0-1.0
+
+# - Other Planner Options -
+
+#default_statistics_target = 100	# range 1-10000
+#constraint_exclusion = partition	# on, off, or partition
+#cursor_tuple_fraction = 0.1		# range 0.0-1.0
+#from_collapse_limit = 8
+#join_collapse_limit = 8		# 1 disables collapsing of explicit
+					# JOIN clauses
+
+
+#------------------------------------------------------------------------------
+# ERROR REPORTING AND LOGGING
+#------------------------------------------------------------------------------
+
+# - Where to Log -
+
+#log_destination = 'stderr'		# Valid values are combinations of
+					# stderr, csvlog, syslog, and eventlog,
+					# depending on platform.  csvlog
+					# requires logging_collector to be on.
+
+# This is used when logging to stderr:
+logging_collector = on		# Enable capturing of stderr and csvlog
+					# into log files. Required to be on for
+					# csvlogs.
+					# (change requires restart)
+
+# These are only used if logging_collector is on:
+log_directory = '<%= log_dir %>'		# directory where log files are written,
+					# can be absolute or relative to PGDATA
+log_filename = 'postgresql.log'	# log file name pattern,
+					# can include strftime() escapes
+#log_file_mode = 0600			# creation mode for log files,
+					# begin with 0 to use octal notation
+#log_truncate_on_rotation = off		# If on, an existing log file with the
+					# same name as the new log file will be
+					# truncated rather than appended to.
+					# But such truncation only occurs on
+					# time-driven rotation, not on restarts
+					# or size-driven rotation.  Default is
+					# off, meaning append to existing files
+					# in all cases.
+#log_rotation_age = 1d			# Automatic rotation of logfiles will
+					# happen after that time.  0 disables.
+#log_rotation_size = 10MB		# Automatic rotation of logfiles will
+					# happen after that much log output.
+					# 0 disables.
+
+# These are relevant when logging to syslog:
+#syslog_facility = 'LOCAL0'
+#syslog_ident = 'postgres'
+
+# This is only relevant when logging to eventlog (win32):
+#event_source = 'PostgreSQL'
+
+# - When to Log -
+
+#client_min_messages = notice		# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   log
+					#   notice
+					#   warning
+					#   error
+
+#log_min_messages = warning		# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic
+
+#log_min_error_statement = error	# values in order of decreasing detail:
+				 	#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+				 	#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic (effectively off)
+
+#log_min_duration_statement = -1	# -1 is disabled, 0 logs all statements
+					# and their durations, > 0 logs only
+					# statements running at least this number
+					# of milliseconds
+
+
+# - What to Log -
+
+#debug_print_parse = off
+#debug_print_rewritten = off
+#debug_print_plan = off
+#debug_pretty_print = on
+#log_checkpoints = off
+#log_connections = off
+#log_disconnections = off
+#log_duration = off
+#log_error_verbosity = default		# terse, default, or verbose messages
+#log_hostname = off
+#log_line_prefix = ''			# special values:
+					#   %a = application name
+					#   %u = user name
+					#   %d = database name
+					#   %r = remote host and port
+					#   %h = remote host
+					#   %p = process ID
+					#   %t = timestamp without milliseconds
+					#   %m = timestamp with milliseconds
+					#   %i = command tag
+					#   %e = SQL state
+					#   %c = session ID
+					#   %l = session line number
+					#   %s = session start timestamp
+					#   %v = virtual transaction ID
+					#   %x = transaction ID (0 if none)
+					#   %q = stop here in non-session
+					#        processes
+					#   %% = '%'
+					# e.g. '<%u%%%d> '
+#log_lock_waits = off			# log lock waits >= deadlock_timeout
+#log_statement = 'none'			# none, ddl, mod, all
+#log_temp_files = -1			# log temporary files equal or larger
+					# than the specified size in kilobytes;
+					# -1 disables, 0 logs all temp files
+#log_timezone = '(defaults to server environment setting)'
+
+
+#------------------------------------------------------------------------------
+# RUNTIME STATISTICS
+#------------------------------------------------------------------------------
+
+# - Query/Index Statistics Collector -
+
+#track_activities = on
+#track_counts = on
+#track_io_timing = off
+#track_functions = none			# none, pl, all
+#track_activity_query_size = 1024 	# (change requires restart)
+#update_process_title = on
+#stats_temp_directory = 'pg_stat_tmp'
+
+
+# - Statistics Monitoring -
+
+#log_parser_stats = off
+#log_planner_stats = off
+#log_executor_stats = off
+#log_statement_stats = off
+
+
+#------------------------------------------------------------------------------
+# AUTOVACUUM PARAMETERS
+#------------------------------------------------------------------------------
+
+#autovacuum = on			# Enable autovacuum subprocess?  'on'
+					# requires track_counts to also be on.
+#log_autovacuum_min_duration = -1	# -1 disables, 0 logs all actions and
+					# their durations, > 0 logs only
+					# actions running at least this number
+					# of milliseconds.
+#autovacuum_max_workers = 3		# max number of autovacuum subprocesses
+					# (change requires restart)
+#autovacuum_naptime = 1min		# time between autovacuum runs
+#autovacuum_vacuum_threshold = 50	# min number of row updates before
+					# vacuum
+#autovacuum_analyze_threshold = 50	# min number of row updates before
+					# analyze
+#autovacuum_vacuum_scale_factor = 0.2	# fraction of table size before vacuum
+#autovacuum_analyze_scale_factor = 0.1	# fraction of table size before analyze
+#autovacuum_freeze_max_age = 200000000	# maximum XID age before forced vacuum
+					# (change requires restart)
+#autovacuum_vacuum_cost_delay = 20ms	# default vacuum cost delay for
+					# autovacuum, in milliseconds;
+					# -1 means use vacuum_cost_delay
+#autovacuum_vacuum_cost_limit = -1	# default vacuum cost limit for
+					# autovacuum, -1 means use
+					# vacuum_cost_limit
+
+
+#------------------------------------------------------------------------------
+# CLIENT CONNECTION DEFAULTS
+#------------------------------------------------------------------------------
+
+# - Statement Behavior -
+
+#search_path = '"$user",public'		# schema names
+#default_tablespace = ''		# a tablespace name, '' uses the default
+#temp_tablespaces = ''			# a list of tablespace names, '' uses
+					# only default tablespace
+#check_function_bodies = on
+#default_transaction_isolation = 'read committed'
+#default_transaction_read_only = off
+#default_transaction_deferrable = off
+#session_replication_role = 'origin'
+#statement_timeout = 0			# in milliseconds, 0 is disabled
+#vacuum_freeze_min_age = 50000000
+#vacuum_freeze_table_age = 150000000
+#bytea_output = 'hex'			# hex, escape
+#xmlbinary = 'base64'
+#xmloption = 'content'
+
+# - Locale and Formatting -
+
+datestyle = 'iso, mdy'
+#intervalstyle = 'postgres'
+#timezone = '(defaults to server environment setting)'
+#timezone_abbreviations = 'Default'     # Select the set of available time zone
+					# abbreviations.  Currently, there are
+					#   Default
+					#   Australia
+					#   India
+					# You can create your own file in
+					# share/timezonesets/.
+#extra_float_digits = 0			# min -15, max 3
+#client_encoding = sql_ascii		# actually, defaults to database
+					# encoding
+
+# These settings are initialized by initdb, but they can be changed.
+lc_messages = 'en_US.UTF-8'			# locale for system error message
+					# strings
+lc_monetary = 'en_US.UTF-8'			# locale for monetary formatting
+lc_numeric = 'en_US.UTF-8'			# locale for number formatting
+lc_time = 'en_US.UTF-8'				# locale for time formatting
+
+# default configuration for text search
+default_text_search_config = 'pg_catalog.english'
+
+# - Other Defaults -
+
+#dynamic_library_path = '$libdir'
+#local_preload_libraries = ''
+
+
+#------------------------------------------------------------------------------
+# LOCK MANAGEMENT
+#------------------------------------------------------------------------------
+
+#deadlock_timeout = 1s
+#max_locks_per_transaction = 64		# min 10
+					# (change requires restart)
+# Note:  Each lock table slot uses ~270 bytes of shared memory, and there are
+# max_locks_per_transaction * (max_connections + max_prepared_transactions)
+# lock table slots.
+#max_pred_locks_per_transaction = 64	# min 10
+					# (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# VERSION/PLATFORM COMPATIBILITY
+#------------------------------------------------------------------------------
+
+# - Previous PostgreSQL Versions -
+
+#array_nulls = on
+#backslash_quote = safe_encoding	# on, off, or safe_encoding
+#default_with_oids = off
+#escape_string_warning = on
+#lo_compat_privileges = off
+#quote_all_identifiers = off
+#sql_inheritance = on
+#standard_conforming_strings = on
+#synchronize_seqscans = on
+
+# - Other Platforms and Clients -
+
+#transform_null_equals = off
+
+
+#------------------------------------------------------------------------------
+# ERROR HANDLING
+#------------------------------------------------------------------------------
+
+#exit_on_error = off			# terminate session on any error?
+#restart_after_crash = on		# reinitialize after backend crash?
+
+
+#------------------------------------------------------------------------------
+# CUSTOMIZED OPTIONS
+#------------------------------------------------------------------------------
+
+# Add settings for extensions here

--- a/jobs/postgresql_node_ng/templates/postgresql_backup.yml.erb
+++ b/jobs/postgresql_node_ng/templates/postgresql_backup.yml.erb
@@ -16,6 +16,10 @@ version_configs = {
   '9.1' => {
     'port'        => 5433,
     'binary_dir'  => '/var/vcap/packages/postgresql91',
+  },
+  '9.2' => {
+    'port'        => 5434,
+    'binary_dir'  => '/var/vcap/packages/postgresql92',
   }
 }
 %>

--- a/jobs/postgresql_node_ng/templates/postgresql_ctl.erb
+++ b/jobs/postgresql_node_ng/templates/postgresql_ctl.erb
@@ -32,6 +32,16 @@ case "$version" in
     PORT=5433
 
     ;;
+  "9.2")
+    PACKAGE_DIR=/var/vcap/packages/postgresql92
+    DATA_DIR=/var/vcap/store/postgresql92
+    RUN_DIR=/var/vcap/sys/run/postgresql
+    PIDFILE=$RUN_DIR/postgresql92.pid
+    LOG_DIR=/var/vcap/sys/log/postgresql92
+    SRC_CONF_FILE=$JOB_DIR/config/postgresql92.conf
+    PORT=5434
+
+    ;;
 esac
 
 FIRST_TIME=0

--- a/jobs/postgresql_node_ng/templates/postgresql_node.yml.erb
+++ b/jobs/postgresql_node_ng/templates/postgresql_node.yml.erb
@@ -18,6 +18,11 @@ version_configs = {
   '9.1' => {
     'port'        => 5433,
     'binary_dir'  => '/var/vcap/packages/postgresql91',
+  },
+
+  '9.2' => {
+    'port'        => 5434,
+    'binary_dir'  => '/var/vcap/packages/postgresql92',
   }
 }
 nats_props_name = properties.nats_props || "nats"

--- a/jobs/postgresql_node_ng/templates/postgresql_worker.yml.erb
+++ b/jobs/postgresql_node_ng/templates/postgresql_worker.yml.erb
@@ -18,6 +18,11 @@ version_configs = {
   '9.1' => {
     'port'        => 5433,
     'binary_dir'  => '/var/vcap/packages/postgresql91/bin',
+  },
+
+  '9.2' => {
+    'port'        => 5434,
+    'binary_dir'  => '/var/vcap/packages/postgresql92/bin',
   }
 }
 %>

--- a/jobs/postgresql_node_ng/templates/warden_ctl
+++ b/jobs/postgresql_node_ng/templates/warden_ctl
@@ -30,7 +30,7 @@ case $1 in
     sysctl -w 'kernel.shmall=<%=plan_conf.shmall%>'
     <%end%>
 
-    for version in "9.0" "9.1"
+    for version in "9.0" "9.1" "9.2"
     do
       case "$version" in
         "9.0")
@@ -41,6 +41,11 @@ case $1 in
         "9.1")
           PG_DIR=/var/vcap/packages/postgresql91
           SRC_CONF_FILE=$JOB_DIR/config/postgresql91.conf
+
+          ;;
+        "9.2")
+          PG_DIR=/var/vcap/packages/postgresql92
+          SRC_CONF_FILE=$JOB_DIR/config/postgresql92.conf
 
           ;;
       esac

--- a/packages/postgresql92/packaging
+++ b/packages/postgresql92/packaging
@@ -1,0 +1,14 @@
+# abort script on any command that exit with a non zero value
+set -e
+
+echo "Extracting PostgreSQL 9.2 archive ..."
+
+tar xzf postgresql/postgresql-9.2-x86_64.tar.gz
+
+cp -a * ${BOSH_INSTALL_TARGET}
+
+tar xzf postgresql/postgresql-initdb-9.2-x86_64.tar.gz
+
+cp -a initdb ${BOSH_INSTALL_TARGET}
+
+rm ${BOSH_INSTALL_TARGET}/packaging

--- a/packages/postgresql92/spec
+++ b/packages/postgresql92/spec
@@ -1,0 +1,5 @@
+---
+name: postgresql92
+files:
+- postgresql/postgresql-9.2-x86_64.tar.gz
+- postgresql/postgresql-initdb-9.2-x86_64.tar.gz


### PR DESCRIPTION
just rebase, no changes (compared to https://github.com/cloudfoundry/cf-release/pull/46)
    Add two blobs: postgresql9.2 and initdb9.2 
    Add postgresql92 package
    Add postgresql92.conf.erb in postgresql_node_ng job

test plan:
- yeti-test plan 100/ plan 200
- ad-hoc: backup test

Change-Id: Iaf2d985862f4097f9202a548560adf6381a37153
