### PR TITLE
Make symmetric_secret optional in ccng template

### DIFF
--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -82,7 +82,9 @@ login:
 uaa:
   url: <%= scheme %>://uaa.<%= p("domain") %>
   resource_id: <%= p("ccng.uaa_resource_id") %>
-  symmetric_secret: "<%= p("uaa.cc.token_secret") %>"
+<% if_p("uaa.cc.token_secret") do |token_secret| %>
+  symmetric_secret: "<%= token_secret %>"
+<% end %>
   verification_key: <%= p("uaa.jwt.verification_key") ? ("|\n      " + p("uaa.jwt.verification_key").gsub("\n", "\n      ")) : '~' %>
 
 # App staging parameters


### PR DESCRIPTION
This is no longer a required property in ccng.
Moreover, its absence is used to indicate that the
UAA is using an asymmetric signature for tokens so
it has to be optional in the yaml template.
