### PR TITLE
[services-ng] add plan configurations for xlog_enforcer

### DIFF
--- a/jobs/postgresql_node_ng/templates/postgresql_node.yml.erb
+++ b/jobs/postgresql_node_ng/templates/postgresql_node.yml.erb
@@ -110,3 +110,5 @@ db_connect_timeout: <%= plan_enabled && plan_conf.db_connect_timeout || 3 %>
 db_query_timeout: <%= plan_enabled && plan_conf.db_query_timeout || 10 %>
 db_use_async_query: <%= plan_enabled && !plan_conf.db_use_async_query.nil? && plan_conf.db_use_async_query.to_s || "true" %>
 warden_socket_path: <%= node.warden_socket_path || "/tmp/warden.sock" %>
+enable_xlog_enforcer: <%= plan_enabled && !plan_conf.enable_xlog_enforcer.nil? && plan_conf.enable_xlog_enforcer.to_s || "true" %>
+xlog_enforce_tolerance: <%= plan_enabled && plan_conf.xlog_enforce_tolerance || 5 %>


### PR DESCRIPTION
- Enable xlog_enforcer
  This pull request only impact ng postgresql service
  Test Plan:
  - Yeti-test passed (plan 100/ plan 200) passed
