### PR TITLE
Fix the stacks value to extract the given array to a YAML list

### DIFF
--- a/jobs/dea_next/templates/dea.yml.erb
+++ b/jobs/dea_next/templates/dea.yml.erb
@@ -94,4 +94,7 @@ staging:
     PATH: "/var/vcap/packages/libpq/bin:/var/vcap/packages/dea_node08/bin:/var/vcap/packages/git/bin:/var/vcap/packages/imagemagick/bin:/var/vcap/packages/ruby_next/bin"
     BUILDPACK_CACHE: "/var/vcap/packages/buildpack_cache"
 
-stacks: <%= properties.dea_next && properties.dea_next.stacks || [ "lucid64" ] %>
+stacks:
+<% (properties.dea_next && properties.dea_next.stacks || [ "lucid64" ]).each do |stack| %>
+  - <%= stack %>
+<% end %>


### PR DESCRIPTION
This commit fixes the error below and enables the process to start up.

```
/var/vcap/packages/dea_next/vendor/bundle/ruby/1.9.1/gems/membrane-0.0.2/lib/membrane/schema/record.rb:42:in `validate': { stacks => Expected instance of Array, given instance of String } (Membrane::SchemaValidationError)
        from /var/vcap/packages/dea_next/lib/dea/config.rb:112:in `validate'
        from /var/vcap/packages/dea_next/lib/dea/bootstrap.rb:61:in `validate_config'
        from /var/vcap/packages/dea_next/lib/dea/bootstrap.rb:65:in `setup'
        from /var/vcap/packages/dea_next/bin/dea:29:in `block in <main>'
        from /var/vcap/packages/dea_next/vendor/bundle/ruby/1.9.1/gems/eventmachine-1.0.0/lib/eventmachine.rb:187:in `call'
        from /var/vcap/packages/dea_next/vendor/bundle/ruby/1.9.1/gems/eventmachine-1.0.0/lib/eventmachine.rb:187:in `run_machine'
        from /var/vcap/packages/dea_next/vendor/bundle/ruby/1.9.1/gems/eventmachine-1.0.0/lib/eventmachine.rb:187:in `run'
        from /var/vcap/packages/dea_next/bin/dea:28:in `<main>'
```
