### PR TITLE
Request: Add -e option to the ctl scripts of the dea_next job

### DIFF
--- a/jobs/dea_next/templates/dea_ctl
+++ b/jobs/dea_next/templates/dea_ctl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 export PATH=/var/vcap/packages/ruby_next/bin:$PATH
 RUN_DIR=/var/vcap/sys/run/dea_next

--- a/jobs/dea_next/templates/dir_server_ctl
+++ b/jobs/dea_next/templates/dir_server_ctl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 RUN_DIR=/var/vcap/sys/run/dea_next
 LOG_DIR=/var/vcap/sys/log/dea_next

--- a/jobs/dea_next/templates/warden_ctl
+++ b/jobs/dea_next/templates/warden_ctl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 RUN_DIR=/var/vcap/sys/run/warden
 LOG_DIR=/var/vcap/sys/log/warden


### PR DESCRIPTION
I'd like to add -e option to these dea_next related scripts.
They are not required when the job is deployed with BOSH, but in developing time, the -e option makes it easy for us to find mistakes and regressions.
