### PR TITLE
Switch Tomcat valve settings for remote IP

### DIFF
--- a/jobs/login/templates/tomcat.server.xml.erb
+++ b/jobs/login/templates/tomcat.server.xml.erb
@@ -13,7 +13,7 @@
 
       <Host name="localhost" appBase="webapps" unpackWARs="true" autoDeploy="false">
         <Valve className="org.apache.catalina.valves.RemoteIpValve"
-               remoteIpHeader="x-cluster-client-ip"
+               remoteIpHeader="x-forwarded-for"
                protocolHeader="x-forwarded-proto" />
 
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="/var/vcap/sys/log/login"

--- a/jobs/uaa/templates/tomcat.server.xml.erb
+++ b/jobs/uaa/templates/tomcat.server.xml.erb
@@ -13,7 +13,7 @@
 
       <Host name="localhost" appBase="webapps" unpackWARs="true" autoDeploy="false">
         <Valve className="org.apache.catalina.valves.RemoteIpValve"
-               remoteIpHeader="x-cluster-client-ip"
+               remoteIpHeader="x-forwarded-for"
                protocolHeader="x-forwarded-proto" />
 
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="/var/vcap/sys/log/uaa"


### PR DESCRIPTION
Most front end load balancers will populate x-forwarded-for, and that's
probably the best we can do (it's only used for reporting anyway)
