### PR TITLE
root_fs now comes from rootfs_lucid64 package

### DIFF
--- a/jobs/dea_next/templates/warden_ctl
+++ b/jobs/dea_next/templates/warden_ctl
@@ -24,24 +24,6 @@ case $1 in
 
     ulimit -c unlimited
 
-    rootfs_path=$DATA_DIR/rootfs
-    rootfs_tgz=/var/vcap/stemcell_base.tar.gz
-
-    # Extract rootfs if needed
-    if [ ! -d $rootfs_path ]
-    then
-      # Make sure its parent directory exists
-      mkdir -p $(dirname $rootfs_path)
-
-      # Extract to temporary path, then rename to target path.
-      # This makes sure that it is not possible that we end up with directory
-      # that contains a partially extracted archive.
-      tmp_path=$(mktemp --tmpdir=$(dirname $rootfs_path) -d)
-      chmod 755 $tmp_path
-      tar -C $tmp_path -zxf $rootfs_tgz
-      mv $tmp_path $rootfs_path
-    fi
-
     # Use default local port range (higher ports are used for pooling)
     echo 32768 61000 > /proc/sys/net/ipv4/ip_local_port_range
 


### PR DESCRIPTION
/var/vcap/stemcell_base.tar.gz is being removed from the base stemcell

This PR goes together with https://github.com/cloudfoundry/bosh/pull/152
but can be merged independently. The /var/vcap/stemcell_base.tar.gz is
not being used by dea_next/warden anymore.
