### PR TITLE
Disable nginx in monitc when ccng.use_nginx is false

### DIFF
--- a/jobs/cloud_controller_ng/monit
+++ b/jobs/cloud_controller_ng/monit
@@ -4,8 +4,10 @@ check process cloud_controller_ng
   stop program "/var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng_ctl stop"
   group vcap
 
+<% if p("ccng.use_nginx") %>
 check process nginx_ccng
   with pidfile /var/vcap/sys/run/nginx_ccng/nginx.pid
   start program "/var/vcap/jobs/cloud_controller_ng/bin/nginx_ctl start"
   stop program "/var/vcap/jobs/cloud_controller_ng/bin/nginx_ctl stop"
   group vcap
+<% end %>


### PR DESCRIPTION
Monit currently tries to start Nginx even when nginx is disabled in the manifest file.
This commit hides the entry for Nginx in the monitrc file when ccng.use_nginx is false.
