### PR TITLE
Fix ng-services not able to start warden due to wrong rootfs

### DIFF
--- a/jobs/mongodb_node_ng/spec
+++ b/jobs/mongodb_node_ng/spec
@@ -30,6 +30,7 @@ packages:
   - mongodb18
   - mongodb20
   - mongodb22
+  - rootfs_lucid64
   - ruby
   - ruby_next
   - sqlite

--- a/jobs/mongodb_node_ng/templates/warden.yml.erb
+++ b/jobs/mongodb_node_ng/templates/warden.yml.erb
@@ -16,7 +16,7 @@ node = properties.mongodb_node
 server:
   container_klass: Warden::Container::Linux
   container_grace_time: ~
-  container_rootfs_path: /var/vcap/data/mongodb/warden/rootfs
+  container_rootfs_path: /var/vcap/packages/rootfs_lucid64
   container_depot_path: /var/vcap/store/mongodb/containers
   unix_domain_permissions: 0777
   unix_domain_path: <%= node.warden_socket_path || "/tmp/warden.sock" %>

--- a/jobs/mysql_node_ng/spec
+++ b/jobs/mysql_node_ng/spec
@@ -37,6 +37,7 @@ packages:
   - mysqlclient
   - mysql
   - mysql55
+  - rootfs_lucid64
   - ruby
   - ruby_next
   - sqlite

--- a/jobs/mysql_node_ng/templates/warden.yml
+++ b/jobs/mysql_node_ng/templates/warden.yml
@@ -5,7 +5,7 @@ node = properties.mysql_node
 server:
   container_klass: Warden::Container::Linux
   container_grace_time: ~
-  container_rootfs_path: /var/vcap/data/mysql/warden/rootfs
+  container_rootfs_path: /var/vcap/packages/rootfs_lucid64
   container_depot_path: /var/vcap/store/mysql/containers
   unix_domain_permissions: 0777
   unix_domain_path: <%= node.warden_socket_path || "/tmp/warden.sock" %>

--- a/jobs/postgresql_node_ng/spec
+++ b/jobs/postgresql_node_ng/spec
@@ -28,6 +28,7 @@ packages:
   - postgresql91
   - postgresql92
   - postgresql_node_ng
+  - rootfs_lucid64
   - ruby
   - ruby_next
   - sqlite

--- a/jobs/postgresql_node_ng/templates/warden.yml
+++ b/jobs/postgresql_node_ng/templates/warden.yml
@@ -5,7 +5,7 @@ node = properties.postgresql_node
 server:
   container_klass: Warden::Container::Linux
   container_grace_time: ~
-  container_rootfs_path: /var/vcap/data/postgresql/warden/rootfs
+  container_rootfs_path: /var/vcap/packages/rootfs_lucid64
   container_depot_path: /var/vcap/store/postgresql/containers
   unix_domain_permissions: 0777
   unix_domain_path: <%= node.warden_socket_path || "/tmp/warden.sock" %>

--- a/jobs/rabbit_node_ng/spec
+++ b/jobs/rabbit_node_ng/spec
@@ -28,6 +28,7 @@ packages:
   - rabbitmq-2.4
   - rabbitmq-2.8
   - rabbitmq-3.0
+  - rootfs_lucid64
   - daylimit
   - ruby
   - ruby_next

--- a/jobs/rabbit_node_ng/templates/warden.yml.erb
+++ b/jobs/rabbit_node_ng/templates/warden.yml.erb
@@ -5,7 +5,7 @@ node = properties.rabbit_node
 server:
   container_klass: Warden::Container::Linux
   container_grace_time: ~
-  container_rootfs_path: /var/vcap/data/rabbit/warden/rootfs
+  container_rootfs_path: /var/vcap/packages/rootfs_lucid64
   container_depot_path: /var/vcap/store/rabbit/containers
   unix_domain_permissions: 0777
   unix_domain_path: <%= node.warden_socket_path || "/tmp/warden.sock" %>

--- a/jobs/redis_node_ng/spec
+++ b/jobs/redis_node_ng/spec
@@ -25,6 +25,7 @@ packages:
   - redis22
   - redis24
   - redis26
+  - rootfs_lucid64
   - ruby
   - ruby_next
   - sqlite

--- a/jobs/redis_node_ng/templates/warden.yml.erb
+++ b/jobs/redis_node_ng/templates/warden.yml.erb
@@ -14,7 +14,7 @@ node = properties.redis_node
 server:
   container_klass: Warden::Container::Linux
   container_grace_time: ~
-  container_rootfs_path: /var/vcap/data/redis/warden/rootfs
+  container_rootfs_path: /var/vcap/packages/rootfs_lucid64
   container_depot_path: /var/vcap/store/redis/containers
   unix_domain_permissions: 0777
   unix_domain_path: <%= node.warden_socket_path || "/tmp/warden.sock" %>


### PR DESCRIPTION
While deploying cf on OpenStack, a problem occurred while provisioning mongodb service. Problem was related to warden. It turned out warden wasn't able to create a container. The message received in the warden.log on the mongodb_node was: `/var/vcap/store/mongodb/containers/16toij4v21f/setup.sh: line 75: mnt/etc/hostname: No such file or directory`

The following fix has been verified to fix the mongodb problem locally, inspired by the way this is done in the dea_next job.
