### PR TITLE
Do not restrict `bind-address` even when `micro` is true

### DIFF
--- a/jobs/mysql_node_ng/templates/my.cnf.erb
+++ b/jobs/mysql_node_ng/templates/my.cnf.erb
@@ -36,9 +36,6 @@ max_heap_table_size         = <%= properties.mysql_node.max_heap_table_size %>
 
 init-file = <%= use_warden ? '/var/vcap/store/mysql_common/config/warden_mysql_init' : '/var/vcap/jobs/mysql_node_ng/config/mysql_init' %>
 
-<% if properties.micro %>
-bind-address            = 127.0.0.1
-<% end %>
 key_buffer              = <%= plan_enabled && plan_conf.key_buffer || '24' %>M
 innodb_buffer_pool_size = <%= plan_enabled && plan_conf.innodb_buffer_pool_size || '72' %>M
 max_allowed_packet      = <%= plan_enabled && plan_conf.max_allowed_packet || '16' %>M

--- a/jobs/mysql_node_ng/templates/my55.cnf.erb
+++ b/jobs/mysql_node_ng/templates/my55.cnf.erb
@@ -36,9 +36,6 @@ max_heap_table_size         = <%= properties.mysql_node.max_heap_table_size %>
 
 init-file = <%= use_warden ? '/var/vcap/store/mysql_common/config/warden_mysql_init' : '/var/vcap/jobs/mysql_node_ng/config/mysql_init' %>
 
-<% if properties.micro %>
-bind-address            = 127.0.0.1
-<% end %>
 key_buffer              = <%= plan_enabled && plan_conf.key_buffer || '24' %>M
 innodb_buffer_pool_size = <%= plan_enabled && plan_conf.innodb_buffer_pool_size || '72' %>M
 max_allowed_packet      = <%= plan_enabled && plan_conf.max_allowed_packet || '16' %>M


### PR DESCRIPTION
Both of NG service processes and application processes run in warden containers, so their IP addresses are different from each other.
This commit removes the `bind-address: 127.0.0.1` in my.cnf to accept connections from different IP address.
