### PR TITLE
Allow colocation of uaa & login & servicesmgmt

### DIFF
--- a/jobs/login/monit
+++ b/jobs/login/monit
@@ -4,8 +4,8 @@ check process login
   stop program "/var/vcap/jobs/login/bin/login_ctl stop"
   group vcap
 
-check process vcap_registrar
-  with pidfile /var/vcap/sys/run/vcap_registrar/vcap_registrar.pid
+check process login_vcap_registrar
+  with pidfile /var/vcap/sys/run/login/vcap_registrar.pid
   start program "/var/vcap/jobs/login/bin/vcap_registrar_ctl start"
   stop program "/var/vcap/jobs/login/bin/vcap_registrar_ctl stop"
   group vcap

--- a/jobs/login/templates/vcap_registrar.config.yml.erb
+++ b/jobs/login/templates/vcap_registrar.config.yml.erb
@@ -1,6 +1,6 @@
 ---
 logging:
-  file: /var/vcap/sys/log/vcap_registrar/vcap_registrar.log
+  file: /var/vcap/sys/log/login/vcap_registrar.log
   <% if properties.syslog_aggregator %>
   syslog: vcap.login_vcap_registrar
   <% end %>

--- a/jobs/login/templates/vcap_registrar_ctl
+++ b/jobs/login/templates/vcap_registrar_ctl
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
 export PATH=/var/vcap/packages/ruby/bin:$PATH
-RUN_DIR=/var/vcap/sys/run/vcap_registrar
-LOG_DIR=/var/vcap/sys/log/vcap_registrar
+RUN_DIR=/var/vcap/sys/run/login
+LOG_DIR=/var/vcap/sys/log/login
 PIDFILE=$RUN_DIR/vcap_registrar.pid
 
 source /var/vcap/packages/common/utils.sh

--- a/jobs/servicesmgmt/monit
+++ b/jobs/servicesmgmt/monit
@@ -4,8 +4,8 @@ check process servicesmgmt
   stop program "/var/vcap/jobs/servicesmgmt/bin/servicesmgmt_ctl stop"
   group vcap
 
-check process vcap_registrar
-  with pidfile /var/vcap/sys/run/vcap_registrar/vcap_registrar.pid
+check process servicesmgmt_vcap_registrar
+  with pidfile /var/vcap/sys/run/servicesmgmt/vcap_registrar.pid
   start program "/var/vcap/jobs/servicesmgmt/bin/vcap_registrar_ctl start"
   stop program "/var/vcap/jobs/servicesmgmt/bin/vcap_registrar_ctl stop"
   group vcap

--- a/jobs/servicesmgmt/templates/vcap_registrar.config.yml.erb
+++ b/jobs/servicesmgmt/templates/vcap_registrar.config.yml.erb
@@ -1,6 +1,6 @@
 ---
 logging:
-  file: /var/vcap/sys/log/vcap_registrar/vcap_registrar.log
+  file: /var/vcap/sys/log/servicesmgmt/vcap_registrar.log
   <% if properties.syslog_aggregator %>
   syslog: vcap.servicesmgmt_vcap_registrar
   <% end %>

--- a/jobs/servicesmgmt/templates/vcap_registrar_ctl
+++ b/jobs/servicesmgmt/templates/vcap_registrar_ctl
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
 export PATH=/var/vcap/packages/ruby/bin:$PATH
-RUN_DIR=/var/vcap/sys/run/vcap_registrar
-LOG_DIR=/var/vcap/sys/log/vcap_registrar
+RUN_DIR=/var/vcap/sys/run/servicesmgmt
+LOG_DIR=/var/vcap/sys/log/servicesmgmt
 PIDFILE=$RUN_DIR/vcap_registrar.pid
 
 source /var/vcap/packages/common/utils.sh

--- a/jobs/uaa/monit
+++ b/jobs/uaa/monit
@@ -4,8 +4,8 @@ check process uaa
   stop program "/var/vcap/jobs/uaa/bin/uaa_ctl stop"
   group vcap
 
-check process vcap_registrar
-  with pidfile /var/vcap/sys/run/vcap_registrar/vcap_registrar.pid
+check process uaa_vcap_registrar
+  with pidfile /var/vcap/sys/run/uaa/vcap_registrar.pid
   start program "/var/vcap/jobs/uaa/bin/vcap_registrar_ctl start"
   stop program "/var/vcap/jobs/uaa/bin/vcap_registrar_ctl stop"
   group vcap

--- a/jobs/uaa/templates/vcap_registrar.config.yml.erb
+++ b/jobs/uaa/templates/vcap_registrar.config.yml.erb
@@ -1,6 +1,6 @@
 ---
 logging:
-  file: /var/vcap/sys/log/vcap_registrar/vcap_registrar.log
+  file: /var/vcap/sys/log/uaa/vcap_registrar.log
   <% if properties.syslog_aggregator %>
   syslog: vcap.uaa_vcap_registrar
   <% end %>

--- a/jobs/uaa/templates/vcap_registrar_ctl
+++ b/jobs/uaa/templates/vcap_registrar_ctl
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
 export PATH=/var/vcap/packages/ruby/bin:$PATH
-RUN_DIR=/var/vcap/sys/run/vcap_registrar
-LOG_DIR=/var/vcap/sys/log/vcap_registrar
+RUN_DIR=/var/vcap/sys/run/uaa
+LOG_DIR=/var/vcap/sys/log/uaa
 PIDFILE=$RUN_DIR/vcap_registrar.pid
 
 source /var/vcap/packages/common/utils.sh


### PR DESCRIPTION
```
$ sudo grep monit /var/vcap/bosh/log/current
...
2013-06-12_00:16:51.98024 /var/vcap/monit/job/0000_core_noprops.login.monitrc:1: Error: service name conflict, vcap_registrar already defined '/var/vcap/sys/run/vcap_registrar/vcap_registrar.pid'
```

It turns out that 3 jobs all create the same pid file:

```
$ grep "vcap_registrar/vcap_registrar.pid" jobs/*/monit
jobs/login/monit:  with pidfile /var/vcap/sys/run/vcap_registrar/vcap_registrar.pid
jobs/servicesmgmt/monit:  with pidfile /var/vcap/sys/run/vcap_registrar/vcap_registrar.pid
jobs/uaa/monit:  with pidfile /var/vcap/sys/run/vcap_registrar/vcap_registrar.pid
```

Proposed solution: put the pid file in the `/var/vcap/sys/run/JOB` folder. This is what we do/did for nginx.

PR attached.
