### PR TITLE
Remove vcap_redis properties from cloud_controller_ng

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -217,12 +217,6 @@ properties:
   description:
  login.url:
   description:
- vcap_redis.address:
-  description:
- vcap_redis.port:
-  description:
- vcap_redis.password:
-  description:
  syslog_aggregator:
   description:
  uaa.jwt.verification_key:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -68,13 +68,6 @@ db:
   pool_timeout: <%= p("ccdb_ng.pool_timeout", 10) %>
   log_level: <%= p("ccng.db_logging_level", "debug2") %>
 
-<% if_p("vcap_redis.address", "vcap_redis.port", "vcap_redis.password") do |address, port, password| %>
-redis:
-  host: <%= address %>
-  port: <%= port %>
-  password: "<%= password %>"
-<% end %>
-
 <% scheme = p("uaa.no_ssl") ? "http" : "https"
    domain = p("domain") %>
 


### PR DESCRIPTION
Redis was removed as a dependency in March https://github.com/cloudfoundry/cloud_controller_ng/commit/2e3dd24e0c1500ab8769475668339e06dab91aa5
