### PR TITLE
Change the dea ctl script to run the dea as vcap

### DIFF
--- a/jobs/dea_next/templates/dea_ctl
+++ b/jobs/dea_next/templates/dea_ctl
@@ -14,11 +14,12 @@ case $1 in
 
   start)
     pid_guard $PIDFILE "DEA"
-    echo $$ > $PIDFILE
 
     mkdir -p $RUN_DIR
     mkdir -p $LOG_DIR
     mkdir -p $DATA_DIR
+    
+    echo $$ > $PIDFILE
 
     chown vcap:vcap $PIDFILE
     chown vcap:vcap $RUN_DIR


### PR DESCRIPTION
- we had to create the data directory in the script so we could change the owner to vcap

Signed-off-by: Alex Jackson ajackson@pivotallabs.com
