### PR TITLE
Remove -release suffix from final release name

### DIFF
--- a/config/final.yml
+++ b/config/final.yml
@@ -1,5 +1,5 @@
 ---
-final_name: cf-release
+final_name: cf
 min_cli_version: 1.5.0
 blobstore:
   provider: s3

--- a/releases/cf-132.yml
+++ b/releases/cf-132.yml
@@ -301,5 +301,5 @@ jobs:
     Njg1OTc4NjI0MGQ1NWIwZmIwMzhmMTNkOTFiZjQwZDY5NTA3MjZlNw==
 commit_hash: b4ddedb2
 uncommitted_changes: true
-name: cf-release
+name: cf
 version: 132

--- a/templates/cf-aws-template.yml.erb
+++ b/templates/cf-aws-template.yml.erb
@@ -10,7 +10,7 @@
 name: <%= find("name") %>
 director_uuid: <%= find("director_uuid") %>
 releases:
-- name: cf-release
+- name: cf
   version: latest
 
 compilation:


### PR DESCRIPTION
There is no value and only wasted characters in suffixing
-release to the release name of a bosh release. There is no history or
tradition of doing this and I'd not like to start now.
