### PR TITLE
making warden container mtu configurable in dea manifest file

### DIFF
--- a/jobs/dea_next/templates/warden.yml.erb
+++ b/jobs/dea_next/templates/warden.yml.erb
@@ -26,8 +26,9 @@ network:
   allow_networks: <%= properties.dea_next.allow_networks %>
   <%end %>
 
-  # Interface MTU size (default: 1454 for OpenStack)
-  # With MTU 1500 you will get problems with rubygems with GRE tunneling
+  # Interface MTU size (default: 1500)
+  # With MTU 1500 you will get problems with rubygems and GRE tunneling by OpenStack
+  # You will need for Gre tunneling 1454
   <% if properties.dea_next && properties.dea_next.mtu %>
   mtu: <%= properties.dea_next.mtu %>
   <%else%>


### PR DESCRIPTION
This are the config template changes to make the MTU size of each warden container configurable with the manifest file.

Explanation here: https://github.com/cloudfoundry/warden/pull/26
