### PR TITLE
Allow disable DEA disk quota for warden-cpi

### DIFF
--- a/jobs/dea_next/spec
+++ b/jobs/dea_next/spec
@@ -66,4 +66,7 @@ properties:
   dea_next.streaming_timeout:
     description:
     default: 60
+  disk_quota_enabled:
+    description: "disk quota must be disabled to use warden-inside-warden with the warden cpi"
+    default: true
 

--- a/jobs/dea_next/templates/warden.yml.erb
+++ b/jobs/dea_next/templates/warden.yml.erb
@@ -5,6 +5,8 @@ server:
   container_klass: Warden::Container::Linux
   container_rootfs_path: /var/vcap/packages/rootfs_lucid64
   container_depot_path: /var/vcap/data/warden/depot
+  quota:
+    disk_quota_enabled: <%= properties.disk_quota_enabled %>
 
 logging:
   file: /var/vcap/sys/log/warden/warden.log


### PR DESCRIPTION
Running warden inside warden doesn't work if disk quotas are enabled for the inner warden.  This pull request should be a no-op unless you update your dea_next job's properites:

``` yaml
- name: dea_next
  template: dea_next
  instances: 1
  resource_pool: infrastructure
  networks:
  - name: default
  properties:
    disk_quota_enabled: false

```
