### PR TITLE
Fix 405 Not Allowed when downloading app from cc_ng

### DIFF
--- a/jobs/cloud_controller_ng/templates/nginx.conf.erb
+++ b/jobs/cloud_controller_ng/templates/nginx.conf.erb
@@ -104,6 +104,12 @@ http {
     }
 
     location ~ /staging/(buildpack_cache|droplets)/.*/upload {
+      
+      # Allow download the droplets and buildpacks
+      if ($request_method = GET){
+        proxy_pass http://cloud_controller;
+      }
+      
       # Pass along auth header
       set $auth_header $upstream_http_x_auth;
       proxy_set_header Authorization $auth_header;


### PR DESCRIPTION
The nginx.conf in cf-release should allow droplets and buildpack download thru cc_ng.
