### PR TITLE
If syslog_aggregator running, properties host/port required

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -268,9 +268,14 @@ properties:
  vcap_redis.password:
   description: "deprecated"
 
- syslog_aggregator:
-  default: vcap.cloud_controller_ng
-  description: "Tag for logging to syslog. If not defined, cc will not log to syslog"
+ # if syslog_aggregator job template is running, provide
+ # these properties to configure other job templates to
+ # send it syslog logs
+ syslog_aggregator.address:
+  description: "Host to send logs for aggregating"
+ syslog_aggregator.port:
+  description: "Port to send logs for aggregating"
+
  uaa.jwt.verification_key:
   default: ""
   description: "ssl cert defined in the manifest by the UAA, required by the cc to communicate with UAA"

--- a/jobs/collector/spec
+++ b/jobs/collector/spec
@@ -41,7 +41,11 @@ properties:
     description: "IP address of OpenTsdb"
   opentsdb.port:
     description: "TCP port of OpenTsdb"
+
+  # if syslog_aggregator job template is running, provide
+  # these properties to configure other job templates to
+  # send it syslog logs
   syslog_aggregator.address:
-    description: "IP address of syslog aggregator"
+    description: "Host to send logs for aggregating"
   syslog_aggregator.port:
-    description: "port of syslog aggregator"
+    description: "Port to send logs for aggregating"

--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -13,8 +13,14 @@ packages:
   - gorouter
   - syslog_aggregator
 properties:
-  syslog_aggregator:
-    description:
+  # if syslog_aggregator job template is running, provide
+  # these properties to configure other job templates to
+  # send it syslog logs
+  syslog_aggregator.address:
+    description: "Host to send logs for aggregating"
+  syslog_aggregator.port:
+    description: "Port to send logs for aggregating"
+
   router.status.port:
     description:
   router.status.user:

--- a/jobs/health_manager_next/spec
+++ b/jobs/health_manager_next/spec
@@ -28,10 +28,15 @@ properties:
     description: "TCP port of NATS server"
   nats.user:
     description: "user name for NATS login"
+
+  # if syslog_aggregator job template is running, provide
+  # these properties to configure other job templates to
+  # send it syslog logs
   syslog_aggregator.address:
-    description: "IP address of syslog aggregator"
+    description: "Host to send logs for aggregating"
   syslog_aggregator.port:
-    description: "TCP port of syslog aggregator"
+    description: "Port to send logs for aggregating"
+
   health_manager.cc_partition:
     description:
     default: 'default'

--- a/jobs/login/spec
+++ b/jobs/login/spec
@@ -46,10 +46,15 @@ properties:
     description: "User name for NATS login"
   networks.apps:
     description: "The App network name"
+
+  # if syslog_aggregator job template is running, provide
+  # these properties to configure other job templates to
+  # send it syslog logs
   syslog_aggregator.address:
-    description: "IP address for syslog aggregator"
+    description: "Host to send logs for aggregating"
   syslog_aggregator.port:
-    description: "Port of syslog aggregator"
+    description: "Port to send logs for aggregating"
+
   uaa.clients.login.secret:
     description:
   uaa.dump_requests:

--- a/jobs/saml_login/spec
+++ b/jobs/saml_login/spec
@@ -93,10 +93,15 @@ properties:
     description:
   env.no_proxy:
     description:
+
+  # if syslog_aggregator job template is running, provide
+  # these properties to configure other job templates to
+  # send it syslog logs
   syslog_aggregator.address:
-    description:
+    description: "Host to send logs for aggregating"
   syslog_aggregator.port:
-    description:
+    description: "Port to send logs for aggregating"
+
   login.port:
     description:
     default: 8080

--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -83,10 +83,15 @@ properties:
     description: "User name for NATS login"
   networks.apps:
     description: "The App network name"
+
+  # if syslog_aggregator job template is running, provide
+  # these properties to configure other job templates to
+  # send it syslog logs
   syslog_aggregator.address:
-    description: "IP address for syslog aggregator"
+    description: "Host to send logs for aggregating"
   syslog_aggregator.port:
-    description: "Port of syslog aggregator"
+    description: "Port to send logs for aggregating"
+
   uaadb.address:
     description: "The UAA database IP address"
   uaadb.databases:


### PR DESCRIPTION
If syslog_aggregator job template is running then deployment file should provide:

```
properties:
 syslog_aggregator:
   host: 0.syslog_aggregator.default.mydeployment.bosh
   port: 54321
```

If syslog_aggregator job template is not running, then do not specify `properties.syslog_aggregator` at all.

The PR also copies the same inline documentation & same descriptions to all jobs that can emit syslog
