### PR TITLE
fix typo: properties.login --> properties.saml_login

### DIFF
--- a/jobs/saml_login/templates/tomcat.server.xml.erb
+++ b/jobs/saml_login/templates/tomcat.server.xml.erb
@@ -8,7 +8,7 @@
 
   <Service name="Catalina">
 
-    <Connector class="org.apache.coyote.http11.Http11NioProtocol" port="<%= (properties.login && properties.login.port) ? properties.login.port : 8080 %>" protocol="HTTP/1.1" connectionTimeout="20000"/>
+    <Connector class="org.apache.coyote.http11.Http11NioProtocol" port="<%= (properties.saml_login && properties.saml_login.port) ? properties.saml_login.port : 8080 %>" protocol="HTTP/1.1" connectionTimeout="20000"/>
     <Engine name="Catalina" defaultHost="localhost">
 
       <Host name="localhost" appBase="webapps" unpackWARs="true" autoDeploy="false">


### PR DESCRIPTION
Most people wouldn't notice/care.  But I colocate saml_login with another job that uses 8080, so without this fix I need to specify both properties.login.port and properties.saml_login.port, even though I am not using the login job.
