### PR TITLE
fix saml_login login.url

### DIFF
--- a/jobs/saml_login/templates/login.yml.erb
+++ b/jobs/saml_login/templates/login.yml.erb
@@ -45,7 +45,7 @@ dump_requests: <%= properties.uaa.dump_requests %>
 <% end %>
 
 login:
-  url: <%= uaa_base %>
+  url: <%= "#{protocol}://login.#{properties.domain}" %>
   # The entity base url is the location of this application
   # (The host and port of the application that will accept assertions)
   entityBaseURL: <%= "#{protocol}://login.#{properties.domain}" %>


### PR DESCRIPTION
login.url URL is used to generate the passcode link (https://github.com/cloudfoundry/login-server/blob/master/saml-login-server/src/main/webapp/WEB-INF/spring-servlet.xml#L478).

but uaa doesn't response to /passcode, saml-login does: 

```
nicholask@utility:~/cf/login-server$ git grep '/passcode'
saml-login-server/src/main/java/org/cloudfoundry/identity/uaa/login/PasscodeController.java:    @RequestMapping(value = { "/passcode" }, method = RequestMeth
saml-login-server/src/main/webapp/WEB-INF/spring-servlet.xml:                                   <constructor-arg name="text" value="One Time Code (Get one at
```
