### PR TITLE
[ finishes #54080837 ] allow syslog_aggregator can be disabled.

### DIFF
--- a/jobs/collector/templates/config.yml.erb
+++ b/jobs/collector/templates/config.yml.erb
@@ -1,7 +1,7 @@
 ---
 logging:
   file: /var/vcap/sys/log/collector/collector.log
-  <% if properties.syslog_aggregator %>
+  <% if properties.syslog_aggregator.address %>
   syslog: vcap.collector
   <% end %>
   level: info

--- a/jobs/collector/templates/syslog_forwarder.conf.erb
+++ b/jobs/collector/templates/syslog_forwarder.conf.erb
@@ -1,4 +1,4 @@
-<% if properties.syslog_aggregator %>
+<% if properties.syslog_aggregator.address %>
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 $WorkDirectory /var/vcap/sys/rsyslog/buffered  # where messages should be buffered on disk

--- a/jobs/health_manager_next/templates/health_manager_next.yml.erb
+++ b/jobs/health_manager_next/templates/health_manager_next.yml.erb
@@ -9,7 +9,7 @@ local_route: <%= spec.networks.send(properties.networks.apps).ip %>
 mbus: nats://<%= properties.nats.user %>:<%= properties.nats.password %>@<%= properties.nats.address %>:<%= properties.nats.port %>
 logging:
   file: /var/vcap/sys/log/health_manager_next/health_manager_next.log
-  <% if properties.syslog_aggregator %>
+  <% if properties.syslog_aggregator.address %>
   syslog: vcap.health_manager_next
   <% end %>
   level: debug

--- a/jobs/health_manager_next/templates/syslog_forwarder.conf.erb
+++ b/jobs/health_manager_next/templates/syslog_forwarder.conf.erb
@@ -1,4 +1,4 @@
-<% if properties.syslog_aggregator %>
+<% if properties.syslog_aggregator.address %>
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 $WorkDirectory /var/vcap/sys/rsyslog/buffered # where messages should be buffered on disk

--- a/jobs/login/templates/cf-registrar.config.yml.erb
+++ b/jobs/login/templates/cf-registrar.config.yml.erb
@@ -1,7 +1,7 @@
 ---
 logging:
   file: /var/vcap/sys/log/login/cf-registrar.log
-  <% if properties.syslog_aggregator %>
+  <% if properties.syslog_aggregator.address %>
   syslog: vcap.login_cf-registrar
   <% end %>
   level: info

--- a/jobs/login/templates/login_ctl.erb
+++ b/jobs/login/templates/login_ctl.erb
@@ -57,7 +57,7 @@ case $1 in
     mkdir -p $LOG_DIR
     echo $$ > $PIDFILE
 
-    <% if properties.syslog_aggregator %>
+    <% if properties.syslog_aggregator.address %>
     /var/vcap/packages/syslog_aggregator/setup_syslog_forwarder.sh $JOB_DIR/config
     <% end %>
 

--- a/jobs/login/templates/syslog_forwarder.conf.erb
+++ b/jobs/login/templates/syslog_forwarder.conf.erb
@@ -1,4 +1,4 @@
-<% if properties.syslog_aggregator %>
+<% if properties.syslog_aggregator.address %>
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 

--- a/jobs/saml_login/templates/cf-registrar.config.yml.erb
+++ b/jobs/saml_login/templates/cf-registrar.config.yml.erb
@@ -1,7 +1,7 @@
 ---
 logging:
   file: /var/vcap/sys/log/saml_login/cf-registrar.log
-  <% if properties.syslog_aggregator %>
+  <% if properties.syslog_aggregator.address %>
   syslog: vcap.saml_login_cf-registrar
   <% end %>
   level: info

--- a/jobs/saml_login/templates/saml_login_ctl.erb
+++ b/jobs/saml_login/templates/saml_login_ctl.erb
@@ -57,7 +57,7 @@ case $1 in
     mkdir -p $LOG_DIR
     echo $$ > $PIDFILE
 
-    <% if properties.syslog_aggregator %>
+    <% if properties.syslog_aggregator.address %>
     /var/vcap/packages/syslog_aggregator/setup_syslog_forwarder.sh $JOB_DIR/config
     <% end %>
 

--- a/jobs/saml_login/templates/syslog_forwarder.conf.erb
+++ b/jobs/saml_login/templates/syslog_forwarder.conf.erb
@@ -1,4 +1,4 @@
-<% if properties.syslog_aggregator %>
+<% if properties.syslog_aggregator.address %>
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 

--- a/jobs/uaa/templates/cf-registrar.config.yml.erb
+++ b/jobs/uaa/templates/cf-registrar.config.yml.erb
@@ -1,7 +1,7 @@
 ---
 logging:
   file: /var/vcap/sys/log/uaa/cf-registrar.log
-  <% if properties.syslog_aggregator %>
+  <% if properties.syslog_aggregator.address %>
   syslog: vcap.uaa_cf-registrar
   <% end %>
   level: info

--- a/jobs/uaa/templates/syslog_forwarder.conf.erb
+++ b/jobs/uaa/templates/syslog_forwarder.conf.erb
@@ -1,4 +1,4 @@
-<% if properties.syslog_aggregator %>
+<% if properties.syslog_aggregator.address %>
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 

--- a/jobs/uaa/templates/uaa_ctl.erb
+++ b/jobs/uaa/templates/uaa_ctl.erb
@@ -61,7 +61,7 @@ case $1 in
     mkdir -p $LOG_DIR
     echo $$ > $PIDFILE
 
-    <% if properties.syslog_aggregator %>
+    <% if properties.syslog_aggregator.address %>
     /var/vcap/packages/syslog_aggregator/setup_syslog_forwarder.sh $JOB_DIR/config
     <% end %>
 


### PR DESCRIPTION
```
because to define property foo.bar in spec file implicitly defines foo, test `if properties.foo`
is always true. For this reason, the following 5 jobs, which have syslog_aggregator.address defined
in spec files, had problem when job syslog_aggregator is not enabled.

collector
health_manager_next
login
saml_login
uaa
```
