### PR TITLE
Allow disable DEA kernel tunings for warden-cpi

### DIFF
--- a/jobs/dea_next/spec
+++ b/jobs/dea_next/spec
@@ -66,6 +66,9 @@ properties:
   dea_next.streaming_timeout:
     description:
     default: 60
+  dea_next.kernel_network_tuning_enabled:
+    description: "with latest kernel version, no kernel network tunings allowed with in warden cpi containers"
+    default: true
   disk_quota_enabled:
     description: "disk quota must be disabled to use warden-inside-warden with the warden cpi"
     default: true

--- a/jobs/dea_next/templates/dea_ctl
+++ b/jobs/dea_next/templates/dea_ctl
@@ -28,6 +28,7 @@ case $1 in
 
     ulimit -c unlimited
 
+    <% if p("dea_next.kernel_network_tuning_enabled") == true %>
     # TCP_FIN_TIMEOUT
     # This setting determines the time that must elapse before TCP/IP can release a closed connection and reuse
     # its resources. During this TIME_WAIT state, reopening the connection to the client costs less than establishing
@@ -49,6 +50,7 @@ case $1 in
     # Default value is 0 (disabled). It is generally a safer alternative to tcp_tw_recycle
 
     echo 1 > /proc/sys/net/ipv4/tcp_tw_reuse
+    <% end %>
 
     <% if properties.syslog_aggregator %>
     /var/vcap/packages/syslog_aggregator/setup_syslog_forwarder.sh $JOB_DIR/config

--- a/jobs/dea_next/templates/warden_ctl
+++ b/jobs/dea_next/templates/warden_ctl
@@ -24,8 +24,10 @@ case $1 in
 
     ulimit -c unlimited
 
+    <% if p("dea_next.kernel_network_tuning_enabled") == true %>
     # Use default local port range (higher ports are used for pooling)
     echo 32768 61000 > /proc/sys/net/ipv4/ip_local_port_range
+    <% end %>
 
     # The kernel has a bug where network interfaces cannot be removed when a
     # network namespace is destroyed (NEW_NETNS) due to dangling references.


### PR DESCRIPTION
With latest Linux kernel (bosh-lite), now several system variables are not configurable inside warden containers. including: ip_local_port_range, tcp_fin_timeout, tcp_tw_recycle, tcp_tw_reuse.  so dea_next job will fail deploy in warden-cpi.

this pull request is to allow disable kernel tunings with a switch so that it could pass inside 'warden container vm'. (and we can do the tuning outside the container in bosh-lite ) 

and the default value is set to enabled so not any influence for current logic.

@mkocher story here: https://www.pivotaltracker.com/story/show/54665626 
