### PR TITLE
make nats_stream_forwarder optional

### DIFF
--- a/jobs/syslog_aggregator/monit
+++ b/jobs/syslog_aggregator/monit
@@ -4,8 +4,10 @@ check process syslog_aggregator
   stop program "/var/vcap/jobs/syslog_aggregator/bin/syslog_aggregator_ctl stop"
   group vcap
 
+<% if properties.syslog_aggregator.nats_stream_forwarder.nil? || properties.syslog_aggregator.nats_stream_forwarder %>
 check process nats_stream_forwarder
   with pidfile /var/vcap/sys/run/syslog_aggregator/nats_stream_forwarder.pid
   start program "/var/vcap/jobs/syslog_aggregator/bin/nats_stream_forwarder_ctl start"
   stop program "/var/vcap/jobs/syslog_aggregator/bin/nats_stream_forwarder_ctl stop"
   group vcap
+<% end %>


### PR DESCRIPTION
nats_stream_forwarder seems broken?  so this commit allows you to disable it by adding "properties.syslog_aggregator.nats_stream_forwarder: false" to your deployment manifest.

```
root@ccc25b0b-a75a-4eb8-ba83-390c25799741:~# tail -3 /var/vcap/sys/log/monit/nats_stream_forwarder_ctl.err.log
<internal:lib/rubygems/custom_require>:29:in `require': no such file to load -- nats/client (LoadError)
        from <internal:lib/rubygems/custom_require>:29:in `require'
        from /var/vcap/jobs/syslog_aggregator/bin/nats_stream_forwarder.rb:4:in `<main>'
```
