### PR TITLE
Ensure NFS_SHARE owner is vcap:vcap

### DIFF
--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng_ctl.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng_ctl.erb
@@ -56,6 +56,7 @@ case $1 in
     <% if properties.nfs_server.address %>
     modprobe nfs
     mkdir -p $NFS_SHARE
+    chown vcap:vcap $NFS_SHARE
 
     cp -f /etc/default/nfs-common /etc/default/nfs-common.orig
     cp -f $CC_JOB_DIR/config/nfs-common /etc/default/nfs-common


### PR DESCRIPTION
For our deployment we use an enterprise NFS share.  We ran into trouble switching from debian_nfs_server to our enterprise solution because of a directory ownership problem.

This PR ensures that vcap always owns the NFS_SHARE directory.

It has saved us some trouble.  Perhaps it will save trouble for some others.
