### PR TITLE
Support for setting an offset for DEA indexes.

### DIFF
--- a/jobs/dea_next/spec
+++ b/jobs/dea_next/spec
@@ -61,6 +61,9 @@ properties:
   dea_next.num_instances:
     description:
     default: 30
+  dea_next.offset:
+    description: "allows for unique dea index spread accross deployments"
+    default: 0
   dea_next.stacks:
     description:
   dea_next.streaming_timeout:

--- a/jobs/dea_next/templates/dea.yml.erb
+++ b/jobs/dea_next/templates/dea.yml.erb
@@ -30,7 +30,7 @@ logging:
   <% end %>
   level: debug
 
-index: <%= spec.index %>
+index: <%= p("dea_next.offset") + spec.index %>
 
 intervals:
   heartbeat: 10


### PR DESCRIPTION
We distribute our DEAs over multiple bosh deployments.  So that we can have unique indexes for our DEAs we've added support for setting an offset for DEA indexes. (similar to what routers support today)
