### PR TITLE
Support for setting default group_membership in uaa

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -107,6 +107,8 @@ properties:
     description:
   uaa.require_https:
     description:
+  uaa.scim.group_membership:
+    description: "support for setting default group membership in UAA.  Useful to give a set of users 'cloud_controller.admin', for example"
   uaa_client_auth_credentials.password:
     description:
   uaa_client_auth_credentials.username:

--- a/jobs/uaa/templates/uaa.yml.erb
+++ b/jobs/uaa/templates/uaa.yml.erb
@@ -102,6 +102,10 @@ scim:
   users: <% properties.uaa.scim.users.each do |user| %>
     - <%= user %><% end %>
 <% end %>
+<% if properties.uaa.scim && properties.uaa.scim.group_membership then %>
+  group_membership: <% properties.uaa.scim.group_membership.each do |membership| %>
+    - <%= membership %><% end %>
+<% end %>
 <% if !properties.uaa.require_https.nil? %>
 require_https: <%= properties.uaa.require_https %>
 <% end %>


### PR DESCRIPTION
Since we use Ldap to manage users we don't have to create a new set of users each time we do a fresh dev/test deployment.  In such a scenario it is also nice to automatically set a group of users as admins, for example.
