### PR TITLE
allow drain.rb to not fail if dea job never started correctly

### DIFF
--- a/jobs/dea_next/templates/drain.rb
+++ b/jobs/dea_next/templates/drain.rb
@@ -3,6 +3,7 @@
 require "logger"
 require "fileutils"
 
+FileUtils.mkdir_p("/var/vcap/sys/log/dea_next")
 logger = Logger.new("/var/vcap/sys/log/dea_next/drain.log")
 
 job_change, hash_change, *updated_packages = ARGV


### PR DESCRIPTION
If dea_next didn't actually start (due to some bosh error), then bin/drain cannot run.

```
Updating job dea
  dea/6 (canary) (00:00:01)                                                                         
Done                    24/24 00:00:01                                                              

Error 450001: Drain script exit 1: 
/var/vcap/bosh/lib/ruby/gems/1.9.1/gems/bosh_agent-1.5.0.pre.3/lib/bosh_agent/message/drain.rb:182:in `run'
/var/vcap/bosh/lib/ruby/gems/1.9.1/gems/bosh_agent-1.5.0.pre.3/lib/bosh_agent/message/drain.rb:117:in `run_drain_script'
/var/vcap/bosh/lib/ruby/gems/1.9.1/gems/bosh_agent-1.5.0.pre.3/lib/bosh_agent/message/drain.rb:78:in `drain_for_update'
/var/vcap/bosh/lib/ruby/gems/1.9.1/gems/bosh_agent-1.5.0.pre.3/lib/bosh_agent/message/drain.rb:63:in `drain'
/var/vcap/bosh/lib/ruby/gems/1.9.1/gems/bosh_agent-1.5.0.pre.3/lib/bosh_agent/message/drain.rb:13:in `process'
/var/vcap/bosh/lib/ruby/gems/1.9.1/gems/bosh_agent-1.5.0.pre.3/lib/bosh_agent/handler.rb:277:in `process'
/var/vcap/bosh/lib/ruby/gems/1.9.1/gems/bosh_agent-1.5.0.pre.3/lib/bosh_agent/handler.rb:262:in `process_long_running'
/var/vcap/bosh/lib/ruby/gems/1.9.1/gems/bosh_agent-1.5.0.pre.3/lib/bosh_agent/handler.rb:189:in `block in process_in_thread'
<internal:prelude>:10:in `synchronize'
/var/vcap/bosh/lib/ruby/gems/1.9.1/gems/bosh_agent-1.5.0.pre.3/lib/bosh_agent/handler.rb:187:in `process_in_thread'
/var/vcap/bosh/lib/ruby/gems/1.9.1/gems/bosh_agent-1.5.0.pre.3/lib/bosh_agent/handler.rb:167:in `block in handle_message'
/var/vcap/bosh/lib/ruby/gems/1.9.1/gems/eventmachine-0.12.10/lib/eventmachine.rb:1060:in `call'
/var/vcap/bosh/lib/ruby/gems/1.9.1/gems/eventmachine-0.12.10/lib/eventmachine.rb:1060:in `block in spawn_threadpool'

```

This patch permits bin/drain to run, thus allowing the VM to be re-deployed/applied.
