### PR TITLE
Fix cf-aws-template

### DIFF
--- a/templates/cf-aws-template.yml.erb
+++ b/templates/cf-aws-template.yml.erb
@@ -81,6 +81,15 @@ resource_pools:
 jobs:
 # ====================== BEGIN CF JOBS =========================
 
+- name: nats
+  template: nats
+  instances: 1
+  resource_pool: common
+  networks:
+  - name: cf1
+    static_ips:
+    - <%= ip( 1, 'cf1.static') %>
+
 - name: syslog_aggregator
   template: syslog_aggregator
   instances: 1
@@ -90,15 +99,6 @@ jobs:
   - name: cf1
     static_ips:
     - <%= ip( 0, 'cf1.static') %>
-
-- name: nats
-  template: nats
-  instances: 1
-  resource_pool: common
-  networks:
-  - name: cf1
-    static_ips:
-    - <%= ip( 1, 'cf1.static') %>
 
 - name: uaa
   template: uaa


### PR DESCRIPTION
- NATS ip address in properties should not be hardcoded
- NATS job should update before syslog job in case of a new deploy

The background is we always want to keep in sync with cf-release aws template for warden-cpi. so we wrote a transform script to generate yaml from aws template.

But Found 2 issues
1) the nats ip address in properties is hardcoded so using different network address will fail
2) nats should be update before syslog aggregator in a brand new deploy. other wise syslog will fail for connecting to nats.

yes we can fix in the transform script, but think this is more general fix to do it in this templates. and also no influence to aws deploy. so sent this pull request for review.
