### PR TITLE
Add parameter to make dea directory server protocal configurable

### DIFF
--- a/jobs/dea_next/spec
+++ b/jobs/dea_next/spec
@@ -68,6 +68,9 @@ properties:
   dea_next.streaming_timeout:
     description:
     default: 60
+  dea_next.directory_server_protocol:
+    description: 'The protocol to use when communicating with the directory server ("http" or "https")'
+    default: 'https'
   dea_next.kernel_network_tuning_enabled:
     description: "with latest kernel version, no kernel network tunings allowed with in warden cpi containers"
     default: true

--- a/jobs/dea_next/templates/dea.yml.erb
+++ b/jobs/dea_next/templates/dea.yml.erb
@@ -10,7 +10,7 @@ base_dir: /var/vcap/data/dea_next
 warden_socket: /var/vcap/data/warden/warden.sock
 
 directory_server:
-  protocol: "https"
+  protocol: '<%= p('dea_next.directory_server_protocol') %>'
   v1_port: 12345
   v2_port: 34567
   file_api_port: 23456


### PR DESCRIPTION
make it configurable so we can chose http rather than hardcoded https.

this is useful when we use warden-cpi which streaming log go directly to router rather than elb. 
as now router only support http protocol, so https will cause some error while streaming log.
