### PR TITLE
Loggregator production push

### DIFF
--- a/templates/cf-release-template.yml.erb
+++ b/templates/cf-release-template.yml.erb
@@ -233,14 +233,45 @@ jobs:
   networks:
   - name: cf1
 
-- name: dea_next
 <% if production? -%>
+- name: dea_next
   template: dea_next
-<% else -%>
+  instances: <%= find('jobs.dea_next.instances') - 1 %>
+  update:
+    max_in_flight: <%= q("dea.update.max_in_flight", 1) %>
+  resource_pool: dea
+  networks:
+  - name: cf1
+    default:
+    - dns
+    - gateway
+  properties:
+    dea_next:
+      stacks:
+      - lucid64
+
+- name: dea_next_with_loggregator
   template:
   - dea_next
   - dea_logging_agent
-<% end -%>
+  instances: 1
+  update:
+    max_in_flight: <%= q("dea.update.max_in_flight", 1) %>
+  resource_pool: dea
+  networks:
+  - name: cf1
+    default:
+    - dns
+    - gateway
+  properties:
+    dea_next:
+      stacks:
+      - lucid64
+<% else -%>
+- name: dea_next
+  template:
+  - dea_next
+  - dea_logging_agent
   instances: <%= find('jobs.dea_next.instances') %>
   update:
     max_in_flight: <%= q("dea.update.max_in_flight", 1) %>
@@ -254,6 +285,7 @@ jobs:
     dea_next:
       stacks:
       - lucid64
+<% end -%>
 
 - name: collector
   template: collector
@@ -449,14 +481,12 @@ properties:
       smtp_port: 587
       smtp_domain: gmail.com
 
-<% unless production? -%>
   loggregator:
     server: <%= loggregator_static_ip %>:3456
     status:
       user: <%= find("properties.loggregator.status.user") %>
       password: <%= find("properties.loggregator.status.password") %>
       port: 5768
-<% end -%>
 
   login:
     protocol: https


### PR DESCRIPTION
These are the proposed changes to production to add the loggregator server and dea logging agents. The dea logging agent will be installed on one dea only.

For the loggregator logs-cf-plugin to work, we will manually add TCP port 4443 to the prod ELB(s).
