### PR TITLE
Rename cf-registrar_ctrl files with job name prefixes

### DIFF
--- a/jobs/login/monit
+++ b/jobs/login/monit
@@ -6,6 +6,6 @@ check process login
 
 check process login_cf-registrar
   with pidfile /var/vcap/sys/run/login/cf-registrar.pid
-  start program "/var/vcap/jobs/login/bin/cf-registrar_ctl start"
-  stop program "/var/vcap/jobs/login/bin/cf-registrar_ctl stop"
+  start program "/var/vcap/jobs/login/bin/login_cf-registrar_ctl start"
+  stop program "/var/vcap/jobs/login/bin/login_cf-registrar_ctl stop"
   group vcap

--- a/jobs/login/spec
+++ b/jobs/login/spec
@@ -2,7 +2,7 @@
 name: login
 templates:
   login_ctl.erb: bin/login_ctl
-  cf-registrar_ctl: bin/cf-registrar_ctl
+  cf-registrar_ctl: bin/login_cf-registrar_ctl
 
   cf-registrar.config.yml.erb: config/cf-registrar/config.yml
   login.yml.erb: config/login.yml

--- a/jobs/saml_login/monit
+++ b/jobs/saml_login/monit
@@ -6,6 +6,6 @@ check process saml_login
 
 check process saml_login_cf-registrar
   with pidfile /var/vcap/sys/run/saml_login/cf-registrar.pid
-  start program "/var/vcap/jobs/saml_login/bin/cf-registrar_ctl start"
-  stop program "/var/vcap/jobs/saml_login/bin/cf-registrar_ctl stop"
+  start program "/var/vcap/jobs/saml_login/bin/saml_login_cf-registrar_ctl start"
+  stop program "/var/vcap/jobs/saml_login/bin/saml_login_cf-registrar_ctl stop"
   group vcap

--- a/jobs/saml_login/spec
+++ b/jobs/saml_login/spec
@@ -2,7 +2,7 @@
 name: saml_login
 templates:
   saml_login_ctl.erb: bin/saml_login_ctl
-  cf-registrar_ctl: bin/cf-registrar_ctl
+  cf-registrar_ctl: bin/saml_login_cf-registrar_ctl
 
   cf-registrar.config.yml.erb: config/cf-registrar/config.yml
   login.yml.erb: config/login.yml

--- a/jobs/uaa/monit
+++ b/jobs/uaa/monit
@@ -6,6 +6,6 @@ check process uaa
 
 check process uaa_cf-registrar
   with pidfile /var/vcap/sys/run/uaa/cf-registrar.pid
-  start program "/var/vcap/jobs/uaa/bin/cf-registrar_ctl start"
-  stop program "/var/vcap/jobs/uaa/bin/cf-registrar_ctl stop"
+  start program "/var/vcap/jobs/uaa/bin/uaa_cf-registrar_ctl start"
+  stop program "/var/vcap/jobs/uaa/bin/uaa_cf-registrar_ctl stop"
   group vcap

--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -2,7 +2,7 @@
 name: uaa
 templates:
   uaa_ctl.erb: bin/uaa_ctl
-  cf-registrar_ctl: bin/cf-registrar_ctl
+  cf-registrar_ctl: bin/uaa_cf-registrar_ctl
 
   cf-registrar.config.yml.erb: config/cf-registrar/config.yml
   uaa.yml.erb: config/uaa.yml


### PR DESCRIPTION
I found that when cf-registrar enabled templates are collocated in a single job, the log outputs generated by the monit are written together in a single file `/var/vcap/sys/log/monit/cf-registrar_ctl.log`.
This commit fixes the problem by renaming the `cf-registrar_ctl` file with component prefixes.
