### PR TITLE
set default value for cc_partition to "default" to match that in the HM

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -99,7 +99,7 @@ properties:
   default: "api"
   description: "Host part of the cloud_controller api URI, will be joined with value of 'domain'"
  ccng.cc_partition:
-  default: "ng"
+  default: "default"
   description: "Deprecated. Defines a 'partition' for the health_manager job"
  ccng.bootstrap_admin_email:
   default: "admin@example.com"


### PR DESCRIPTION
Allows the cc and hm to communicate correctly even when deployment manifest doesn't explicitly set this value.
