### PR TITLE
Document login.links.xyz properties and defaults

### DIFF
--- a/jobs/login/spec
+++ b/jobs/login/spec
@@ -24,12 +24,15 @@ properties:
     description:
   login.links:
     description: A hash of home/passwd/signup URLS (see commented examples below)
-  # login.links.home:
-  #   default: https://console.run.pivotal.io
-  # login.links.passwd:
-  #   default: https://console.run.pivotal.io/password_resets/new
-  # login.links.signup:
-  #   default: https://console.run.pivotal.io/register
+  login.links.home:
+    description: URL for primary console/dashboard for users
+    default: https://console.run.pivotal.io
+  login.links.passwd:
+    description: URL for requesting password reset
+    default: https://console.run.pivotal.io/password_resets/new
+  login.links.signup:
+    description: URL for requesting to signup/register for an account
+    default: https://console.run.pivotal.io/register
   login.port:
     default: 8080
     description:

--- a/jobs/login/templates/login.yml.erb
+++ b/jobs/login/templates/login.yml.erb
@@ -4,8 +4,8 @@ name: login
 logging:
   config: /var/vcap/jobs/login/config/log4j.properties
 
-<% protocol = (properties.login && properties.login.protocol) ? properties.login.protocol : "http" %>
-<% if !properties.login || !properties.login.uaa_base
+<% protocol = p("login.protocol") %> # http or https
+<% unless properties.login.uaa_base
   # Fix this to https when SSL certs are working in dev and staging
   uaa_base = "#{protocol}://uaa.#{properties.domain}"
 else
@@ -21,10 +21,11 @@ uaa:
     url: <%= uaa_base %>/clientinfo
   approvals:
     url: <%= uaa_base %>/approvals
-<% if properties.login and properties.login.links then %>
-links: <% properties.login.links.marshal_dump.each do |id,url| %>
-  <%= id %>: <%= url %><% end %>
-<% end %>
+
+links:
+  home:   <%= p("login.links.home") %>
+  passwd: <%= p("login.links.passwd") %>
+  signup: <%= p("login.links.signup") %>
 
 <% if !properties.uaa.clients || !properties.uaa.clients.login %>
 LOGIN_SECRET: <%= properties.uaa.login.client_secret %>


### PR DESCRIPTION
Nowhere in cf-release is it mentioned that the 3 available login.links.xyz 
properties are and what their default values are. This commit brings across 
the current default values that login-server itself provides if 
login.links.home or login.links.passwd or login.links.signup are not
provided.
