### PR TITLE
Remove unuseful max_errors from the universe

### DIFF
--- a/templates/cf-aws-template.yml.erb
+++ b/templates/cf-aws-template.yml.erb
@@ -26,7 +26,6 @@ update:
   canary_watch_time: 30000-600000
   update_watch_time: 30000-600000
   max_in_flight: 4
-  max_errors: 1
 
 networks:
 - name: cf1

--- a/templates/cf-release-template.yml.erb
+++ b/templates/cf-release-template.yml.erb
@@ -132,7 +132,6 @@ update:
   canary_watch_time: 30000-600000
   update_watch_time: 30000-600000
   max_in_flight: 1
-  max_errors: 1
 
 networks:
 - name: cf1


### PR DESCRIPTION
max_errors option has been removed from Bosh a long time ago (https://github.com/cloudfoundry/bosh/commit/a38c8fb4097a86f6cb6dcab078d0ef50231b0aff)
