### PR TITLE
Buildpack cache now has subdirectories.

### DIFF
--- a/packages/buildpack_cache/spec
+++ b/packages/buildpack_cache/spec
@@ -1,4 +1,4 @@
 ---
 name: buildpack_cache
 files:
-- buildpack_cache/*
+- buildpack_cache/**/*


### PR DESCRIPTION
New artifacts in java-buildpack are not being included in the buildpack-cache.
