### PR TITLE
remove dea_next.num_instances - not used by dea_ng

### DIFF
--- a/jobs/dea_next/spec
+++ b/jobs/dea_next/spec
@@ -58,9 +58,6 @@ properties:
   dea_next.memory_overcommit_factor:
     description:
     default: 1
-  dea_next.num_instances:
-    description:
-    default: 30
   dea_next.stacks:
     default:
     - "lucid64"

--- a/jobs/dea_next/templates/dea.yml.erb
+++ b/jobs/dea_next/templates/dea.yml.erb
@@ -42,7 +42,6 @@ resources:
   memory_overcommit_factor: <%= p("dea_next.memory_overcommit_factor") %>
   disk_mb: <%= p("dea_next.disk_mb") %>
   disk_overcommit_factor: <%= p("dea_next.disk_overcommit_factor") %>
-  num_instances: <%= p("dea_next.num_instances") %>
 
 bind_mounts:
 - src_path: /var/vcap/packages/buildpack_cache


### PR DESCRIPTION
There is no useful usage of resources.num_instances in dea_ng.
