### PR TITLE
cf-aws-template.yml.erb - anyone using it?

### DIFF
--- a/templates/cf-aws-template.yml.erb
+++ b/templates/cf-aws-template.yml.erb
@@ -22,7 +22,7 @@
 name: <%= find("name") %>
 director_uuid: <%= find("director_uuid") %>
 releases:
-- name: cf-release
+- name: cf
   version: latest
 
 compilation:


### PR DESCRIPTION
`templates/cf-aws-template.yml.erb` references release name `cf-release` instead of `cf`. It's over a month since we switched to `cf` name. Is this template used or supposably useful?
