### PR TITLE
Update saml_login to 1.2.6

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -402,11 +402,6 @@ buildpack_cache/auto-reconfiguration-0.6.8.jar:
   sha: !binary |-
     MjY4MjYwMDM5YzZmMjU4N2M1Y2M0M2MyYjU3M2VlODhiNGRiZWMwYw==
   size: 709165
-saml_login/cloudfoundry-saml-login-server-1.3.0-SNAPSHOT.war:
-  object_id: 74eedfc9-f3f1-4497-9dc4-3a46ea501e39
-  sha: !binary |-
-    OWQwODQyNjg1MjJhMzIyNjU1N2U2ODQzY2FkN2VlZGVlYzU4NzkwMQ==
-  size: 21508295
 ruby/ruby-1.9.3-p448.tar.gz:
   object_id: 37208aad-5274-4364-8590-c8516bc57a1b
   sha: !binary |-
@@ -552,3 +547,8 @@ golang/go1.1.2.linux-amd64-yacc-shaved.tar.gz:
   sha: !binary |-
     MDJhYTlmNDdiOTVjZTAxMmI1NzAyZGFmNDFkM2ZmNGI3ODFhYzMwZQ==
   size: 41768327
+saml_login/cloudfoundry-saml-login-server-1.2.6.war:
+  object_id: f4e7bb56-5ae9-436e-a5ad-cc0d79dd5660
+  sha: !binary |-
+    Yzc1MzhmYjdmNzdjZTM5ZGE4ZjExN2M5YWY0MmE2YjY2MGUyZmZkNQ==
+  size: 21491455

--- a/packages/saml_login/packaging
+++ b/packages/saml_login/packaging
@@ -20,7 +20,7 @@ mv apache-tomcat-7.0.42 tomcat
 
 cd tomcat
 rm -rf webapps/*
-cp -a ${BOSH_COMPILE_TARGET}/saml_login/cloudfoundry-saml-login-server-1.3.0-SNAPSHOT.war webapps/ROOT.war
+cp -a ${BOSH_COMPILE_TARGET}/saml_login/cloudfoundry-saml-login-server-1.2.6.war webapps/ROOT.war
 cp -a ${BOSH_COMPILE_TARGET}/uaa/cloudfoundry-identity-varz-1.0.2.war webapps/varz.war
 
 cd ${BOSH_INSTALL_TARGET}


### PR DESCRIPTION
This commit updates the saml_login server to 1.2.6.  Previously an untracked 1.3 SNAPSHOT was being used.

This update matches the 1.2.5 login-server with one additional change to support the autologin flow.
