### PR TITLE
Raise cf client access token validity to 10 minutes

### DIFF
--- a/jobs/uaa/templates/uaa.yml.erb
+++ b/jobs/uaa/templates/uaa.yml.erb
@@ -73,7 +73,7 @@ oauth:
       authorized-grant-types: implicit,password,refresh_token
       scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write
       authorities: uaa.none
-      access-token-validity: 300
+      access-token-validity: 600
       refresh-token-validity: 2592000
 <% end %>
 <% if !properties.uaa.clients || !properties.uaa.clients.login %>


### PR DESCRIPTION
5 minutes has shown to be too short of a window for pushes of large applications.  Prior to the change to reduce the access token to 5 minutes we had been running with 10 minutes, this change sets that value by default.
