### PR TITLE
Output `login` values only when `login.enabled` is `true`

### DIFF
--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -74,7 +74,7 @@ active_record_db:
 <% scheme = p("uaa.no_ssl") ? "http" : "https"
    domain = p("domain") %>
 
-<% if_p("login.enabled") do %>
+<% if p("login.enabled") %>
 login:
   url: <%= p("login.url", "#{scheme}://login.#{domain}") %>
 <% end %>


### PR DESCRIPTION
When `login.enabled` is set to `false`,  the `login:` filed should not be written.
