### PR TITLE
fix: nats_stream_forwarder can't start

### DIFF
--- a/jobs/nats/templates/nats_stream_forwarder_ctl.erb
+++ b/jobs/nats/templates/nats_stream_forwarder_ctl.erb
@@ -5,6 +5,7 @@ LOG_DIR=/var/vcap/sys/log/nats_stream_forwarder
 JOB_DIR=/var/vcap/jobs/nats
 BIN_DIR=$JOB_DIR/bin
 PIDFILE=$RUN_DIR/nats_stream_forwarder.pid
+export PATH=/var/vcap/packages/ruby/bin:$PATH
 export BUNDLE_GEMFILE=/var/vcap/packages/nats/Gemfile
 export CONFIG_DIR=$JOB_DIR/config
 


### PR DESCRIPTION
`nats_stream_forwarder` failed to start due to an error:

```
/var/vcap/jobs/nats/bin/nats_stream_forwarder_ctl: line 27: exec: bundle: not found
```
