### PR TITLE
Enable openstack blob storage [rebased from https://github.com/cloudfoundry/cf-release/pull/191]

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -195,6 +195,9 @@ properties:
   description: "OpenStack authorization link"
  ccng.resource_pool.fog_connection.openstack_tenant:
   description: "OpenStack tenant name"
+ ccng.resource_pool.fog_connection.openstack_temp_url_key:
+  description: "OpenStack temporary URL key used to create temporary URLs to blobs"
+  default: cc-temp-url-key
  ccng.resource_pool.cdn.uri:
   description: "URI for a CDN to used for resource pool downloads"
   default: ""

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -131,6 +131,7 @@ resource_pool:
     openstack_api_key: <%= p("ccng.resource_pool.fog_connection.openstack_api_key") %>
     openstack_auth_url: <%= p("ccng.resource_pool.fog_connection.openstack_auth_url") %>
     openstack_tenant: <%= p("ccng.resource_pool.fog_connection.openstack_tenant") %>
+    openstack_temp_url_key: <%= p("ccng.resource_pool.fog_connection.openstack_temp_url_key") %>
     <% else %>
     aws_access_key_id: <%= p("ccng.resource_pool.fog_connection.aws_access_key_id") %>
     aws_secret_access_key: <%= p("ccng.resource_pool.fog_connection.aws_secret_access_key") %>
@@ -155,6 +156,7 @@ packages:
     openstack_api_key: <%= p("ccng.packages.fog_connection.openstack_api_key") %>
     openstack_auth_url: <%= p("ccng.packages.fog_connection.openstack_auth_url") %>
     openstack_tenant: <%= p("ccng.packages.fog_connection.openstack_tenant") %>
+    openstack_temp_url_key: <%= p("ccng.packages.fog_connection.openstack_temp_url_key") %>
     <% else %>
     aws_access_key_id: <%= p("ccng.packages.fog_connection.aws_access_key_id") %>
     aws_secret_access_key: <%= p("ccng.packages.fog_connection.aws_secret_access_key") %>
@@ -179,6 +181,7 @@ droplets:
     openstack_api_key: <%= p("ccng.droplets.fog_connection.openstack_api_key") %>
     openstack_auth_url: <%= p("ccng.droplets.fog_connection.openstack_auth_url") %>
     openstack_tenant: <%= p("ccng.droplets.fog_connection.openstack_tenant") %>
+    openstack_temp_url_key: <%= p("ccng.droplets.fog_connection.openstack_temp_url_key") %>
     <% else %>
     aws_access_key_id: <%= p("ccng.droplets.fog_connection.aws_access_key_id") %>
     aws_secret_access_key: <%= p("ccng.droplets.fog_connection.aws_secret_access_key") %>
@@ -203,6 +206,7 @@ buildpacks:
     openstack_api_key: <%= p("ccng.buildpacks.fog_connection.openstack_api_key") %>
     openstack_auth_url: <%= p("ccng.buildpacks.fog_connection.openstack_auth_url") %>
     openstack_tenant: <%= p("ccng.buildpacks.fog_connection.openstack_tenant") %>
+    openstack_temp_url_key: <%= p("ccng.buildpacks.fog_connection.openstack_temp_url_key") %>
     <% else %>
     aws_access_key_id: <%= p("ccng.buildpacks.fog_connection.aws_access_key_id") %>
     aws_secret_access_key: <%= p("ccng.buildpacks.fog_connection.aws_secret_access_key") %>


### PR DESCRIPTION
This is a rebased version of @TieWei's https://github.com/cloudfoundry/cf-release/pull/191 with jobs/cloud_controller_ng/spec fixed. Commits are still attributed to @TieWei
