### PR TITLE
fix PATH in nats_stream_forwarder_ctl

### DIFF
--- a/jobs/nats/templates/nats_stream_forwarder_ctl.erb
+++ b/jobs/nats/templates/nats_stream_forwarder_ctl.erb
@@ -17,7 +17,7 @@ case $1 in
     mkdir -p $RUN_DIR
     mkdir -p $LOG_DIR
 
-    PATH=/var/vcap/bosh/bin:$PATH
+    PATH=/var/vcap/packages/ruby/bin:$PATH
 
     <% if_p("syslog_aggregator") do %>
         /var/vcap/packages/syslog_aggregator/setup_syslog_forwarder.sh $CONFIG_DIR


### PR DESCRIPTION
After updated my devbox to v147, there is err showed in "sys/log/nats_stream_forwarder.stderr.log" said: "/var/vcap/jobs/nats/bin/nats_stream_forwarder_ctl: line 25: exec: bundle: not found"

We need add /var/vcap/packages/ruby/bin when export PATH, 

And Dr Nic said:
There should never be a reason for the following two paths to both be in $PATH
- /var/vcap/bosh/bin
- /var/vcap/packages/ANYTHING/bin

please ref the discuss in:
https://groups.google.com/a/cloudfoundry.org/forum/#!topic/vcap-dev/jB-YlxlzEFI
