### PR TITLE
Update spec

### DIFF
--- a/jobs/nats/spec
+++ b/jobs/nats/spec
@@ -10,6 +10,7 @@ packages:
   - common
   - gnatsd
   - nats
+  - ruby
   - syslog_aggregator
 properties:
   networks.apps:


### PR DESCRIPTION
re-added ruby package, otherwise ruby NATS will not work.
