### PR TITLE
default ha_proxy.ssl_pem "" is invalid

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -9,7 +9,6 @@ templates:
   cert.pem.erb:              config/cert.pem
 properties:
   ha_proxy.ssl_pem:
-    default:
     description: "SSL certificate (PEM file)"
   ha_proxy.timeout:
     default: 300
@@ -21,8 +20,6 @@ properties:
     default:
     description:
   router.servers.z1:
-    default:
-    description:
+    description: Array of router IPs/hostnames
   router.servers.z2:
-    default:
-    description:
+    description: Array of router IPs/hostnames


### PR DESCRIPTION
In haproxy job, there is an `ha_proxy.ssl_pem` property with a default value of "". Unforuntately, this is an invalid property value and the haproxy job will no start.

```
==> /var/vcap/sys/log/haproxy/startup_stderr.log <==
[ALERT] 333/173110 (1764) : parsing [/var/vcap/jobs/haproxy/config/haproxy.config:26] : 'bind :443' : unable to load SSL private key from PEM file '/var/vcap/jobs/haproxy/config/cert.pem'.
[ALERT] 333/173110 (1764) : parsing [/var/vcap/jobs/haproxy/config/haproxy.config:34] : 'bind :4443' : unable to load SSL private key from PEM file '/var/vcap/jobs/haproxy/config/cert.pem'.
[ALERT] 333/173110 (1764) : Error(s) found in configuration file : /var/vcap/jobs/haproxy/config/haproxy.config
[ALERT] 333/173110 (1764) : Proxy 'https-in': no SSL certificate specified for bind ':443' at [/var/vcap/jobs/haproxy/config/haproxy.config:26] (use 'crt').
[ALERT] 333/173110 (1764) : Proxy 'ssl-in': no SSL certificate specified for bind ':4443' at [/var/vcap/jobs/haproxy/config/haproxy.config:34] (use 'crt').
[ALERT] 333/173110 (1764) : Fatal errors found in configuration.
Sat Nov 30 17:31:10 UTC 2013: Errored starting HAProxy

==> /var/vcap/sys/log/haproxy/startup_stdout.log <==
Sat Nov 30 17:31:10 UTC 2013: Starting HAProxy
Sat Nov 30 17:31:10 UTC 2013: Errored starting HAProxy
```
