### PR TITLE
Fix wrong varz credentials for uaa & login jobs

### DIFF
--- a/jobs/login/monit
+++ b/jobs/login/monit
@@ -9,3 +9,4 @@ check process login_cf-registrar
   start program "/var/vcap/jobs/login/bin/login_cf-registrar_ctl start"
   stop program "/var/vcap/jobs/login/bin/login_cf-registrar_ctl stop"
   group vcap
+  depends on login

--- a/jobs/uaa/monit
+++ b/jobs/uaa/monit
@@ -9,3 +9,4 @@ check process uaa_cf-registrar
   start program "/var/vcap/jobs/uaa/bin/uaa_cf-registrar_ctl start"
   stop program "/var/vcap/jobs/uaa/bin/uaa_cf-registrar_ctl stop"
   group vcap
+  depends on uaa


### PR DESCRIPTION
The cf-registerar should wait for the varz.yml file to be properly populated.
Because this file [gets changed on uaa/login startup](https://github.com/cloudfoundry/cf-release/blob/master/jobs/uaa/templates/uaa_ctl.erb#L68-L73) we should wait on that.
