### PR TITLE
update tomcat's defaults to trust 172.16/12 networks as internal proxies

### DIFF
--- a/jobs/login/templates/tomcat.server.xml.erb
+++ b/jobs/login/templates/tomcat.server.xml.erb
@@ -14,7 +14,9 @@
       <Host name="localhost" appBase="webapps" unpackWARs="true" autoDeploy="false">
         <Valve className="org.apache.catalina.valves.RemoteIpValve"
                remoteIpHeader="x-forwarded-for"
-               protocolHeader="x-forwarded-proto" />
+               protocolHeader="x-forwarded-proto"
+               internalProxies="10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}" 
+        />
 
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="/var/vcap/sys/log/login"
                prefix="localhost_access." suffix=".log" rotatable="true" pattern="%h %l %u %t &quot;%r&quot; %s %b"/>

--- a/jobs/pivotal_login/templates/tomcat.server.xml.erb
+++ b/jobs/pivotal_login/templates/tomcat.server.xml.erb
@@ -14,7 +14,9 @@
       <Host name="localhost" appBase="webapps" unpackWARs="true" autoDeploy="false">
         <Valve className="org.apache.catalina.valves.RemoteIpValve"
                remoteIpHeader="x-forwarded-for"
-               protocolHeader="x-forwarded-proto" />
+               protocolHeader="x-forwarded-proto"
+               internalProxies="10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}" 
+        />
 
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="/var/vcap/sys/log/pivotal_login"
                prefix="localhost_access." suffix=".log" rotatable="true" pattern="%h %l %u %t &quot;%r&quot; %s %b"/>

--- a/jobs/saml_login/templates/tomcat.server.xml.erb
+++ b/jobs/saml_login/templates/tomcat.server.xml.erb
@@ -13,8 +13,10 @@
 
       <Host name="localhost" appBase="webapps" unpackWARs="true" autoDeploy="false">
         <Valve className="org.apache.catalina.valves.RemoteIpValve"
-               remoteIpHeader="x-cluster-client-ip"
-               protocolHeader="x-forwarded-proto" />
+               remoteIpHeader="x-forwarded-for"
+               protocolHeader="x-forwarded-proto"
+               internalProxies="10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}" 
+        />
 
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="/var/vcap/sys/log/login"
                prefix="localhost_access." suffix=".log" rotatable="true" pattern="%h %l %u %t &quot;%r&quot; %s %b"/>

--- a/jobs/uaa/templates/tomcat.server.xml.erb
+++ b/jobs/uaa/templates/tomcat.server.xml.erb
@@ -14,7 +14,9 @@
       <Host name="localhost" appBase="webapps" unpackWARs="true" autoDeploy="false">
         <Valve className="org.apache.catalina.valves.RemoteIpValve"
                remoteIpHeader="x-forwarded-for"
-               protocolHeader="x-forwarded-proto" />
+               protocolHeader="x-forwarded-proto"
+               internalProxies="10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}" 
+        />
 
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="/var/vcap/sys/log/uaa"
                prefix="localhost_access." suffix=".log" rotatable="true" pattern="%h %l %u %t &quot;%r&quot; %s %b"/>


### PR DESCRIPTION
Fairly common use case is to deploy CF in a 172.16/12 network. Tomcat (used by identity) does not recognize this subnet by default, but it can be configured. The following commit, simply adds 172.16/12 to tomcat's default.

Tomcat by default supports, 10/8, 192.168/16, 169.254/16 and 127/8. We've added the regex 172.1[6-9]{1}.\d{1,3}.\d{1,3}|172.2[0-9]{1}.\d{1,3}.\d{1,3}|172.3[0-1]{1}.\d{1,3}.\d{1,3} to support the 172.16/12 range see - http://tomcat.apache.org/tomcat-7.0-doc/api/org/apache/catalina/valves/RemoteIpValve.html
