### PR TITLE
Explicit release name for each job

### DIFF
--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -3,6 +3,9 @@ networks: (( merge ))
 meta:
   environment: ~
 
+  release:
+    name: cf
+
   networks:
     z1:
       apps: cf1
@@ -21,6 +24,7 @@ meta:
 
 jobs:
   - name: ha_proxy_z1
+    release: (( meta.release.name ))
     template: haproxy
     instances: 0
     resource_pool: router_z1
@@ -37,6 +41,7 @@ jobs:
           z2: (( jobs.router_z2.networks.cf2.static_ips ))
 
   - name: nats_z1
+    release: (( meta.release.name ))
     template:
       - nats
       - nats_stream_forwarder
@@ -49,6 +54,7 @@ jobs:
       networks: (( meta.networks.z1 ))
 
   - name: nats_z2
+    release: (( meta.release.name ))
     template:
       - nats
       - nats_stream_forwarder
@@ -61,6 +67,7 @@ jobs:
       networks: (( meta.networks.z2 ))
 
   - name: logs_z1
+    release: (( meta.release.name ))
     template: syslog_aggregator
     instances: 0
     resource_pool: medium_z1
@@ -72,6 +79,7 @@ jobs:
       networks: (( meta.networks.z1 ))
 
   - name: logs_z2
+    release: (( meta.release.name ))
     template: syslog_aggregator
     instances: 0
     resource_pool: medium_z2
@@ -83,6 +91,7 @@ jobs:
       networks: (( meta.networks.z2 ))
 
   - name: stats_z1
+    release: (( meta.release.name ))
     template: collector
     instances: 1
     resource_pool: small_z1
@@ -92,6 +101,7 @@ jobs:
       networks: (( meta.networks.z1 ))
 
   - name: nfs_z1
+    release: (( meta.release.name ))
     template: debian_nfs_server
     instances: 0
     resource_pool: medium_z1
@@ -101,6 +111,7 @@ jobs:
         static_ips: ~
 
   - name: postgres_z1
+    release: (( meta.release.name ))
     template: postgres
     instances: 0
     resource_pool: large_z1
@@ -112,6 +123,7 @@ jobs:
       db: databases
 
   - name: uaa_z1
+    release: (( meta.release.name ))
     template: uaa
     instances: 1
     resource_pool: large_z1
@@ -121,6 +133,7 @@ jobs:
       networks: (( meta.networks.z1 ))
 
   - name: uaa_z2
+    release: (( meta.release.name ))
     template: uaa
     instances: 1
     resource_pool: large_z2
@@ -130,6 +143,7 @@ jobs:
       networks: (( meta.networks.z2 ))
 
   - name: login_z1
+    release: (( meta.release.name ))
     template: (( merge || "pivotal_login" ))
     instances: 1
     resource_pool: medium_z1
@@ -139,6 +153,7 @@ jobs:
       networks: (( meta.networks.z1 ))
 
   - name: api_z1
+    release: (( meta.release.name ))
     template: cloud_controller_ng
     instances: 1
     resource_pool: large_z1
@@ -152,6 +167,7 @@ jobs:
         host: (( meta.loggregator_endpoint.z1.host ))
 
   - name: api_z2
+    release: (( meta.release.name ))
     template: cloud_controller_ng
     instances: 1
     resource_pool: large_z2
@@ -165,6 +181,7 @@ jobs:
         host: (( meta.loggregator_endpoint.z2.host ))
 
   - name: hm_z1
+    release: (( meta.release.name ))
     template: health_manager_next
     instances: 0
     resource_pool: medium_z1
@@ -209,6 +226,7 @@ jobs:
       leader_ip: (( jobs.etcd_leader_z1.networks.cf1.static_ips.[0] ))
 
   - name: hm9000_z1
+    release: (( meta.release.name ))
     template: hm9000
     instances: 1
     persistent_disk: 1024
@@ -220,6 +238,7 @@ jobs:
       etcd_ips: (( jobs.etcd_leader_z1.networks.cf1.static_ips jobs.etcd_z1.networks.cf1.static_ips jobs.etcd_z2.networks.cf2.static_ips ))
 
   - name: runner_z1
+    release: (( meta.release.name ))
     template: (( merge || ["dea_next", "dea_logging_agent"] ))
     instances: 1
     update:
@@ -234,6 +253,7 @@ jobs:
         host: (( meta.loggregator_endpoint.z1.host ))
 
   - name: runner_z2
+    release: (( meta.release.name ))
     template: (( merge || ["dea_next", "dea_logging_agent"] ))
     instances: 1
     update:
@@ -248,6 +268,7 @@ jobs:
         host: (( meta.loggregator_endpoint.z2.host ))
 
   - name: taskmaster_z1
+    release: (( meta.release.name ))
     template: narc
     instances: 1
     resource_pool: runner_z1
@@ -257,6 +278,7 @@ jobs:
       networks: (( meta.networks.z1 ))
 
   - name: taskmaster_z2
+    release: (( meta.release.name ))
     template: narc
     instances: 1
     resource_pool: runner_z2
@@ -266,6 +288,7 @@ jobs:
       networks: (( meta.networks.z2 ))
 
   - name: loggregator_z1
+    release: (( meta.release.name ))
     template: loggregator
     instances: 2
     resource_pool: large_z1
@@ -276,6 +299,7 @@ jobs:
       networks: (( meta.networks.z1 ))
 
   - name: loggregator_z2
+    release: (( meta.release.name ))
     template: loggregator
     instances: 2
     resource_pool: large_z2
@@ -286,6 +310,7 @@ jobs:
       networks: (( meta.networks.z2 ))
 
   - name: loggregator_trafficcontroller_z1
+    release: (( meta.release.name ))
     template: loggregator_trafficcontroller
     instances: 1
     resource_pool: small_z1
@@ -298,6 +323,7 @@ jobs:
         zone: z1
 
   - name: loggregator_trafficcontroller_z2
+    release: (( meta.release.name ))
     template: loggregator_trafficcontroller
     instances: 1
     resource_pool: small_z2
@@ -310,6 +336,7 @@ jobs:
         zone: z2
 
   - name: router_z1
+    release: (( meta.release.name ))
     template: gorouter
     instances: 1
     resource_pool: router_z1
@@ -322,6 +349,7 @@ jobs:
         host: (( meta.loggregator_endpoint.z1.host ))
 
   - name: router_z2
+    release: (( meta.release.name ))
     template: gorouter
     instances: 1
     resource_pool: router_z2


### PR DESCRIPTION
This means that when adding an additional release to a resulting manifest, the person does not need to manually add `release: cf` to each and every job.

There is no affect to people who do not add additional releases to their CF deployment file.
