### PR TITLE
Single fog connection defaults in erb

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -176,9 +176,6 @@ properties:
   ccng.resource_pool.fog_connection.provider:
     description: "Local for shared resources on NFS. AWS to place them in S3. OpenStack to place them in swift."
     default: "Local"
-  ccng.resource_pool.fog_connection.local_root:
-    description: "The directory used as the root for the Local fog provider"
-    default: "/var/vcap/nfs/shared"
   ccng.resource_pool.cdn.uri:
     description: "URI for a CDN to used for resource pool downloads"
     default: ""
@@ -197,9 +194,6 @@ properties:
   ccng.packages.fog_connection.provider:
     description: "Local for shared resources on NFS. AWS to place them in S3. OpenStack to place them in swift."
     default: "Local"
-  ccng.packages.fog_connection.local_root:
-    description: "The directory used as the root for the Local fog provider"
-    default: "/var/vcap/nfs/shared"
   ccng.packages.cdn.uri:
     description: "URI for a CDN to used for app package downloads"
     default: ""
@@ -218,9 +212,6 @@ properties:
   ccng.droplets.fog_connection.provider:
     description: "Local for droplets on NFS. AWS to place them in S3. OpenStack to place them in swift."
     default: "Local"
-  ccng.droplets.fog_connection.local_root:
-    description: "The directory used as the root for the Local fog provider"
-    default: "/var/vcap/nfs/shared"
   ccng.droplets.cdn.uri:
     description: "URI for a CDN to used for droplet downloads"
     default: ""
@@ -239,9 +230,6 @@ properties:
   ccng.buildpacks.fog_connection.provider:
     description: "Local for buildpacks on NFS. AWS to place them in S3. OpenStack to place them in swift."
     default: "Local"
-  ccng.buildpacks.fog_connection.local_root:
-    description: "The directory used as the root for the Local fog provider"
-    default: "/var/vcap/nfs/shared"
   ccng.buildpacks.cdn.uri:
     description: "URI for a CDN to used for buildpack downloads"
     default: ""

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -127,7 +127,10 @@ resource_pool:
     key_pair_id: <%= p("ccng.resource_pool.cdn.key_pair_id") %>
     private_key: <%= p("ccng.resource_pool.cdn.private_key").inspect %>
   <% end %>
-  fog_connection: <%= p("ccng.resource_pool.fog_connection").to_json %>
+  fog_connection: <%= fc = properties.ccng.resource_pool.fog_connection
+    fc.local_root ||= "/var/vcap/nfs/shared" if fc.provider.downcase == "local"
+    fc.marshal_dump.to_json
+  %>
 
 packages:
   app_package_directory_key: <%= p("ccng.packages.app_package_directory_key") %>
@@ -137,7 +140,11 @@ packages:
     key_pair_id: <%= p("ccng.packages.cdn.key_pair_id") %>
     private_key: <%= p("ccng.packages.cdn.private_key").inspect %>
   <% end %>
-  fog_connection: <%= p("ccng.packages.fog_connection").to_json %>
+  fog_connection: <%= fc = properties.ccng.packages.fog_connection
+    fc.local_root ||= "/var/vcap/nfs/shared" if fc.provider.downcase == "local"
+    fc.marshal_dump.to_json
+  %>
+
 
 droplets:
   droplet_directory_key: <%= p("ccng.droplets.droplet_directory_key") %>
@@ -147,7 +154,11 @@ droplets:
     key_pair_id: <%= p("ccng.droplets.cdn.key_pair_id") %>
     private_key: <%= p("ccng.droplets.cdn.private_key").inspect %>
   <% end %>
-  fog_connection: <%= p("ccng.droplets.fog_connection").to_json %>
+  fog_connection: <%= fc = properties.ccng.droplets.fog_connection
+    fc.local_root ||= "/var/vcap/nfs/shared" if fc.provider.downcase == "local"
+    fc.marshal_dump.to_json
+  %>
+
 
 buildpacks:
   buildpack_directory_key: <%= p("ccng.buildpacks.buildpack_directory_key") %>
@@ -157,7 +168,11 @@ buildpacks:
     key_pair_id: <%= p("ccng.buildpacks.cdn.key_pair_id") %>
     private_key: <%= p("ccng.buildpacks.cdn.private_key").inspect %>
   <% end %>
-  fog_connection: <%= p("ccng.buildpacks.fog_connection").to_json %>
+  fog_connection: <%= fc = properties.ccng.buildpacks.fog_connection
+    fc.local_root ||= "/var/vcap/nfs/shared" if fc.provider.downcase == "local"
+    fc.marshal_dump.to_json
+  %>
+
 
 db_encryption_key: <%= p("ccng.db_encryption_key") %>
 

--- a/jobs/cloud_controller_ng/templates/nginx.conf.erb
+++ b/jobs/cloud_controller_ng/templates/nginx.conf.erb
@@ -56,7 +56,7 @@ http {
     # nginx will serve the file root || location || foo.txt
     location /droplets/ {
       internal;
-      root   <%= p("ccng.droplets.fog_connection.local_root") %>;
+      root   <%= p("ccng.droplets.fog_connection.local_root", "/var/vcap/nfs/shared") %>;
     }
 
 <% if p("ccng.packages.fog_connection.provider").downcase == "local" %>
@@ -64,7 +64,7 @@ http {
     # nginx will serve the file root || location || foo.txt
     location <%= "/#{p('ccng.packages.app_package_directory_key')}/" %> {
       internal;
-      root   <%= p("ccng.packages.fog_connection.local_root") %>;
+      root   <%= p("ccng.packages.fog_connection.local_root", "/var/vcap/nfs/shared") %>;
     }
 <% end %>
 
@@ -73,7 +73,7 @@ http {
     # nginx will serve the file root || location || foo.txt
     location <%= "/#{p('ccng.droplets.droplet_directory_key')}/" %> {
       internal;
-      root   <%= p("ccng.droplets.fog_connection.local_root") %>;
+      root   <%= p("ccng.droplets.fog_connection.local_root", "/var/vcap/nfs/shared") %>;
     }
 <% end %>
 


### PR DESCRIPTION
As discussed in https://github.com/cloudfoundry/cf-release/pull/232 single `fog_connection` with the default for `local_root` in the templates.
If this PR gets merged the following PRs can be closed:
- [Use single fog_connection hash for ccng (second attempt)](https://github.com/cloudfoundry/cf-release/pull/236)
- [Add ceph as blobstore via s3 api](https://github.com/cloudfoundry/cf-release/pull/230)
- [Add AWS S3 region configuration option in ccng template](https://github.com/cloudfoundry/cf-release/pull/225)
