### PR TITLE
Enable deployment to specified 'Availability Zone' and attach 'zone' att...

### DIFF
--- a/jobs/dea_next/spec
+++ b/jobs/dea_next/spec
@@ -71,6 +71,9 @@ properties:
   dea_next.evacuation_delay:
     description: "Duration to wait before shutting down, in seconds."
     default: 115
+  dea_next.zone:
+    description: "The Availability Zone"
+    default: "default"
   disk_quota_enabled:
     description: "disk quota must be disabled to use warden-inside-warden with the warden cpi"
     default: true

--- a/jobs/dea_next/templates/dea.yml.erb
+++ b/jobs/dea_next/templates/dea.yml.erb
@@ -64,3 +64,5 @@ staging:
     BUILDPACK_CACHE: "/var/vcap/packages/buildpack_cache"
 
 stacks: <%= p("dea_next.stacks") %>
+placement_properties:
+  zone: <%= p("dea_next.zone") %>


### PR DESCRIPTION
Cloud Controller currently does not have a complete high availability support for applications even there are multiple instances. With our previous PRs - https://github.com/cloudfoundry/cloud_controller_ng/pull/122 and https://github.com/cloudfoundry/dea_ng/pull/78 we have improved HA for applications with new attribute of "availability zone" and corresponding algorism in cloud controller. However it was still not supported to set "availability zone" attribute through CF deployment.
This commit can add "availability zone" attribute to DEA through CF deployment by taking account of "availability zone" defined by IaaS (for example AWS and Open Stack). If "availability zone" is not defined by IaaS, it will make no difference from the old behavior. The implementation can be a simple 1-1 map of "availability zone" from IaaS to PaaS (DEA in CF), or n-1 map with different zone names if required.
We achieve this by changing job template and specification file of CF release. CF user can refine the deployment file to enable "availability zone" attribute to be attached through the deployment process. Following is a sample snippet of deployment manifest file:

<pre>
resource_pools:
...
- name: dea_pool_1
  network: default
  size: 2
  stemcell:
    name: bosh-openstack-kvm-ubuntu
    version: 1504
  cloud_properties:
    instance_type: bluemix.small
    <b>availability_zone: az1</b>
- name: dea_pool_2
  network: default
  size: 2
  stemcell:
    name: bosh-openstack-kvm-ubuntu
    version: 1504
  cloud_properties:
    instance_type: bluemix.small
    <b>availability_zone: az2</b>
...
jobs:
...
- name: dea_job_1
  release: cf-ha-150
  template: dea_next
  instances: 2
  resource_pool: dea_pool_1
  update:
    max_in_flight: 8
  networks:
  - name: default
  properties:
    dea_next:
      <b>zone: az1</b>
      stacks:
      - lucid64
- name: dea_job_2
  release: cf-ha-150
  template: dea_next
  instances: 2
  resource_pool: dea_pool_2
  update:
    max_in_flight: 8
  networks:
  - name: default
  properties:
    dea_next:
      <b>zone: az2</b>
      stacks:
      - lucid64
...
</pre>

The whole sample can be found with following link: <br>
https://github.com/liurui-1/sample_deployment_manifest_add_zone/blob/master/deployment-sample.yml <br>
IaaS including AWS and Open Stack can be supported with this PR because they have built-in support of "availability zone". 
