### PR TITLE
Create a oauth.approvals scope for managing approvals

### DIFF
--- a/jobs/uaa/templates/uaa.yml.erb
+++ b/jobs/uaa/templates/uaa.yml.erb
@@ -83,7 +83,7 @@ oauth:
       secret: "<%= properties.uaa.login.client_secret %>"
       authorized-grant-types: authorization_code,client_credentials,refresh_token
       authorities: oauth.login
-      scope: openid
+      scope: openid,oauth.approvals
       redirect-uri: https://login.<%= properties.domain %>
 <% end %>
 <% if properties.uaa.scim %>

--- a/templates/cf-aws-template.yml.erb
+++ b/templates/cf-aws-template.yml.erb
@@ -382,11 +382,12 @@ properties:
     clients:
       login:
         id: login
-        scope: openid
+        scope: openid,oauth.approvals
         authorities: oauth.login
         secret: HZtd2FyZS5jb20iL
         authorized-grant-types: authorization_code,client_credentials,refresh_token
         redirect-uri: http://login.<%= find("properties.domain") %>
+        override: true
       portal:
         id: portal
         scope: scim.write,scim.read,openid,cloud_controller.read,cloud_controller.write,console.admin,console.support

--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -102,7 +102,7 @@ properties:
     clients:
       login:
         override: true
-        scope: openid
+        scope: openid,oauth.approvals
         authorities: oauth.login
         secret: (( merge ))
         authorized-grant-types: authorization_code,client_credentials,refresh_token


### PR DESCRIPTION
Based on the issue
https://github.com/cloudfoundry/uaa/issues/66

The following fixes have been implemented in UAA and login server
https://github.com/cloudfoundry/uaa/pull/67
https://github.com/cloudfoundry/login-server/pull/41

Accessing the /approvals URL requires a specific scope, oauth.approvals. By default the login client should have this scope preconfigured. This change may affect existing installations that wish to allow the login client to manage approvals.

Existing login clients can be amended with
uaac client update login --scope "openid, uaa.user, oauth.approvals"

@rmorgan should approve
