### PR TITLE
Do not treat warnings as errors for GCC on Ubuntu 12.04

### DIFF
--- a/packages/nginx/packaging
+++ b/packages/nginx/packaging
@@ -79,7 +79,8 @@ pushd nginx-0.8.54
     --add-module=../headers-more-v0.15rc1 \
     --add-module=../nginx_upload_module-2.2.0 \
     --add-module=../simpl-ngx_devel_kit-bc97eea \
-    --add-module=../chaoslawful-lua-nginx-module-4d92cb1
+    --add-module=../chaoslawful-lua-nginx-module-4d92cb1 \
+    --with-cc-opt='-Wno-error'
 
   make
   make install


### PR DESCRIPTION
@jambay 

I confirmed that packaging the nginx package fails on Ubuntu 12.04.
This commit fix the problem and make cf-release deployable on Ubuntu 12.04 stemcells.
