### PR TITLE
Fix Stderr getting duplicated in stdout

### DIFF
--- a/jobs/cloud_controller_ng/templates/cloud_controller_jobs_ctl.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_jobs_ctl.erb
@@ -50,8 +50,8 @@ case $1 in
     cd $CC_PACKAGE_DIR/cloud_controller_ng
     export QUEUES=cc-<%= name %>-<%= spec.index.to_i %>,$GENERIC_QUEUE
     exec chpst -u vcap:vcap bundle exec rake jobs:work \<% if properties.syslog_aggregator && properties.syslog_aggregator.address %>
-      > >(tee -a >(logger -p user.info -t vcap.jobs_work.stdout) $LOG_DIR/jobs_work.stdout.log) \
-      2> >(tee -a >(logger -p user.error -t vcap.jobs_work.stderr) $LOG_DIR/jobs_work.stderr.log)<% else %>
+      > >(tee >(logger -p user.info -t vcap.jobs_work.stdout) >>$LOG_DIR/jobs_work.stdout.log) \
+      2> >(tee >(logger -p user.error -t vcap.jobs_work.stderr) >>$LOG_DIR/jobs_work.stderr.log)<% else %>
       >>$LOG_DIR/jobs_work.stdout.log \
       2>>$LOG_DIR/jobs_work.stderr.log
       <% end %>

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng_ctl.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng_ctl.erb
@@ -126,8 +126,8 @@ case $1 in
     <% if spec.index.to_i == 0 %>
       cd $CC_PACKAGE_DIR/cloud_controller_ng
       chpst -u vcap:vcap bundle exec rake db:migrate \<% if properties.syslog_aggregator && properties.syslog_aggregator.address %>
-        > >(tee -a >(logger -p user.info -t vcap.db_migrate.stdout) $LOG_DIR/db_migrate.stdout.log) \
-        2> >(tee -a >(logger -p user.error -t vcap.db_migrate.stderr) $LOG_DIR/db_migrate.stderr.log)<% else %>
+        > >(tee >(logger -p user.info -t vcap.db_migrate.stdout) >>$LOG_DIR/db_migrate.stdout.log) \
+        2> >(tee >(logger -p user.error -t vcap.db_migrate.stderr) >>$LOG_DIR/db_migrate.stderr.log)<% else %>
         >>$LOG_DIR/db_migrate.stdout.log \
         2>>$LOG_DIR/db_migrate.stderr.log
         <% end %>
@@ -143,8 +143,8 @@ case $1 in
       exec chpst -u vcap:vcap $CC_PACKAGE_DIR/cloud_controller_ng/bin/cloud_controller -m \<% else %>
       exec chpst -u vcap:vcap $CC_PACKAGE_DIR/cloud_controller_ng/bin/cloud_controller \<% end %>
         -c $CLOUD_CONTROLLER_NG_CONFIG \<% if properties.syslog_aggregator && properties.syslog_aggregator.address %>
-        > >(tee -a >(logger -p user.info -t vcap.cloud_controller_ng.stdout) $LOG_DIR/cloud_controller_ng.stdout.log) \
-        2> >(tee -a >(logger -p user.error -t vcap.cloud_controller_ng.stderr) $LOG_DIR/cloud_controller_ng.stderr.log)<% else %>
+        > >(tee -a >(logger -p user.info -t vcap.cloud_controller_ng.stdout) >>$LOG_DIR/cloud_controller_ng.stdout.log) \
+        2> >(tee -a >(logger -p user.error -t vcap.cloud_controller_ng.stderr) >>$LOG_DIR/cloud_controller_ng.stderr.log)<% else %>
         >>$LOG_DIR/cloud_controller_ng.stdout.log \
         2>>$LOG_DIR/cloud_controller_ng.stderr.log
         <% end %>

--- a/jobs/cloud_controller_ng/templates/nginx_ctl.erb
+++ b/jobs/cloud_controller_ng/templates/nginx_ctl.erb
@@ -36,8 +36,8 @@ case $1 in
 	<% if properties.syslog_aggregator && properties.syslog_aggregator.address %>
     exec /var/vcap/packages/nginx/sbin/nginx \
          -c $CC_JOB_DIR/config/nginx.conf \
-	      > >(tee -a >(logger -p user.info -t vcap.nginx.stdout) $LOG_DIR/nginx.stdout.log) \
-	      2> >(tee -a >(logger -p user.error -t vcap.nginx.stderr) $LOG_DIR/nginx.stderr.log)
+	      > >(tee >(logger -p user.info -t vcap.nginx.stdout) >>$LOG_DIR/nginx.stdout.log) \
+	      2> >(tee >(logger -p user.error -t vcap.nginx.stderr) >>$LOG_DIR/nginx.stderr.log)
 	<% else %>
     exec /var/vcap/packages/nginx/sbin/nginx \
          -c $CC_JOB_DIR/config/nginx.conf \


### PR DESCRIPTION
This fixes a minor issue with PR https://github.com/cloudfoundry/cf-release/pull/218

tee sends out put to the specified files in addition to stdout.  This was causing stderr output to get duplicated into stdout.

This fix nulls out the stdout generated from `tee`ing stderr.

Hope to get around to adding syslog support for other jobs soon.

Mike
