### PR TITLE
Newrelic check

### DIFF
--- a/jobs/cloud_controller_ng/templates/cloud_controller_clock_ctl.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_clock_ctl.erb
@@ -19,10 +19,14 @@ export LANG=en_US.UTF-8
 
 export GENERIC_QUEUE=cc-generic
 
+<% if p("ccng.newrelic", nil) %>
+export NEWRELIC_ENABLE=false
+<% else %>
 <% if_p("ccng.newrelic.license_key") do %>
-    export NRCONFIG=$CONFIG_DIR/newrelic.yml
-    export RACK_ENV=<%= properties.ccng.newrelic.environment_name %>_background # used by NewRelic
-    export NEW_RELIC_DISPATCHER=delayed_job
+export NRCONFIG=$CONFIG_DIR/newrelic.yml
+export RACK_ENV=<%= properties.ccng.newrelic.environment_name %>_background # used by NewRelic
+export NEW_RELIC_DISPATCHER=delayed_job
+<% end %>
 <% end %>
 
 source /var/vcap/packages/common/utils.sh

--- a/jobs/cloud_controller_ng/templates/cloud_controller_jobs_ctl.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_jobs_ctl.erb
@@ -19,10 +19,14 @@ export LANG=en_US.UTF-8
 
 export GENERIC_QUEUE=cc-generic
 
+<% if p("ccng.newrelic", nil) %>
+export NEWRELIC_ENABLE=FALSE
+<% else %>
 <% if_p("ccng.newrelic.license_key") do %>
 export NRCONFIG=$CONFIG_DIR/newrelic.yml
 export RACK_ENV=<%= properties.ccng.newrelic.environment_name %>_background # used by NewRelic
 export NEW_RELIC_DISPATCHER=delayed_job
+<% end %>
 <% end %>
 
 source /var/vcap/packages/common/utils.sh

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng_ctl.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng_ctl.erb
@@ -35,9 +35,13 @@ export C_INCLUDE_PATH=/var/vcap/packages/libpq/include:$C_INCLUDE_PATH
 export LIBRARY_PATH=/var/vcap/packages/libpq/lib:$LIBRARY_PATH
 export LANG=en_US.UTF-8
 
+<% if p("ccng.newrelic",nil) %>
+export NEWRELIC_ENABLE=false
+<% else %>
 <% if_p("ccng.newrelic.license_key") do %>
 export NRCONFIG=$CONFIG_DIR/newrelic.yml
 export RACK_ENV=<%= properties.ccng.newrelic.environment_name %> # used by NewRelic
+<% end %>
 <% end %>
 
 source /var/vcap/packages/common/utils.sh


### PR DESCRIPTION
Hello all,

I was trying out this new release, and was receiving the following error on the cloud controller:
*\* [NewRelic][12/24/13 03:34:10 +0000 b4bfdbc4-213a-4cbb-83d9-3a097c4c58ec (18981)] ERROR : Unable to read configuration file : Is a directory - /var/vcap/data/packages/cloud_controller_ng/32.1-dev.1/cloud_controller_ng
...
*\* [NewRelic][12/24/13 03:38:46 +0000 b4bfdbc4-213a-4cbb-83d9-3a097c4c58ec (20908)] INFO : To prevent agent startup add a NEWRELIC_ENABLE=false environment variable or modify the "development" section of your newrelic.yml.

In digging deeper, I realized that I don't have a "newrelic" section under the cloud controller properties. Consequently, the newrelic agent was starting without the NRCONFIG environment variable being pointed to the newrelic.yml file. If this is a feature that is "disabled by default", then this is probably an edge case to be handled.

In this pull request, if "ccng.newrelic" is not set in the properties, then another environment variable will be set: NEWRELIC_ENABLE=false. It seems to have cleared up this error, at least with the limited couple of runs I've performed.

(My apologies for multiple pull request attempts - was trying to get it right.)

Anyway, please let me know if this seems like a reasonable solution, or if I should approach this differently.

Thanks!
Jeremy
