### PR TITLE
Fix syslog_aggregator job failing due to wrong bin path

### DIFF
--- a/jobs/syslog_aggregator/templates/syslog_aggregator_ctl
+++ b/jobs/syslog_aggregator/templates/syslog_aggregator_ctl
@@ -27,8 +27,15 @@ case $1 in
     cp -a $BIN_DIR/reap_old_logs /etc/cron.hourly
     cp -a $BIN_DIR/symlink_logs /etc/cron.hourly
     cp -a $PACKAGE_DIR/send_error_mail /etc/cron.daily
+    
+    if [ -f  /usr/local/sbin/rsyslogd ]
+    then
+      RSYSLOGD=/usr/local/sbin/rsyslogd
+    else
+      RSYSLOGD=/usr/sbin/rsyslogd
+    fi    
 
-    exec /usr/sbin/rsyslogd -f $JOB_DIR/config/rsyslogd.conf -i $PIDFILE -c 4 -x \
+    exec $RSYSLOGD -f $JOB_DIR/config/rsyslogd.conf -i $PIDFILE -c 4 -x \
          >>$LOG_DIR/rsyslogd.stdout.log \
          2>>$LOG_DIR/rsyslogd.stderr.log
 


### PR DESCRIPTION
We found that the path of rsyslogd is different among different version of stemcell, so we can make it work better by replacing hard coded path.
