### PR TITLE
Fix default NFS mount in Cloud Controller template

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -168,7 +168,7 @@ properties:
     default: "Local"
   ccng.default_fog_connection.local_root:
     description: "Local root when fog provider is not overridden (should be an NFS mount if using more than one cloud controller)"
-    default: "/var/vcap/nfs/store"
+    default: "/var/vcap/nfs/shared"
 
   ccng.resource_pool.minimum_size:
     description: "Minimum size of a resource to add to the pool"


### PR DESCRIPTION
The BOSH Job for the Cloud Controller puts the default fog connection as
  provider: Local
  local_root: /var/vcap/nfs/store

Recent commits have caused this location to no longer be writeable by the Cloud Controller; with the new NFS share being located at /var/vcap/nfs/shared

To keep people from having to specify this in the manifest; it's best if we make the default spec correct.
