### PR TITLE
Make the default upload size larger for nginx.

### DIFF
--- a/jobs/cloud_controller_ng/templates/nginx.conf.erb
+++ b/jobs/cloud_controller_ng/templates/nginx.conf.erb
@@ -27,7 +27,7 @@ http {
 
   keepalive_timeout  75 20; #inherited from router
 
-  client_max_body_size 256M; #already enforced upstream/but doesn't hurt.
+  client_max_body_size 1024M; #already enforced upstream/but doesn't hurt.
 
   upstream cloud_controller {
     server unix:/var/vcap/sys/run/cloud_controller_ng/cloud_controller.sock;


### PR DESCRIPTION
Enterprise customers will require larger uploads to Cloud Controller than 256MB.  Also the comments here seem to indicate that this option is "enforced upstream" but manual testing does not confirm this.
