### PR TITLE
Allowing the saml login to be installed offline

### DIFF
--- a/packages/saml_login/pre_packaging
+++ b/packages/saml_login/pre_packaging
@@ -1,8 +1,4 @@
 set -e -x
 
-cd ${BUILD_DIR}
-echo `pwd`
-echo `ls -alh`
-
 cd ${BUILD_DIR}/vcap-common
 BUNDLE_WITHOUT=development:test bundle package --all


### PR DESCRIPTION
I came across this problem while trying to install the most recent version of cf-release with ops manager.
