### PR TITLE
Making CC router's max body size configurable. 

### DIFF
--- a/jobs/cloud_controller_ng/templates/nginx.conf.erb
+++ b/jobs/cloud_controller_ng/templates/nginx.conf.erb
@@ -27,7 +27,7 @@ http {
 
   keepalive_timeout  75 20; #inherited from router
 
-  client_max_body_size 256M; #already enforced upstream/but doesn't hurt.
+  client_max_body_size <%= p(["router.client_max_body_size", 256]) %>; #already enforced upstream/but doesn't hurt.
 
   upstream cloud_controller {
     server unix:/var/vcap/sys/run/cloud_controller_ng/cloud_controller.sock;


### PR DESCRIPTION
Droplets size more than 256 Mb was not supported. This gives user to deal with huge Apps/Droplet
