### PR TITLE
Fix saml_login to work with cf-registrar.

### DIFF
--- a/jobs/saml_login/spec
+++ b/jobs/saml_login/spec
@@ -91,6 +91,8 @@ properties:
     description: "IP address of Cloud Foundry NATS server"
   nats.port:
     description: "IP port of Cloud Foundry NATS server"
+  nats.machines:
+    description: "IP of each NATS cluster member."
   networks.apps:
     description:
   env.http_proxy:


### PR DESCRIPTION
The config key of 'mbus' was changed to 'message_bus_servers'
https://github.com/cloudfoundry/vcap-common/blob/86c1201162dc8b2938d7abac3c1f45978e852502/bin/cf-registrar#L32

@rmorgan  -- please review and confirm.  Thanks.
