### PR TITLE
LDAP authentication in SAML login server

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -568,3 +568,28 @@ buildpack_cache/java-buildpack/http:%2F%2Fdownload.pivotal.io.s3.amazonaws.com%2
   sha: !binary |-
     NjdhZWY5MjIwMDBkM2NhYTNmYmJhMThiN2I1ZmE4NDI2ZjIwZjJkNw==
   size: 4670
+saml_login/cloudfoundry-saml-login-server-1.3.0.war:
+  object_id: 274f71ff-40fb-4268-9bcb-2dc01ba55478
+  sha: !binary |-
+    OGEwMTk5ZDdkZjdjMmI0MDAyMDcwODQzY2NhMzcxODU0NjE1ZTYzMQ==
+  size: 23957368
+login/cloudfoundry-login-server-1.3.0.war:
+  object_id: 8bfb9e7c-51b7-42e8-885f-74ba4c03ecec
+  sha: !binary |-
+    NTY0YmI4NjJmNmU4NjIwNWI5MTI0MzBmNjVmNWRjMGFlNmFlMDllNQ==
+  size: 8466569
+pivotal_login/pivotal-login-server-1.3.0.war:
+  object_id: 57dd069c-1f2c-4a08-8082-d32935aa78c4
+  sha: !binary |-
+    ZDQyMjNkYzY0MDk3ZjY4MjY4ZDZiOWNjYzEyMDNjMjlkZTQ1MWNjZA==
+  size: 8479782
+maven/apache-maven-3.1.1-bin.tar.gz:
+  object_id: 6f015bd2-aefb-4996-a9d7-1ac8c3411ad6
+  sha: !binary |-
+    NjMwZWVhMjEwN2IwNzQyYWNiMzE1YjIxNDAwOWJhMDg2MDJkZGE1Zg==
+  size: 5494427
+uaa/cloudfoundry-identity-uaa-1.5.0.war:
+  object_id: b62ff53a-54b3-45cf-bda1-6292d525fb9c
+  sha: !binary |-
+    ZDNiMzI0YjVlMjhjZDg1MzA5MzU2OTllNzRjODVjN2E4NjliM2RiZQ==
+  size: 20778508

--- a/jobs/saml_login/spec
+++ b/jobs/saml_login/spec
@@ -15,6 +15,7 @@ templates:
   web.xml.erb: config/tomcat/web.xml
   syslog_forwarder.conf.erb: config/syslog_forwarder.conf
   uaa.crt.erb: config/uaa.crt
+  ldap.crt.erb: config/ldap.crt
 
 packages:
   - common
@@ -28,30 +29,46 @@ properties:
   description: "The SAML Login Server enables authentication to the UAA via SAML."
   domain:
     description: "The domain that the saml login server will listen at."
-  uaa.clients:
-    description: "List of UAA clients that contains the client for the login server."
-  uaa.clients.login:
-    description: "Login client configuration."
+  env.http_proxy:
+    description: "The http_proxy accross the VMs"
+  env.https_proxy:
+    description: "The https_proxy accross the VMs"
+  env.no_proxy:
+    description: "Set No_Proxy accross the VMs"
+  nats.address:
+    description: "IP address of NATS server"
+  nats.password:
+    description: "Password for NATS login"
+  nats.port:
+    description: "TCP port of NATS server"
+  nats.user:
+    description: "User name for NATS login"
+  nats.machines:
+    description: "IP of each NATS cluster member."
+  networks.apps:
+    description: "The App network name"
+  syslog_aggregator.address:
+    description: "IP address for syslog aggregator"
+  syslog_aggregator.port:
+    description: "Port of syslog aggregator"
   uaa.clients.login.secret:
-    description: "Secret of the login client."
-  uaa.login.client_secret:
-    description: "Secret of the login client."
-  uaa.require_https:
-    description: "Boolean value to configure whether the login server will require SSL."
-    default: false
+    description:
   uaa.dump_requests:
-    description: "Boolean value to configure whether the login server will log requests."
-    default: false
+    description:
+  uaa.login.client_secret:
+    description:
+  uaa.require_https:
+    description:
   saml_login.uaa_certificate:
     description: "Certificate to import if the UAA is using self-signed certificates"
-  saml_login.idp_metadata_url:
+  saml_login.idpMetadataURL:
     description: "URL location of the IDP Metadata."
   saml_login.idp_metadata_file:
     description: "Optional IDP Metadata file for the SAML login server."
   saml_login.port:
     description: "Port that the local SAML login server is listening on."
     default: 8080
-  saml_login.idp_entity_alias:
+  saml_login.idpEntityAlias:
     description: "An alias for the IDP."
   saml_login.protocol:
     description:
@@ -80,29 +97,41 @@ properties:
   saml_login.assertion_consumer_index:
     description:
     default: 1
-  saml_login.nameid_format:
+  saml_login.nameidFormat:
     description:
     default: "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
-  nats.user:
-    description: "Username for vcap registrar to connect to NATS"
-  nats.password:
-    description: "Password for vcap registrar to connect to NATS"
-  nats.address:
-    description: "IP address of Cloud Foundry NATS server"
-  nats.port:
-    description: "IP port of Cloud Foundry NATS server"
-  networks.apps:
-    description:
-  env.http_proxy:
-    description:
-  env.https_proxy:
-    description:
-  env.no_proxy:
-    description:
-  syslog_aggregator.address:
-    description:
-  syslog_aggregator.port:
-    description:
-  login.port:
-    description:
-    default: 8080
+  saml_login.spring_profiles:
+    description: "The spring bean profile to use for the spring configuration files. Only options at this time is ldap for additional profile. Default is empty. Setting this to ldap requires the uaa.login.addnew property to be set to true on the UAA."
+  saml_login.ldap.profile_type:
+    description: "The file to be used for configuring the LDAP authentication. options are simple-bind, search-and-bind and search-and-compare"
+  saml_login.ldap.url:
+    description: "The URL to the ldap server, must start with ldap:// or ldaps://"
+  saml_login.ldap.userDNPattern:
+    description: "Used with simple-bind only. A semi-colon separated lists of DN patterns to construct a DN direct from the user ID without performing a search."
+  saml_login.ldap.userDN:
+    description: "Used with search-and-bind and search-and-compare. A valid LDAP ID that has read permissions to perform a search of the LDAP tree for user information. "
+  saml_login.ldap.userPassword:
+    description: "Used with search-and-bind and search-and-compare. Password for the LDAP ID that performs a search of the LDAP tree for user information."
+  saml_login.ldap.searchBase:
+    description: "Used with search-and-bind and search-and-compare. Define a base where the search starts at."
+    default: ""
+  saml_login.ldap.searchFilter:
+    description: "Used with search-and-bind and search-and-compare. Search filter used. Takes one parameter, user ID defined as {0}"
+    default: "cn={0}"
+  saml_login.ldap.passwordAttributeName:
+    description: "Used with search-and-compare only. The name of the password attribute in the LDAP directory"
+    default: "userPassword"
+  saml_login.ldap.localPasswordCompare:
+    description: "Used with search-and-compare only. Set to true if passwords are retrieved by the search, and should be compared in the login server."
+    default: "true"
+  saml_login.ldap.passwordEncoder:
+    description: "Used with search-and-compare only. The encoder used to properly encode user password to match the one in the LDAP directory."
+    default: "org.cloudfoundry.identity.uaa.login.ldap.DynamicPasswordComparator"
+  saml_login.ldap.sslCertificate:
+    description: "Used with ldaps:// URLs. The certificate, if self signed, to be trusted by this connection."
+  saml_login.ldap.sslCertificateAlias:
+    description: "Used with ldaps:// URLs. The certificate alias, to be trusted by this connection and stored in the keystore."
+  saml_login.analytics.code:
+    description: "Analytics code"
+  saml_login.analytics.domain:
+    description: "Analytics domain"

--- a/jobs/saml_login/templates/install_crt.erb
+++ b/jobs/saml_login/templates/install_crt.erb
@@ -5,13 +5,13 @@
 JDK_HOME=/var/vcap/packages/saml_login/jdk
 
 #define the certificate to import
-CERT_FILE=/var/vcap/jobs/saml_login/config/uaa.crt
+CERT_FILE=/var/vcap/jobs/saml_login/config/$1
 
 #define the trust store
 TRUST_STORE_FILE=$JDK_HOME/lib/security/cacerts
 
 #define the alias
-CERT_ALIAS=uaacert
+CERT_ALIAS=$2
 
 #check if the cert file exists, readable and that the trust store exists and is writeable
 if test -r "$CERT_FILE" -a -f "$CERT_FILE" -a -f $TRUST_STORE_FILE -a -w $TRUST_STORE_FILE

--- a/jobs/saml_login/templates/ldap.crt.erb
+++ b/jobs/saml_login/templates/ldap.crt.erb
@@ -1,0 +1,1 @@
+<%= p("saml_login.ldap.sslCertificate", "") %>

--- a/jobs/saml_login/templates/login.yml.erb
+++ b/jobs/saml_login/templates/login.yml.erb
@@ -2,19 +2,18 @@
 name: saml_login
 
 <%
-  props = properties.saml_login
   config_artifacts_path = "/var/vcap/jobs/saml_login/config/security"
 %>
 
 logging:
   config: /var/vcap/jobs/saml_login/config/log4j.properties
 
-<% protocol = (props && props.protocol) ? props.protocol : "http" %>
-<% if !props || !props.uaa_base
+<% protocol = (properties.saml_login && properties.saml_login.protocol) ? properties.saml_login.protocol : "http" %>
+<% if !properties.saml_login || !properties.saml_login.uaa_base
   # Fix this to https when SSL certs are working in dev and staging
   uaa_base = "#{protocol}://uaa.#{properties.domain}"
 else
-  uaa_base = props.uaa_base
+  uaa_base = properties.saml_login.uaa_base
 end %>
 uaa:
   url: <%= uaa_base %>
@@ -26,8 +25,8 @@ uaa:
     url: <%= uaa_base %>/clientinfo
   approvals:
     url: <%= uaa_base %>/approvals
-<% if props and props.links then %>
-links: <% props.links.marshal_dump.each do |id,url| %>
+<% if properties.saml_login and properties.saml_login.links then %>
+links: <% properties.saml_login.links.marshal_dump.each do |id,url| %>
   <%= id %>: <%= url %><% end %>
 <% end %>
 
@@ -50,26 +49,62 @@ login:
   # (The host and port of the application that will accept assertions)
   entityBaseURL: <%= "#{protocol}://login.#{properties.domain}" %>
   # The entityID of this SP
-  entityID: <%= (props && props.entityid) ? props.entityid : "login.#{properties.domain}" %>
-
-  # The location and credentials of the certificate for this SP
-  serviceProviderKey: !
-  <%= "    '" + p("saml_login.serviceProviderKey").gsub("\n", "\n\n    ") + "'" %>
-  serviceProviderCertificate: !
-  <%= "    '" + p("saml_login.serviceProviderCertificate").gsub("\n", "\n\n    ") + "'" %>
+  entityID: <%= (properties.saml_login && properties.saml_login.entityid) ? properties.saml_login.entityid : "login.#{properties.domain}" %>
 
   # The entity alias of the IDP
-  idpEntityAlias: <%= props.idp_entity_alias %>
+  idpEntityAlias: <%= properties.saml_login.idpEntityAlias %>
+  <% if !properties.saml_login.idpMetadataURL.nil? %>
+  idpMetadataURL: <%= properties.saml_login.idpMetadataURL %>
+  <% end %>
   <% if !properties.saml_login.idp_metadata_file.nil? %>
   idpMetadataFile: /var/vcap/jobs/saml_login/<%= properties.saml_login.idp_metadata_file %>
   <% end %>
-  <% if !properties.saml_login.idp_metadata_url.nil? %>
-  idpMetadataURL: <%= properties.saml_login.idp_metadata_url %>
-  <% end %>
+  serviceProviderCertificate: ! <%= "'" + p("saml_login.serviceProviderCertificate").gsub("\n", "\n\n    ") + "'" %>
+  serviceProviderKey: ! <%= "'" + p("saml_login.serviceProviderKey").gsub("\n", "\n\n    ") + "'" %>
+  serviceProviderKeyPassword: <%= properties.saml_login.serviceProviderKeyPassword %>
 
   authorize:
-    url: <%= uaa_base %>/login/oauth/authorize
+    url: <%= "#{protocol}://login.#{properties.domain}/oauth/authorize" %>
 
   saml:
-    assertionConsumerIndex: <%= (props && props.assertion_consumer_index) ? props.assertion_consumer_index : 1 %>
-    nameID: <%= (props && props.nameid_format) ? props.nameid_format : "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress" %>
+    assertionConsumerIndex: <%= (properties.saml_login && properties.saml_login.assertionConsumerIndex) ? properties.saml_login.assertionConsumerIndex : 1 %>
+    nameID: <%= (properties.saml_login && properties.saml_login.nameidFormat) ? properties.saml_login.nameidFormat : "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress" %>
+    
+<% if properties.saml_login.analytics && properties.saml_login.analytics.code && properties.saml_login.analytics.domain %>
+analytics:
+  code: <%= properties.saml_login.analytics.code %>
+  domain: <%= properties.saml_login.analytics.domain %>
+<% end %>
+
+
+<% if properties.saml_login && properties.saml_login.spring_profiles %>
+spring_profiles: <%= properties.saml_login.spring_profiles %>
+<% end %>
+
+<% if properties.saml_login && properties.saml_login.spring_profiles && properties.saml_login.spring_profiles.index('ldap') >= 0 %>
+ldap:
+  profile:
+    file: <%= (properties.saml_login.ldap.profile_type == 'simple-bind') ? 'ldap/ldap-simple-bind.xml' : (properties.saml_login.ldap.profile_type == 'search-and-bind') ? 'ldap/ldap-search-and-bind.xml' : 'ldap/ldap-search-and-compare.xml' %>
+  base:
+    url: '<%= properties.saml_login.ldap.url %>'
+    <% if properties.saml_login.ldap.profile_type == 'simple-bind' %> 
+    userDnPattern: '<%= properties.saml_login.ldap.userDNPattern %>'
+    <% else  %>
+    userDn: '<%= properties.saml_login.ldap.userDN %>'
+    password: '<%= properties.saml_login.ldap.userPassword %>'
+    searchBase: '<%= properties.saml_login.ldap.searchBase %>' 
+    searchFilter: '<%= properties.saml_login.ldap.searchFilter %>'
+    <% end %>
+    <% if properties.saml_login.ldap.profile_type == 'search-and-compare' %> 
+    passwordAttributeName: <%= properties.saml_login.ldap.passwordAttributeName %>
+    passwordEncoder: <%= properties.saml_login.ldap.localPasswordCompare %>
+    localPasswordCompare: <%= properties.saml_login.ldap.passwordEncoder %>
+    <% end %>
+  <% if properties.saml_login.ldap.sslCertificate %>
+  ssl: 
+    sslCertificate: ! <%= "'" + p("saml_login.ldap.sslCertificate").gsub("\n", "\n\n    ") + "'" %>
+    <% if properties.saml_login.ldap.sslCertificateAlias %>
+    sslCertificateAlias: <%= properties.saml_login.ldap.sslCertificateAlias %>
+    <% end %>
+  <% end %>  
+<% end %>

--- a/jobs/saml_login/templates/saml_login_ctl.erb
+++ b/jobs/saml_login/templates/saml_login_ctl.erb
@@ -58,7 +58,11 @@ case $1 in
     echo $$ > $PIDFILE
 
     <% if properties.saml_login && properties.saml_login.uaa_certificate %>
-    /var/vcap/jobs/saml_login/bin/install_crt
+    /var/vcap/jobs/saml_login/bin/install_crt uaa.crt uaacert
+    <% end %>
+    
+    <% if properties.saml_login && properties.saml_login.ldap &&  properties.saml_login.ldap.sslCertificate %>
+    /var/vcap/jobs/saml_login/bin/install_crt ldap.crt ldapcert
     <% end %>
 
     <% if properties.syslog_aggregator && properties.syslog_aggregator.address %>

--- a/jobs/saml_login/templates/tomcat.server.xml.erb
+++ b/jobs/saml_login/templates/tomcat.server.xml.erb
@@ -18,7 +18,7 @@
                internalProxies="10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}" 
         />
 
-        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="/var/vcap/sys/log/login"
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="/var/vcap/sys/log/saml_login"
                prefix="localhost_access." suffix=".log" rotatable="true" pattern="%h %l %u %t &quot;%r&quot; %s %b"/>
 
       </Host>

--- a/jobs/uaa/templates/uaa.yml.erb
+++ b/jobs/uaa/templates/uaa.yml.erb
@@ -110,6 +110,4 @@ require_https: <%= properties.uaa.require_https %>
 <% if !properties.uaa.dump_requests.nil? %>
 dump_requests: <%= properties.uaa.dump_requests %>
 <% end %>
-<% if properties.uaa.login && !properties.uaa.login.addnew.nil? %>
 login.addnew: <%= properties.uaa.login.addnew %>
-<% end %>

--- a/packages/login/packaging
+++ b/packages/login/packaging
@@ -19,7 +19,7 @@ mv apache-tomcat-7.0.42 tomcat
 
 cd tomcat
 rm -rf webapps/*
-cp -a ${BOSH_COMPILE_TARGET}/login/cloudfoundry-login-server-1.2.10.war webapps/ROOT.war
+cp -a ${BOSH_COMPILE_TARGET}/login/cloudfoundry-login-server-1.3.0.war webapps/ROOT.war
 cp -a ${BOSH_COMPILE_TARGET}/uaa/cloudfoundry-identity-varz-1.0.2.war webapps/varz.war
 
 cd ${BOSH_INSTALL_TARGET}

--- a/packages/pivotal_login/packaging
+++ b/packages/pivotal_login/packaging
@@ -19,7 +19,7 @@ mv apache-tomcat-7.0.42 tomcat
 
 cd tomcat
 rm -rf webapps/*
-cp -a ${BOSH_COMPILE_TARGET}/pivotal_login/pivotal-login-server-1.2.10.war webapps/ROOT.war
+cp -a ${BOSH_COMPILE_TARGET}/pivotal_login/pivotal-login-server-1.3.0.war webapps/ROOT.war
 cp -a ${BOSH_COMPILE_TARGET}/uaa/cloudfoundry-identity-varz-1.0.2.war webapps/varz.war
 
 cd ${BOSH_INSTALL_TARGET}

--- a/packages/saml_login/packaging
+++ b/packages/saml_login/packaging
@@ -19,11 +19,10 @@ mv apache-tomcat-7.0.42 tomcat
 
 cd tomcat
 rm -rf webapps/*
-cp -a ${BOSH_COMPILE_TARGET}/saml_login/cloudfoundry-saml-login-server-1.2.10.war webapps/ROOT.war
+cp -a ${BOSH_COMPILE_TARGET}/saml_login/cloudfoundry-saml-login-server-1.3.0.war webapps/ROOT.war
 cp -a ${BOSH_COMPILE_TARGET}/uaa/cloudfoundry-identity-varz-1.0.2.war webapps/varz.war
 
 cd ${BOSH_INSTALL_TARGET}
 cp -a ${BOSH_COMPILE_TARGET}/vcap-common vcap-common
 cd vcap-common
-export PATH=/var/vcap/packages/git/bin:$PATH
 /var/vcap/packages/ruby/bin/bundle install --local --deployment --without=development test

--- a/packages/saml_login/spec
+++ b/packages/saml_login/spec
@@ -2,8 +2,8 @@
 name: saml_login
 dependencies:
 - ruby
-- git
 files:
 - saml_login/**/*
 - uaa/**/*
 - vcap-common/**/*
+

--- a/packages/uaa/packaging
+++ b/packages/uaa/packaging
@@ -19,7 +19,7 @@ mv apache-tomcat-7.0.42 tomcat
 
 cd tomcat
 rm -rf webapps/*
-cp -a ${BOSH_COMPILE_TARGET}/uaa/cloudfoundry-identity-uaa-1.4.7.war webapps/ROOT.war
+cp -a ${BOSH_COMPILE_TARGET}/uaa/cloudfoundry-identity-uaa-1.5.0.war webapps/ROOT.war
 cp -a ${BOSH_COMPILE_TARGET}/uaa/cloudfoundry-identity-batch-1.0.2.war webapps/batch.war
 cp -a ${BOSH_COMPILE_TARGET}/uaa/cloudfoundry-identity-varz-1.0.2.war webapps/varz.war
 

--- a/templates/cf-infrastructure-warden.yml
+++ b/templates/cf-infrastructure-warden.yml
@@ -94,6 +94,7 @@ properties:
     clients:
       login:
         secret: login-secret
+        redirect-uri: (( "http://login." domain ))
       developer_console:
         secret: console-secret
       app-direct:
@@ -110,6 +111,10 @@ properties:
     no_ssl: true
 
   login:
+    catalina_opts: -Xmx384m -XX:MaxPermSize=128m
+    protocol: http
+
+  saml_login:
     catalina_opts: -Xmx384m -XX:MaxPermSize=128m
     protocol: http
 

--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -456,6 +456,7 @@ properties:
 
   login: (( merge ))
   pivotal_login: (( login ))
+  saml_login: (( merge ))
 
   router:
     endpoint_timeout: 60

--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -128,7 +128,10 @@ properties:
     batch:
       username: (( merge ))
       password: (( merge ))
-
+    
+    login:
+      addnew: false
+      
     clients:
       login:
         override: true


### PR DESCRIPTION
Updated blobs with Login Server v1.3.0 and UAA v1.5.0. 

This depends on 
https://github.com/cloudfoundry/cf-release/pull/270
in order for the saml_login job to work properly.

Features added
1. Ability to easily configure a vCenter SSO properly. Tested against v5.5
2. Allow three different LDAP configurations for authentication to be configured through the deployment manifest
3. SAML and LDAP are features that can be enabled/disabled through the deployment manifest
4. Allow configuration of the LDAP SSL certificate.

Upload Apache Maven for future pre-packaging of the UAA and Login Servers.

References:
https://www.pivotaltracker.com/story/show/61157516
https://www.pivotaltracker.com/story/show/50697129
