### PR TITLE
Move property defaults to job spec file instead of within ERB templates

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -144,6 +144,12 @@ properties:
   ccng.use_nginx:
     default: true
     description: "Use nginx in front of the CC"
+  ccng.nginx_client_inactivity_timeout:
+    default: 300
+    description: "Inactivity timeout period between nginx and its clients."
+  ccng.nginx_app_inactivity_timeout:
+    default: 300
+    description: "Inactivity timeout period between nginx and its backends."
 
   ccng.uaa_resource_id:
     default: "cloud_controller"

--- a/jobs/cloud_controller_ng/templates/nginx.conf.erb
+++ b/jobs/cloud_controller_ng/templates/nginx.conf.erb
@@ -37,8 +37,8 @@ http {
     listen    9022;
     server_name  _;
     server_name_in_redirect off;
-    proxy_send_timeout          <%= p("router.client_inactivity_timeout", 300) %>;
-    proxy_read_timeout          <%= p("router.app_inactivity_timeout", 300) %>;
+    proxy_send_timeout          <%= p("ccng.nginx_client_inactivity_timeout").to_i %>;
+    proxy_read_timeout          <%= p("ccng.nginx_app_inactivity_timeout").to_i %>;
 
     # proxy and log all CC traffic
     location / {


### PR DESCRIPTION
Hi Guys,

Just noticed that some properties were being defaulted inside ERB code, instead of leveraging the job spec file.

Figure it'd be best to have them on the spec instead, so a documented manifest can be easily formed from the spec files.

Looking through the remainder of the code using something like:

```
grep -HR --only-matching --perl-regexp "..p\(('|\")[A-Za-z0-9 \._-]+('|\"),[A-Za-z0-9 \._-]+\)" *
```

Did not reveal any other use cases.

I also chose to rename the property to ccng.\* instead of router.\* as router.\* didn't seem to be used anywhere else (in particular, not even on the router job). I assume this is left over from prior to switching between nginx/gorouter.
