### PR TITLE
Deploy parallel on warden

### DIFF
--- a/templates/cf-deployment.yml
+++ b/templates/cf-deployment.yml
@@ -32,6 +32,7 @@ update:
   max_in_flight: 1
   canary_watch_time: 30000-600000
   update_watch_time: 5000-600000
+  serial: true
 
 resource_pools:
   - name: small_z1

--- a/templates/cf-infrastructure-warden.yml
+++ b/templates/cf-infrastructure-warden.yml
@@ -18,6 +18,7 @@ update:
   max_in_flight: 50
   canary_watch_time: 1000-180000
   update_watch_time: 1000-180000
+  serial: false
 
 properties:
   ssl:


### PR DESCRIPTION
As was announced [here](https://groups.google.com/a/cloudfoundry.org/forum/#!msg/bosh-users/GVPX4-jVZ0g/PEwN1pqxwNgJ), bosh supports parallel deployments. This PR makes parallel deploys the default when using bosh-lite.
