### PR TITLE
Added configuration options which limited of the app instances spawned per dea.

### DIFF
--- a/jobs/dea_next/spec
+++ b/jobs/dea_next/spec
@@ -55,6 +55,9 @@ properties:
   dea_next.memory_overcommit_factor:
     description:
     default: 1
+  dea_next.max_instances:
+    description: "Maximum number of allowable application instances not in the deleted state in a given DEA."
+    default: 256
   dea_next.stacks:
     default:
     - "lucid64"

--- a/jobs/dea_next/templates/dea.yml.erb
+++ b/jobs/dea_next/templates/dea.yml.erb
@@ -54,6 +54,7 @@ resources:
   memory_overcommit_factor: <%= p("dea_next.memory_overcommit_factor") %>
   disk_mb: <%= p("dea_next.disk_mb") %>
   disk_overcommit_factor: <%= p("dea_next.disk_overcommit_factor") %>
+  max_instances: <%= p("dea_next.max_instances") %>
 
 bind_mounts:
 - src_path: /var/vcap/packages/buildpack_cache

--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -427,6 +427,7 @@ properties:
     memory_overcommit_factor: 3
     disk_mb: (( merge ))
     disk_overcommit_factor: 2
+    max_instances: 256
     staging_disk_inode_limit: 200000
     instance_disk_inode_limit: 200000
     deny_networks: (( merge || [] ))


### PR DESCRIPTION
This is an integral part of the change set which aims at giving users the a way to limit the number of app instances spawned per DEA.  This pull request tried to expose the necessary configuration for the feature.

Other pull requests:
cloudfoundry / cloud_controller_ng:   https://github.com/cloudfoundry/cloud_controller_ng/pull/134
cloudfoundry / dea_ng:                      https://github.com/cloudfoundry/dea_ng/pull/85
