### PR TITLE
migrate syslog forwarder back to using TCP instead of RELP

### DIFF
--- a/jobs/cloud_controller_ng/templates/syslog_forwarder.conf.erb
+++ b/jobs/cloud_controller_ng/templates/syslog_forwarder.conf.erb
@@ -1,5 +1,4 @@
 <% if_p("syslog_aggregator.address", "syslog_aggregator.port") do |address, port| %>
-$ModLoad omrelp
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 $WorkDirectory /var/vcap/sys/rsyslog/buffered  # where messages should be buffered on disk
@@ -15,7 +14,7 @@ $ActionQueueHighWaterMark 8000          # Num messages. Assuming avg size of 512
 $ActionQueueTimeoutEnqueue 0            # Discard messages if the queue + disk is full
 $ActionQueueSaveOnShutdown on           # Save in-memory data to disk if rsyslog shuts down
 $template LongTagForwardFormat, "<%%PRI%>%TIMESTAMP:::date-rfc3339% %HOSTNAME% %syslogtag%%msg:::sp-if-no-1st-sp%%msg%" #Eliminate 32 character tag limit
-:programname, startswith, "vcap." :omrelp:<%= address %>:<%= port %>;LongTagForwardFormat
+:programname, startswith, "vcap." @@<%= address %>:<%= port %>;LongTagForwardFormat
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/collector/templates/syslog_forwarder.conf.erb
+++ b/jobs/collector/templates/syslog_forwarder.conf.erb
@@ -1,5 +1,4 @@
 <% if properties.syslog_aggregator && properties.syslog_aggregator.address %>
-$ModLoad omrelp
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 $WorkDirectory /var/vcap/sys/rsyslog/buffered  # where messages should be buffered on disk
@@ -14,7 +13,7 @@ $ActionQueueLowWaterMark 2000           # Num messages. Assuming avg size of 512
 $ActionQueueHighWaterMark 8000          # Num messages. Assuming avg size of 512B, this is 4MiB. (If this is reached, messages will spill to disk until the low watermark is reached).
 $ActionQueueTimeoutEnqueue 0            # Discard messages if the queue + disk is full
 $ActionQueueSaveOnShutdown on           # Save in-memory data to disk if rsyslog shuts down
-:programname, startswith, "vcap." :omrelp:<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
+:programname, startswith, "vcap." @@<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/dea_logging_agent/templates/syslog_forwarder.conf.erb
+++ b/jobs/dea_logging_agent/templates/syslog_forwarder.conf.erb
@@ -1,5 +1,4 @@
 <% if properties.syslog_aggregator && properties.syslog_aggregator.address %>
-$ModLoad omrelp
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 $WorkDirectory /var/vcap/sys/rsyslog/buffered # where messages should be buffered on disk
@@ -14,7 +13,7 @@ $ActionQueueLowWaterMark 2000           # Num messages. Assuming avg size of 512
 $ActionQueueHighWaterMark 8000          # Num messages. Assuming avg size of 512B, this is 4MiB. (If this is reached, messages will spill to disk until the low watermark is reached).
 $ActionQueueTimeoutEnqueue 0            # Discard messages if the queue + disk is full
 $ActionQueueSaveOnShutdown on           # Save in-memory data to disk if rsyslog shuts down
-:programname, startswith, "vcap." :omrelp:<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
+:programname, startswith, "vcap." @@<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/dea_next/templates/syslog_forwarder.conf.erb
+++ b/jobs/dea_next/templates/syslog_forwarder.conf.erb
@@ -1,5 +1,4 @@
 <% if properties.syslog_aggregator && properties.syslog_aggregator.address %>
-$ModLoad omrelp
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 $WorkDirectory /var/vcap/sys/rsyslog/buffered # where messages should be buffered on disk
@@ -14,7 +13,7 @@ $ActionQueueLowWaterMark 2000           # Num messages. Assuming avg size of 512
 $ActionQueueHighWaterMark 8000          # Num messages. Assuming avg size of 512B, this is 4MiB. (If this is reached, messages will spill to disk until the low watermark is reached).
 $ActionQueueTimeoutEnqueue 0            # Discard messages if the queue + disk is full
 $ActionQueueSaveOnShutdown on           # Save in-memory data to disk if rsyslog shuts down
-:programname, startswith, "vcap." :omrelp:<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
+:programname, startswith, "vcap." @@<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/gorouter/templates/syslog_forwarder.conf.erb
+++ b/jobs/gorouter/templates/syslog_forwarder.conf.erb
@@ -1,5 +1,4 @@
 <% if properties.syslog_aggregator && properties.syslog_aggregator.address %>
-$ModLoad omrelp
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 $WorkDirectory /var/vcap/sys/rsyslog/buffered # where messages should be buffered on disk
@@ -14,7 +13,7 @@ $ActionQueueLowWaterMark 2000           # Num messages. Assuming avg size of 512
 $ActionQueueHighWaterMark 8000          # Num messages. Assuming avg size of 512B, this is 4MiB. (If this is reached, messages will spill to disk until the low watermark is reached).
 $ActionQueueTimeoutEnqueue 0            # Discard messages if the queue + disk is full
 $ActionQueueSaveOnShutdown on           # Save in-memory data to disk if rsyslog shuts down
-:programname, startswith, "vcap." :omrelp:<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
+:programname, startswith, "vcap." @@<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/haproxy/templates/syslog_forwarder.conf.erb
+++ b/jobs/haproxy/templates/syslog_forwarder.conf.erb
@@ -1,5 +1,4 @@
 <% if_p("syslog_aggregator.address", "syslog_aggregator.port") do |address, port| %>
-$ModLoad omrelp
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 $WorkDirectory /var/vcap/sys/rsyslog/buffered  # where messages should be buffered on disk
@@ -14,7 +13,7 @@ $ActionQueueLowWaterMark 2000           # Num messages. Assuming avg size of 512
 $ActionQueueHighWaterMark 8000          # Num messages. Assuming avg size of 512B, this is 4MiB. (If this is reached, messages will spill to disk until the low watermark is reached).
 $ActionQueueTimeoutEnqueue 0            # Discard messages if the queue + disk is full
 $ActionQueueSaveOnShutdown on           # Save in-memory data to disk if rsyslog shuts down
-:programname, startswith, "vcap." :omrelp:<%= address %>:<%= port %>
+:programname, startswith, "vcap." @@<%= address %>:<%= port %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/health_manager_next/templates/syslog_forwarder.conf.erb
+++ b/jobs/health_manager_next/templates/syslog_forwarder.conf.erb
@@ -1,5 +1,4 @@
 <% if properties.syslog_aggregator && properties.syslog_aggregator.address %>
-$ModLoad omrelp
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 $WorkDirectory /var/vcap/sys/rsyslog/buffered # where messages should be buffered on disk
@@ -14,7 +13,7 @@ $ActionQueueLowWaterMark 2000           # Num messages. Assuming avg size of 512
 $ActionQueueHighWaterMark 8000          # Num messages. Assuming avg size of 512B, this is 4MiB. (If this is reached, messages will spill to disk until the low watermark is reached).
 $ActionQueueTimeoutEnqueue 0            # Discard messages if the queue + disk is full
 $ActionQueueSaveOnShutdown on           # Save in-memory data to disk if rsyslog shuts down
-:programname, startswith, "vcap." :omrelp:<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
+:programname, startswith, "vcap." @@<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/hm9000/templates/syslog_forwarder.conf.erb
+++ b/jobs/hm9000/templates/syslog_forwarder.conf.erb
@@ -1,5 +1,4 @@
 <% if properties.syslog_aggregator && properties.syslog_aggregator.address %>
-$ModLoad omrelp
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 $WorkDirectory /var/vcap/sys/rsyslog/buffered # where messages should be buffered on disk
@@ -15,7 +14,7 @@ $ActionQueueHighWaterMark 8000          # Num messages. Assuming avg size of 512
 $ActionQueueTimeoutEnqueue 0            # Discard messages if the queue + disk is full
 $ActionQueueSaveOnShutdown on           # Save in-memory data to disk if rsyslog shuts down
 $template SyslogFormat, "<%%PRI%>%TIMESTAMP% localhost vcap.hm9000[] %msg%"
-:rawmsg, contains, "vcap.hm9000" :omrelp:<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>;SyslogFormat
+:rawmsg, contains, "vcap.hm9000" @@<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>;SyslogFormat
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/loggregator/templates/syslog_forwarder.conf.erb
+++ b/jobs/loggregator/templates/syslog_forwarder.conf.erb
@@ -1,5 +1,4 @@
 <% if properties.syslog_aggregator && properties.syslog_aggregator.address %>
-$ModLoad omrelp
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 $WorkDirectory /var/vcap/sys/rsyslog/buffered # where messages should be buffered on disk
@@ -14,7 +13,7 @@ $ActionQueueLowWaterMark 2000           # Num messages. Assuming avg size of 512
 $ActionQueueHighWaterMark 8000          # Num messages. Assuming avg size of 512B, this is 4MiB. (If this is reached, messages will spill to disk until the low watermark is reached).
 $ActionQueueTimeoutEnqueue 0            # Discard messages if the queue + disk is full
 $ActionQueueSaveOnShutdown on           # Save in-memory data to disk if rsyslog shuts down
-:programname, startswith, "vcap." :omrelp:<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
+:programname, startswith, "vcap." @@<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/loggregator_trafficcontroller/templates/syslog_forwarder.conf.erb
+++ b/jobs/loggregator_trafficcontroller/templates/syslog_forwarder.conf.erb
@@ -1,5 +1,4 @@
 <% if properties.syslog_aggregator && properties.syslog_aggregator.address %>
-$ModLoad omrelp
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 $WorkDirectory /var/vcap/sys/rsyslog/buffered # where messages should be buffered on disk
@@ -14,7 +13,7 @@ $ActionQueueLowWaterMark 2000           # Num messages. Assuming avg size of 512
 $ActionQueueHighWaterMark 8000          # Num messages. Assuming avg size of 512B, this is 4MiB. (If this is reached, messages will spill to disk until the low watermark is reached).
 $ActionQueueTimeoutEnqueue 0            # Discard messages if the queue + disk is full
 $ActionQueueSaveOnShutdown on           # Save in-memory data to disk if rsyslog shuts down
-:programname, startswith, "vcap." :omrelp:<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
+:programname, startswith, "vcap." @@<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/login/templates/syslog_forwarder.conf.erb
+++ b/jobs/login/templates/syslog_forwarder.conf.erb
@@ -1,5 +1,4 @@
 <% if properties.syslog_aggregator && properties.syslog_aggregator.address %>
-$ModLoad omrelp
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 
@@ -18,7 +17,7 @@ $ActionQueueLowWaterMark 2000           # Num messages. Assuming avg size of 512
 $ActionQueueHighWaterMark 8000          # Num messages. Assuming avg size of 512B, this is 4MiB. (If this is reached, messages will spill to disk until the low watermark is reached).
 $ActionQueueTimeoutEnqueue 0            # Discard messages if the queue + disk is full
 $ActionQueueSaveOnShutdown on           # Save in-memory data to disk if rsyslog shuts down
-:programname, startswith, "vcap." :omrelp:<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
+:programname, startswith, "vcap." @@<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/nats/templates/syslog_forwarder.conf.erb
+++ b/jobs/nats/templates/syslog_forwarder.conf.erb
@@ -1,5 +1,4 @@
 <% if_p("syslog_aggregator.address", "syslog_aggregator.port") do |address, port| %>
-$ModLoad omrelp
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 $WorkDirectory /var/vcap/sys/rsyslog/buffered  # where messages should be buffered on disk
@@ -14,7 +13,7 @@ $ActionQueueLowWaterMark 2000           # Num messages. Assuming avg size of 512
 $ActionQueueHighWaterMark 8000          # Num messages. Assuming avg size of 512B, this is 4MiB. (If this is reached, messages will spill to disk until the low watermark is reached).
 $ActionQueueTimeoutEnqueue 0            # Discard messages if the queue + disk is full
 $ActionQueueSaveOnShutdown on           # Save in-memory data to disk if rsyslog shuts down
-:programname, startswith, "vcap." :omrelp:<%= address %>:<%= port %>
+:programname, startswith, "vcap." @@<%= address %>:<%= port %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/nats_stream_forwarder/templates/syslog_forwarder.conf.erb
+++ b/jobs/nats_stream_forwarder/templates/syslog_forwarder.conf.erb
@@ -1,5 +1,4 @@
 <% if_p("syslog_aggregator.address", "syslog_aggregator.port") do |address, port| %>
-$ModLoad omrelp
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 $WorkDirectory /var/vcap/sys/rsyslog/buffered  # where messages should be buffered on disk
@@ -14,7 +13,7 @@ $ActionQueueLowWaterMark 2000           # Num messages. Assuming avg size of 512
 $ActionQueueHighWaterMark 8000          # Num messages. Assuming avg size of 512B, this is 4MiB. (If this is reached, messages will spill to disk until the low watermark is reached).
 $ActionQueueTimeoutEnqueue 0            # Discard messages if the queue + disk is full
 $ActionQueueSaveOnShutdown on           # Save in-memory data to disk if rsyslog shuts down
-:programname, startswith, "vcap." :omrelp:<%= address %>:<%= port %>
+:programname, startswith, "vcap." @@<%= address %>:<%= port %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/pivotal_login/templates/syslog_forwarder.conf.erb
+++ b/jobs/pivotal_login/templates/syslog_forwarder.conf.erb
@@ -1,5 +1,4 @@
 <% if properties.syslog_aggregator && properties.syslog_aggregator.address %>
-$ModLoad omrelp
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 
@@ -18,7 +17,7 @@ $ActionQueueLowWaterMark 2000           # Num messages. Assuming avg size of 512
 $ActionQueueHighWaterMark 8000          # Num messages. Assuming avg size of 512B, this is 4MiB. (If this is reached, messages will spill to disk until the low watermark is reached).
 $ActionQueueTimeoutEnqueue 0            # Discard messages if the queue + disk is full
 $ActionQueueSaveOnShutdown on           # Save in-memory data to disk if rsyslog shuts down
-:programname, startswith, "vcap." :omrelp:<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
+:programname, startswith, "vcap." @@<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/saml_login/templates/syslog_forwarder.conf.erb
+++ b/jobs/saml_login/templates/syslog_forwarder.conf.erb
@@ -1,5 +1,4 @@
 <% if properties.syslog_aggregator && properties.syslog_aggregator.address %>
-$ModLoad omrelp
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 
@@ -18,7 +17,7 @@ $ActionQueueLowWaterMark 2000           # Num messages. Assuming avg size of 512
 $ActionQueueHighWaterMark 8000          # Num messages. Assuming avg size of 512B, this is 4MiB. (If this is reached, messages will spill to disk until the low watermark is reached).
 $ActionQueueTimeoutEnqueue 0            # Discard messages if the queue + disk is full
 $ActionQueueSaveOnShutdown on           # Save in-memory data to disk if rsyslog shuts down
-:programname, startswith, "vcap." :omrelp:<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
+:programname, startswith, "vcap." @@<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/uaa/templates/syslog_forwarder.conf.erb
+++ b/jobs/uaa/templates/syslog_forwarder.conf.erb
@@ -1,5 +1,4 @@
 <% if properties.syslog_aggregator && properties.syslog_aggregator.address %>
-$ModLoad omrelp
 $ModLoad imuxsock                       # local message reception (rsyslog uses a datagram socket)
 $MaxMessageSize 4k                      # default is 2k
 
@@ -18,7 +17,7 @@ $ActionQueueLowWaterMark 2000           # Num messages. Assuming avg size of 512
 $ActionQueueHighWaterMark 8000          # Num messages. Assuming avg size of 512B, this is 4MiB. (If this is reached, messages will spill to disk until the low watermark is reached).
 $ActionQueueTimeoutEnqueue 0            # Discard messages if the queue + disk is full
 $ActionQueueSaveOnShutdown on           # Save in-memory data to disk if rsyslog shuts down
-:programname, startswith, "vcap." :omrelp:<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
+:programname, startswith, "vcap." @@<%= properties.syslog_aggregator.address %>:<%= properties.syslog_aggregator.port %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"


### PR DESCRIPTION
Signed-off-by: Johannes Petzold jpetzold@pivotallabs.com
