### PR TITLE
Fixing default compilation size for vsphere

### DIFF
--- a/templates/cf-infrastructure-vsphere.yml
+++ b/templates/cf-infrastructure-vsphere.yml
@@ -6,9 +6,9 @@ meta:
 
 compilation:
   cloud_properties:
-    ram: 2048
-    disk: 8096
-    cpu: 4
+    ram: 1024
+    disk: 6144
+    cpu: 2
 networks: (( merge ))
 
 resource_pools:


### PR DESCRIPTION
Current sizing fails to compile buildpack_cache with no space left on device.

```
Compiling packages
  loggregator/17 (00:11:27)
  gnatsd/3 (00:12:37)
  dea_logging_agent/17 (00:13:30)
  loggregator_trafficcontroller/8 (00:13:33)
  haproxy/2 (00:01:23)
  buildpack_cache/8: #<EErrno::ENOSPC: No space left on device - /var/vcap/data/tmp/96705681-2871-4626-b2ee-c3d51f41cc05>: ["/var/vcap/bosh/lib/ruby/1.9.1/logger.rb:606:in `write'", "/var/vcap/bosh/lib/ruby/1.9.1/logger.rb:606:in `add_log_header'", "/var
Task 218 error
```

Reused sizing suggested into https://github.com/cloudfoundry/cf-docs/blob/master/source/docs/running/deploying-cf/vsphere/cloud-foundry-example-manifest.md 
