### PR TITLE
Rename 'port' to better named 'external port'

### DIFF
--- a/jobs/cloud_controller_ng/monit
+++ b/jobs/cloud_controller_ng/monit
@@ -6,7 +6,7 @@ check process cloud_controller_ng
   group vcap
   if totalmem > 2250 Mb then alert
   if totalmem > 2450 Mb then restart
-  if failed host <%= spec.networks.send(properties.networks.apps).ip %> port <%= p("ccng.port") %> protocol http
+  if failed host <%= spec.networks.send(properties.networks.apps).ip %> port <%= p("ccng.external_port") %> protocol http
       and request '/v2/info'
       with timeout 60 seconds for 5 cycles
   then restart

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -80,7 +80,7 @@ properties:
     description: "Pipefs directory for NFS idmapd"
     default: "/var/lib/nfs/rpc_pipefs"
 
-  ccng.port:
+  ccng.external_port:
     description: "External Cloud Controller port"
     default: 9022
 

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -1,6 +1,8 @@
 ---
+#Actually NGX host and port
 local_route: <%= spec.networks.send(properties.networks.apps).ip %>
-port: <%= p("ccng.port") %>
+external_port: <%= p("ccng.external_port") %>
+
 pid_filename: /var/vcap/sys/run/cloud_controller_ng/cloud_controller_ng.pid
 development_mode: <%= p("ccng.development_mode") %>
 

--- a/jobs/cloud_controller_ng/templates/nginx.conf.erb
+++ b/jobs/cloud_controller_ng/templates/nginx.conf.erb
@@ -34,7 +34,7 @@ http {
   }
 
   server {
-    listen    9022;
+    listen    <%= p("ccng.external_port") %>;
     server_name  _;
     server_name_in_redirect off;
     proxy_send_timeout          <%= p("router.client_inactivity_timeout", 300) %>;


### PR DESCRIPTION
I made a change in Cloud Controller master. When you bump CC in cf-release, you would need this PR.

Signed-off-by: Phan Le ple@pivotallabs.com
