### PR TITLE
Remove trial_db from templates

### DIFF
--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -6,7 +6,6 @@ meta:
        total_services: 100
        non_basic_services_allowed: true
        total_routes: 1000
-       trial_db_allowed: true
 
 properties:
   domain: (( merge ))


### PR DESCRIPTION
Based on vcap-dev exchanges [[1]](https://groups.google.com/a/cloudfoundry.org/d/msg/vcap-dev/45DAQHwxww0/fWVP4kQXdaUJ) and an existing tracker story [[2]](https://www.pivotaltracker.com/s/projects/966314/stories/61846224), this PR is part 1/3 in support of removing `trial_db_allowed` and `trial_db_guid`.

Pull requests:
1. Updates to cf-release to remove references from the properties and templates (cloudfoundry/cf-release#299)
2. Removes code related to `trial_db_allowed` from the cloud controller (cloudfoundry/cloud_controller_ng#168)
3. Sequel migration to remove the database column (cloudfoundry/cloud_controller_ng#169)

1 and 2 can be deployed together in one release (but 1 must be merged with or before 2) while 3 should happen in a subsequent release.

[1] https://groups.google.com/a/cloudfoundry.org/d/msg/vcap-dev/45DAQHwxww0/fWVP4kQXdaUJ
[2] https://www.pivotaltracker.com/s/projects/966314/stories/61846224
[3] https://groups.google.com/a/cloudfoundry.org/d/msg/vcap-dev/NY6VIIG-75U/0-2duMUsaa4J
