### PR TITLE
Expose config for ccng.packages.max_package_size

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -218,6 +218,9 @@ properties:
   ccng.packages.app_package_directory_key:
     description: "Directory (bucket) used store app packages.  It does not have be pre-created."
     default: "cc-packages"
+  ccng.packages.max_package_size:
+    description: "Maximum size of application package"
+    default: 536870912
   ccng.packages.fog_connection:
     description: "Fog connection hash"
   ccng.packages.cdn.uri:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -167,6 +167,7 @@ resource_pool:
 
 packages:
   app_package_directory_key: <%= p("ccng.packages.app_package_directory_key") %>
+  max_package_size: <%= p("ccng.packages.max_package_size") %>
   <% if_p("ccng.packages.cdn") do %>
   cdn:
     uri: <%= p("ccng.packages.cdn.uri") %>


### PR DESCRIPTION
In order to support large applications, the max package size configuration from the cloud controller needs to be surfaced in configuration templates.

This PR relies on changes associated with cloudfoundry/cloud_controller_ng#171
