### PR TITLE
Add X-VCAP-Request-ID to nginx access log

### DIFF
--- a/jobs/cloud_controller_ng/templates/nginx.conf.erb
+++ b/jobs/cloud_controller_ng/templates/nginx.conf.erb
@@ -17,7 +17,8 @@ http {
   log_format main  '$host - [$time_local] '
                    '"$request" $status $bytes_sent '
                    '"$http_referer" "$http_user_agent" '
-                   '$proxy_add_x_forwarded_for response_time:$upstream_response_time';
+                   '$proxy_add_x_forwarded_for vcap_request:$upstream_http_x_vcap_request_id '
+                   'response_time:$upstream_response_time';
 
   access_log  /var/vcap/sys/log/nginx_ccng/nginx.access.log  main;
 


### PR DESCRIPTION
Based on a suggestion from @phanle, add vcap request id to the access log for improved correlation between response times and request activity in the cc log.

`10.244.0.138 - [24/Feb/2014:23:18:05 +0000] "GET /v2/info HTTP/1.1" 200 527 "-" "monit/5.2.4" 10.244.0.138 vcap_request:8b9f2ca9-046e-40fa-951b-1ad1fa803374 response_time:0.009`
