### PR TITLE
Make Router listening port configurable

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -23,6 +23,9 @@ properties:
     description: "Transport to be used when forwarding logs (tcp|udp|relp)."
     default: "tcp"
 
+  router.port:
+    description: "Listening Port for Router"
+    default: 80
   router.status.port:
     description: "Port for the Router varz/status endpoint."
     default: 8080

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -29,7 +29,7 @@ loggregatorConfig:
   shared_secret: <%= shared_secret %>
 <% end %>
 
-port: 80
+port: <%= p("router.port") %>
 index: <%= p("router.offset") + spec.index %>
 pidfile: /var/vcap/sys/run/gorouter/gorouter.pid
 go_max_procs: 8

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -32,3 +32,6 @@ properties:
   router.servers.z2:
     default:
     description:
+  router.port:
+    default: 80
+    description: "Listening port for Router"

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -42,10 +42,10 @@ backend http-routers
     <% size = p("router.servers.z1").size %>
 
     <% p("router.servers.z1").each_with_index do |ip, index| %>
-        server node<%= index %> <%= ip %>:80 check inter 1000
+        server node<%= index %> <%= ip %>:<%= p("router.port") %> check inter 1000
     <% end %>
     <% p("router.servers.z2").each_with_index do |ip, index| %>
-        server node<%= index + size %> <%= ip %>:80 check inter 1000
+        server node<%= index + size %> <%= ip %>:<%= p("router.port") %> check inter 1000
     <% end %>
 
 backend tcp-routers
@@ -54,8 +54,8 @@ backend tcp-routers
     <% size = p("router.servers.z1").size %>
 
     <% p("router.servers.z1").each_with_index do |ip, index| %>
-        server node<%= index %> <%= ip %>:80 check inter 1000
+        server node<%= index %> <%= ip %>:<%= p("router.port") %> check inter 1000
     <% end %>
     <% p("router.servers.z2").each_with_index do |ip, index| %>
-        server node<%= index + size %> <%= ip %>:80 check inter 1000
+        server node<%= index + size %> <%= ip %>:<%= p("router.port") %> check inter 1000
     <% end %>


### PR DESCRIPTION
This commit makes collocation of Router and HAProxy possible to support SSL connections on a small deployment.
