### PR TITLE
nginx: do not error out on warning

### DIFF
--- a/packages/nginx/packaging
+++ b/packages/nginx/packaging
@@ -38,6 +38,7 @@ tar xzvf nginx/nginx-0.8.54.tar.gz
 echo "Patching nginx..."
 pushd nginx-0.8.54
   patch -p0 < ../nginx/zero_byte_in_cstr_20120315.patch
+  patch -p0 < ../nginx/no_werror_20140224.patch
 popd
 
 echo "Building lua..."

--- a/packages/nginx/spec
+++ b/packages/nginx/spec
@@ -13,3 +13,4 @@ files:
 - nginx/lua-5.1.4.tar.gz
 - nginx/lua-cjson-1.0.3.tar.gz
 - nginx/lua-openssl-0.1.1.tar.gz
+- nginx/no_werror_20140224.patch

--- a/src/nginx/no_werror_20140224.patch
+++ b/src/nginx/no_werror_20140224.patch
@@ -1,0 +1,11 @@
+--- auto/cc/gcc
++++ auto/cc/gcc
+@@ -169,7 +169,7 @@
+ 
+ 
+ # stop on warning
+-CFLAGS="$CFLAGS -Werror"
++#CFLAGS="$CFLAGS -Werror"
+ 
+ # debug
+ CFLAGS="$CFLAGS -g"


### PR DESCRIPTION
This pull request disables "-Werror" when building nginx. Our custom CPI needs Precise, so that's what our Bosh stemcells use. On Precise, the compiler warns about two unused variables, and "-Werror" makes the build error out.

Up to cf 155, we haven't been building nginx at all, and been setting the ccng.use_nginx flag to false. When that flag disappeared with 3343556d, we disabled "-Werror" instead. This shouldn't hurt when building on Lucid, so we're hoping you will approve this pull request.

Jon Kåre Hellan, UNINETT AS, Trondheim, Norway
