### PR TITLE
Make syslog_aggregator job listen on TCP instead of RELP

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -29,6 +29,9 @@ packages:
   - syslog_aggregator
 
 properties:
+  syslog_aggregator:
+    description: "Syslog Aggregator properties."
+
   name:
     default: "vcap"
     description:
@@ -297,10 +300,6 @@ properties:
   login.url:
     description:
 
-  syslog_aggregator.address:
-    description: "The address of the syslog_aggregator job."
-  syslog_aggregator.port:
-    description: "The port used by the syslog_aggregator job."
   uaa.jwt.verification_key:
     default: ""
     description: "ssl cert defined in the manifest by the UAA, required by the cc to communicate with UAA"

--- a/jobs/cloud_controller_ng/templates/syslog_forwarder.conf.erb
+++ b/jobs/cloud_controller_ng/templates/syslog_forwarder.conf.erb
@@ -28,7 +28,16 @@ template(name="CfLogTemplate" type="list") {
         property(name="msg")
 }
 
+<% case properties.syslog_aggregator.transport
+     when "relp" %>
+$ModLoad omrelp
+:programname, startswith, "vcap." :omrelp:<%= address %>:<%= port %>;CfLogTemplate
+<%   when "udp" %>
+:programname, startswith, "vcap." @<%= address %>:<%= port %>;CfLogTemplate
+<%   else %>
 :programname, startswith, "vcap." @@<%= address %>:<%= port %>;CfLogTemplate
+<% end %>
+
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/collector/spec
+++ b/jobs/collector/spec
@@ -10,6 +10,9 @@ packages:
 - ruby
 - syslog_aggregator
 properties:
+  syslog_aggregator:
+    description: "Syslog Aggregator properties."
+
   collector.aws_access_key_id:
     description: "AWS access key for CloudWatch access"
   collector.aws_secret_access_key:
@@ -59,7 +62,3 @@ properties:
     description: "IP address of OpenTsdb"
   opentsdb.port:
     description: "TCP port of OpenTsdb"
-  syslog_aggregator.address:
-    description: "IP address of syslog aggregator"
-  syslog_aggregator.port:
-    description: "port of syslog aggregator"

--- a/jobs/collector/templates/syslog_forwarder.conf.erb
+++ b/jobs/collector/templates/syslog_forwarder.conf.erb
@@ -28,7 +28,15 @@ template(name="CfLogTemplate" type="list") {
         property(name="msg")
 }
 
+<% case properties.syslog_aggregator.transport
+     when "relp" %>
+$ModLoad omrelp
+:programname, startswith, "vcap." :omrelp:<%= address %>:<%= port %>;CfLogTemplate
+<%   when "udp" %>
+:programname, startswith, "vcap." @<%= address %>:<%= port %>;CfLogTemplate
+<%   else %>
 :programname, startswith, "vcap." @@<%= address %>:<%= port %>;CfLogTemplate
+<% end %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/dea_logging_agent/spec
+++ b/jobs/dea_logging_agent/spec
@@ -11,7 +11,8 @@ packages:
 - syslog_aggregator
 properties:
   syslog_aggregator:
-    description:
+    description: "Syslog Aggregator properties."
+
   dea_logging_agent.debug:
     description: boolean value to turn on verbose mode
     default: false

--- a/jobs/dea_logging_agent/templates/syslog_forwarder.conf.erb
+++ b/jobs/dea_logging_agent/templates/syslog_forwarder.conf.erb
@@ -28,7 +28,15 @@ template(name="CfLogTemplate" type="list") {
         property(name="msg")
 }
 
+<% case properties.syslog_aggregator.transport
+     when "relp" %>
+$ModLoad omrelp
+:programname, startswith, "vcap." :omrelp:<%= address %>:<%= port %>;CfLogTemplate
+<%   when "udp" %>
+:programname, startswith, "vcap." @<%= address %>:<%= port %>;CfLogTemplate
+<%   else %>
 :programname, startswith, "vcap." @@<%= address %>:<%= port %>;CfLogTemplate
+<% end %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/dea_next/spec
+++ b/jobs/dea_next/spec
@@ -21,6 +21,9 @@ packages:
 - syslog_aggregator
 - buildpack_cache
 properties:
+  syslog_aggregator:
+    description: "Syslog Aggregator properties."
+
   domain:
     description: "DNS domain name for this Cloud Foundry deployment"
   nats.address:
@@ -101,8 +104,6 @@ properties:
   disk_quota_enabled:
     description: "disk quota must be disabled to use warden-inside-warden with the warden cpi"
     default: true
-  syslog_aggregator:
-    description: "Syslog aggregator stuff"
   loggregator_endpoint.host:
     description: "The host used to emit messages to the Loggregator"
   loggregator_endpoint.port:

--- a/jobs/dea_next/templates/syslog_forwarder.conf.erb
+++ b/jobs/dea_next/templates/syslog_forwarder.conf.erb
@@ -28,7 +28,15 @@ template(name="CfLogTemplate" type="list") {
         property(name="msg")
 }
 
+<% case properties.syslog_aggregator.transport
+     when "relp" %>
+$ModLoad omrelp
+:programname, startswith, "vcap." :omrelp:<%= address %>:<%= port %>;CfLogTemplate
+<%   when "udp" %>
+:programname, startswith, "vcap." @<%= address %>:<%= port %>;CfLogTemplate
+<%   else %>
 :programname, startswith, "vcap." @@<%= address %>:<%= port %>;CfLogTemplate
+<% end %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -13,7 +13,8 @@ packages:
   - syslog_aggregator
 properties:
   syslog_aggregator:
-    description:
+    description: "Syslog Aggregator properties."
+
   router.status.port:
     description: "Port for the Router varz/status endpoint."
     default: 8080

--- a/jobs/gorouter/templates/syslog_forwarder.conf.erb
+++ b/jobs/gorouter/templates/syslog_forwarder.conf.erb
@@ -28,7 +28,15 @@ template(name="CfLogTemplate" type="list") {
         property(name="msg")
 }
 
+<% case properties.syslog_aggregator.transport
+     when "relp" %>
+$ModLoad omrelp
+:programname, startswith, "vcap." :omrelp:<%= address %>:<%= port %>;CfLogTemplate
+<%   when "udp" %>
+:programname, startswith, "vcap." @<%= address %>:<%= port %>;CfLogTemplate
+<%   else %>
 :programname, startswith, "vcap." @@<%= address %>:<%= port %>;CfLogTemplate
+<% end %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -9,18 +9,15 @@ templates:
   haproxy_ctl:               bin/haproxy_ctl
   cert.pem.erb:              config/cert.pem
 properties:
+  syslog_aggregator:
+    description: "Syslog Aggregator properties."
+
   ha_proxy.ssl_pem:
     default:
     description: "SSL certificate (PEM file)"
   ha_proxy.timeout:
     default: 300
     description: "Server and client timeouts in seconds"
-  syslog_aggregator.address:
-    default:
-    description:
-  syslog_aggregator.port:
-    default:
-    description:
   router.servers.z1:
     default:
     description:

--- a/jobs/haproxy/templates/syslog_forwarder.conf.erb
+++ b/jobs/haproxy/templates/syslog_forwarder.conf.erb
@@ -28,7 +28,15 @@ template(name="CfLogTemplate" type="list") {
         property(name="msg")
 }
 
+<% case properties.syslog_aggregator.transport
+     when "relp" %>
+$ModLoad omrelp
+:programname, startswith, "vcap." :omrelp:<%= address %>:<%= port %>;CfLogTemplate
+<%   when "udp" %>
+:programname, startswith, "vcap." @<%= address %>:<%= port %>;CfLogTemplate
+<%   else %>
 :programname, startswith, "vcap." @@<%= address %>:<%= port %>;CfLogTemplate
+<% end %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/health_manager_next/spec
+++ b/jobs/health_manager_next/spec
@@ -10,6 +10,9 @@ packages:
   - ruby
   - syslog_aggregator
 properties:
+  syslog_aggregator:
+    description: "Syslog Aggregator properties."
+
   cc_props:
     description: "BOSH job name of cloud controller"
     default: 'cc'
@@ -25,10 +28,6 @@ properties:
     description: "TCP port of NATS server"
   nats.user:
     description: "user name for NATS login"
-  syslog_aggregator.address:
-    description: "IP address of syslog aggregator"
-  syslog_aggregator.port:
-    description: "TCP port of syslog aggregator"
   health_manager.cc_partition:
     description:
     default: 'default'

--- a/jobs/health_manager_next/templates/syslog_forwarder.conf.erb
+++ b/jobs/health_manager_next/templates/syslog_forwarder.conf.erb
@@ -28,7 +28,15 @@ template(name="CfLogTemplate" type="list") {
         property(name="msg")
 }
 
+<% case properties.syslog_aggregator.transport
+     when "relp" %>
+$ModLoad omrelp
+:programname, startswith, "vcap." :omrelp:<%= address %>:<%= port %>;CfLogTemplate
+<%   when "udp" %>
+:programname, startswith, "vcap." @<%= address %>:<%= port %>;CfLogTemplate
+<%   else %>
 :programname, startswith, "vcap." @@<%= address %>:<%= port %>;CfLogTemplate
+<% end %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/hm9000/spec
+++ b/jobs/hm9000/spec
@@ -18,6 +18,9 @@ packages:
   - syslog_aggregator
 
 properties:
+  syslog_aggregator:
+    description: "Syslog Aggregator properties."
+
   nats.user:
     description:
   nats.password:
@@ -28,10 +31,6 @@ properties:
     description:
   nats.machines:
     description:
-  syslog_aggregator.address:
-    description: "IP address of syslog aggregator"
-  syslog_aggregator.port:
-    description: "TCP port of syslog aggregator"
   cc.srv_api_uri:
     description:
   ccng.bulk_api_user:

--- a/jobs/hm9000/templates/syslog_forwarder.conf.erb
+++ b/jobs/hm9000/templates/syslog_forwarder.conf.erb
@@ -28,7 +28,15 @@ template(name="CfLogTemplate" type="list") {
         property(name="msg")
 }
 
+<% case properties.syslog_aggregator.transport
+     when "relp" %>
+$ModLoad omrelp
+:programname, startswith, "vcap." :omrelp:<%= address %>:<%= port %>;CfLogTemplate
+<%   when "udp" %>
+:programname, startswith, "vcap." @<%= address %>:<%= port %>;CfLogTemplate
+<%   else %>
 :programname, startswith, "vcap." @@<%= address %>:<%= port %>;CfLogTemplate
+<% end %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/loggregator/spec
+++ b/jobs/loggregator/spec
@@ -11,7 +11,8 @@ packages:
 - syslog_aggregator
 properties:
   syslog_aggregator:
-    description:
+    description: "Syslog Aggregator properties."
+
   loggregator.debug:
     description: boolean value to turn on verbose logging for loggregator system (dea agent & loggregator server)
     default: false

--- a/jobs/loggregator/templates/syslog_forwarder.conf.erb
+++ b/jobs/loggregator/templates/syslog_forwarder.conf.erb
@@ -28,7 +28,15 @@ template(name="CfLogTemplate" type="list") {
         property(name="msg")
 }
 
+<% case properties.syslog_aggregator.transport
+     when "relp" %>
+$ModLoad omrelp
+:programname, startswith, "vcap." :omrelp:<%= address %>:<%= port %>;CfLogTemplate
+<%   when "udp" %>
+:programname, startswith, "vcap." @<%= address %>:<%= port %>;CfLogTemplate
+<%   else %>
 :programname, startswith, "vcap." @@<%= address %>:<%= port %>;CfLogTemplate
+<% end %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/loggregator_trafficcontroller/spec
+++ b/jobs/loggregator_trafficcontroller/spec
@@ -11,7 +11,8 @@ packages:
 - syslog_aggregator
 properties:
   syslog_aggregator:
-    description:
+    description: "Syslog Aggregator properties."
+
   traffic_controller.zone:
     description: Zone of the loggregator_trafficcontroller
   traffic_controller.host:

--- a/jobs/loggregator_trafficcontroller/templates/syslog_forwarder.conf.erb
+++ b/jobs/loggregator_trafficcontroller/templates/syslog_forwarder.conf.erb
@@ -28,7 +28,15 @@ template(name="CfLogTemplate" type="list") {
         property(name="msg")
 }
 
+<% case properties.syslog_aggregator.transport
+     when "relp" %>
+$ModLoad omrelp
+:programname, startswith, "vcap." :omrelp:<%= address %>:<%= port %>;CfLogTemplate
+<%   when "udp" %>
+:programname, startswith, "vcap." @<%= address %>:<%= port %>;CfLogTemplate
+<%   else %>
 :programname, startswith, "vcap." @@<%= address %>:<%= port %>;CfLogTemplate
+<% end %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/login/spec
+++ b/jobs/login/spec
@@ -25,6 +25,9 @@ packages:
   - git
 
 properties:
+  syslog_aggregator:
+    description: "Syslog Aggregator properties."
+
   name: Login Server for the UAA
   description: "The Login Server enables authentication to the UAA optionally with SAML or LDAP."
   login.brand: 
@@ -76,10 +79,6 @@ properties:
     description: "IP of each NATS cluster member."
   networks.apps:
     description: "The App network name"
-  syslog_aggregator.address:
-    description: "IP address for syslog aggregator"
-  syslog_aggregator.port:
-    description: "Port of syslog aggregator"
   uaa.clients.login.secret:
     description:
   uaa.dump_requests:

--- a/jobs/login/templates/syslog_forwarder.conf.erb
+++ b/jobs/login/templates/syslog_forwarder.conf.erb
@@ -32,7 +32,15 @@ template(name="CfLogTemplate" type="list") {
         property(name="msg")
 }
 
+<% case properties.syslog_aggregator.transport
+     when "relp" %>
+$ModLoad omrelp
+:programname, startswith, "vcap." :omrelp:<%= address %>:<%= port %>;CfLogTemplate
+<%   when "udp" %>
+:programname, startswith, "vcap." @<%= address %>:<%= port %>;CfLogTemplate
+<%   else %>
 :programname, startswith, "vcap." @@<%= address %>:<%= port %>;CfLogTemplate
+<% end %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/nats/spec
+++ b/jobs/nats/spec
@@ -13,6 +13,9 @@ packages:
   - ruby
   - syslog_aggregator
 properties:
+  syslog_aggregator:
+    description: "Syslog Aggregator properties."
+
   networks.apps:
     description:
   nats.use_gnatsd:
@@ -36,7 +39,3 @@ properties:
   nats.trace:
     description: "Enable trace logging output."
     default: false
-  syslog_aggregator.address:
-    description: "The address of the syslog_aggregator job."
-  syslog_aggregator.port:
-    description: "The port used by the syslog_aggregator job."

--- a/jobs/nats/templates/syslog_forwarder.conf.erb
+++ b/jobs/nats/templates/syslog_forwarder.conf.erb
@@ -28,7 +28,15 @@ template(name="CfLogTemplate" type="list") {
         property(name="msg")
 }
 
+<% case properties.syslog_aggregator.transport
+     when "relp" %>
+$ModLoad omrelp
+:programname, startswith, "vcap." :omrelp:<%= address %>:<%= port %>;CfLogTemplate
+<%   when "udp" %>
+:programname, startswith, "vcap." @<%= address %>:<%= port %>;CfLogTemplate
+<%   else %>
 :programname, startswith, "vcap." @@<%= address %>:<%= port %>;CfLogTemplate
+<% end %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/nats_stream_forwarder/spec
+++ b/jobs/nats_stream_forwarder/spec
@@ -10,6 +10,9 @@ packages:
   - nats
   - syslog_aggregator
 properties:
+  syslog_aggregator:
+    description: "Syslog Aggregator properties."
+
   nats_props:
     description:
     default: "nats"
@@ -23,7 +26,3 @@ properties:
     description: "NATS address"
   nats.port:
     description: "The port for the NATS server to listen on."
-  syslog_aggregator.address:
-    description: "The address of the syslog_aggregator job."
-  syslog_aggregator.port:
-    description: "The port used by the syslog_aggregator job."

--- a/jobs/nats_stream_forwarder/templates/syslog_forwarder.conf.erb
+++ b/jobs/nats_stream_forwarder/templates/syslog_forwarder.conf.erb
@@ -28,7 +28,15 @@ template(name="CfLogTemplate" type="list") {
         property(name="msg")
 }
 
+<% case properties.syslog_aggregator.transport
+     when "relp" %>
+$ModLoad omrelp
+:programname, startswith, "vcap." :omrelp:<%= address %>:<%= port %>;CfLogTemplate
+<%   when "udp" %>
+:programname, startswith, "vcap." @<%= address %>:<%= port %>;CfLogTemplate
+<%   else %>
 :programname, startswith, "vcap." @@<%= address %>:<%= port %>;CfLogTemplate
+<% end %>
 
   # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"

--- a/jobs/syslog_aggregator/spec
+++ b/jobs/syslog_aggregator/spec
@@ -31,6 +31,8 @@ properties:
     description:
   syslog_aggregator.relay_host_port:
     description:
+  syslog_aggregator.transport:
+    description: "Transport (other than tcp, which is the default) to be used when forwarding logs (relp|udp)."
   syslog_aggregator.address:
     description: "IP address for syslog aggregator"
   syslog_aggregator.port:

--- a/jobs/syslog_aggregator/templates/rsyslogd.conf.erb
+++ b/jobs/syslog_aggregator/templates/rsyslogd.conf.erb
@@ -2,9 +2,18 @@ $ModLoad imuxsock
 $MaxMessageSize 4k
 
 # Caveat - This always binds to all interfaces (cannot specify otherwise).
+$ModLoad imudp
 $ModLoad imtcp
 $InputTCPMaxSessions 1024
+<% case properties.syslog_aggregator.transport
+     when "relp" %>
+$ModLoad imrelp
+$InputRELPServerRun <%= properties.syslog_aggregator.port %>
+<%   when "udp" %>
+$UDPServerRun <%= properties.syslog_aggregator.port %>
+<%   else %>
 $InputTCPServerRun <%= properties.syslog_aggregator.port %>
+<% end %>
 $PrivDropToUser vcap
 $PrivDropToGroup vcap
 

--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -22,6 +22,9 @@ packages:
   - uaa
 
 properties:
+  syslog_aggregator:
+    description: "Syslog Aggregator properties."
+
   uaa.admin.client_secret:
     description:
   uaa.batch.password:
@@ -86,10 +89,6 @@ properties:
     description: "IP of each NATS cluster member."
   networks.apps:
     description: "The App network name"
-  syslog_aggregator.address:
-    description: "IP address for syslog aggregator"
-  syslog_aggregator.port:
-    description: "Port of syslog aggregator"
   uaadb.address:
     description: "The UAA database IP address"
   uaadb.databases:

--- a/jobs/uaa/templates/syslog_forwarder.conf.erb
+++ b/jobs/uaa/templates/syslog_forwarder.conf.erb
@@ -32,7 +32,15 @@ template(name="CfLogTemplate" type="list") {
         property(name="msg")
 }
 
+<% case properties.syslog_aggregator.transport
+     when "relp" %>
+$ModLoad omrelp
+:programname, startswith, "vcap." :omrelp:<%= address %>:<%= port %>;CfLogTemplate
+<%   when "udp" %>
+:programname, startswith, "vcap." @<%= address %>:<%= port %>;CfLogTemplate
+<%   else %>
 :programname, startswith, "vcap." @@<%= address %>:<%= port %>;CfLogTemplate
+<% end %>
 
 # Log vcap messages locally, too
 #$template VcapComponentLogFile, "/var/log/%programname:6:$%/%programname:6:$%.log"


### PR DESCRIPTION
This is necessary because of commit a0c7a2ef9efcc0ae3f3053812afba8dfdfe7e025. It changed the forwarding from RELP to TCP.

I understand you guys are looking to remove the syslog_aggregator job altogether, however this allows it to continue working for the time being.
