### PR TITLE
Problem connecting blob storage with default path_style

### DIFF
--- a/templates/cf-infrastructure-aws.yml
+++ b/templates/cf-infrastructure-aws.yml
@@ -7,6 +7,7 @@ meta:
     provider: AWS
     aws_access_key_id: (( properties.template_only.aws.access_key_id ))
     aws_secret_access_key: (( properties.template_only.aws.secret_access_key ))
+    path_style: true
 
   stemcell:
     name: bosh-aws-xen-ubuntu


### PR DESCRIPTION
The default behavior of fog ist to add the bucket name in front if the s3 URL. This results in a hostname does not match the server certificate (OpenSSL::SSL::SSLError) exception in the cloud_controller.
