### PR TITLE
Upgrade UAA and login server

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -558,3 +558,13 @@ nginx/newrelic_nginx_agent.tar.gz:
   sha: !binary |-
     OThhMWIxMDQ3NTM3MTcwNTkzMmZlYTQ3NjlmOGFjMWIwNDUxMTA2Zg==
   size: 5222
+login/cloudfoundry-login-server-1.4.2.war:
+  object_id: a7e73806-e19c-4cb7-83ca-8b162c913731
+  sha: !binary |-
+    NzkyZTg2YTI0MTA4NWM4NjJiNGE1Y2ZmOTZlOGRiMzc3MjI2ZDAxYw==
+  size: 24484572
+uaa/cloudfoundry-identity-uaa-1.5.4.war:
+  object_id: 32608956-9c23-489d-8f74-36b5b98c2a36
+  sha: !binary |-
+    MjRlOTBiN2Q4NDBmNDczMTczNzAzM2YyMjgyZDRmODNjYTM4NGMzYQ==
+  size: 21185239

--- a/packages/login/packaging
+++ b/packages/login/packaging
@@ -19,7 +19,7 @@ mv apache-tomcat-7.0.42 tomcat
 
 cd tomcat
 rm -rf webapps/*
-cp -a ${BOSH_COMPILE_TARGET}/login/cloudfoundry-login-server-1.4.1.war webapps/ROOT.war
+cp -a ${BOSH_COMPILE_TARGET}/login/cloudfoundry-login-server-1.4.2.war webapps/ROOT.war
 cp -a ${BOSH_COMPILE_TARGET}/uaa/cloudfoundry-identity-varz-1.0.2.war webapps/varz.war
 
 cd ${BOSH_INSTALL_TARGET}

--- a/packages/uaa/packaging
+++ b/packages/uaa/packaging
@@ -19,7 +19,7 @@ mv apache-tomcat-7.0.42 tomcat
 
 cd tomcat
 rm -rf webapps/*
-cp -a ${BOSH_COMPILE_TARGET}/uaa/cloudfoundry-identity-uaa-1.5.3.war webapps/ROOT.war
+cp -a ${BOSH_COMPILE_TARGET}/uaa/cloudfoundry-identity-uaa-1.5.4.war webapps/ROOT.war
 cp -a ${BOSH_COMPILE_TARGET}/uaa/cloudfoundry-identity-batch-1.0.2.war webapps/batch.war
 cp -a ${BOSH_COMPILE_TARGET}/uaa/cloudfoundry-identity-varz-1.0.2.war webapps/varz.war
 


### PR DESCRIPTION
This PR should only be merged if PR https://github.com/cloudfoundry/cf-release/pull/313 is rejected. It ensures that the UAA and login server still get upgraded.
