### PR TITLE
use same etcd data directory regardless of version

### DIFF
--- a/jobs/etcd/templates/etcd_ctl.erb
+++ b/jobs/etcd/templates/etcd_ctl.erb
@@ -1,11 +1,9 @@
 #!/bin/bash
 
-ETCD_VERSION="0.3.0"
-
 RUN_DIR=/var/vcap/sys/run/etcd
 LOG_DIR=/var/vcap/sys/log/etcd
 PIDFILE=$RUN_DIR/etcd.pid
-WORK_DIR=/var/vcap/store/etcd-$ETCD_VERSION
+WORK_DIR=/var/vcap/store/etcd
 
 source /var/vcap/packages/common/utils.sh
 


### PR DESCRIPTION
This introduces a known issue next deploy, but prevents it from happening
every time we upgrade the etcd version. The fix is to stop all etcds, blow
away their data directories, and start them again.

[finishes #66790592]

Signed-off-by: Alex Suraci asuraci@pivotallabs.com
