### PR TITLE
Allow external login server

### DIFF
--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -102,7 +102,6 @@ properties:
 
   login:
     url: ~
-    enabled: ~
     catalina_opts: (( merge ))
     uaa_certificate: ~
     protocol: https


### PR DESCRIPTION
Allow the following properties to be set via stub:
- [login.url](https://github.com/cloudfoundry/cf-release/blob/master/jobs/cloud_controller_ng/spec#L317-L318)
- [uaa.login.client_secret](https://github.com/cloudfoundry/cf-release/blob/master/jobs/uaa/spec#L117-L118)
