### PR TITLE
Use the collector namespace for graphite host and port.

### DIFF
--- a/jobs/collector/spec
+++ b/jobs/collector/spec
@@ -30,7 +30,7 @@ properties:
   collector.datadog_application_key:
     description: "Datadog application key"
   collector.deployment_name:
-    description: "name for this bosh deployment. All metrics will be tagged with deployment:XXX when sending them to CloudWatch and Datadog"
+    description: "name for this bosh deployment. All metrics will be tagged with deployment:XXX when sending them to CloudWatch, Datadog and Graphite"
   collector.intervals.discover:
     description: "the interval in seconds that the collector attempts to discover components"
     default: 60
@@ -61,6 +61,10 @@ properties:
   collector.use_graphite:
     description: "enable Graphite plugin"
     default: false
+  collector.graphite.address:
+    description: "IP address of Graphite"
+  collector.graphite.port:
+    description: "TCP port of Graphite"
   nats.address:
     description: "NATS address"
   nats.password:
@@ -73,7 +77,3 @@ properties:
     description: "IP address of OpenTsdb"
   opentsdb.port:
     description: "TCP port of OpenTsdb"
-  graphite.address:
-    description: "IP address of Graphite"
-  graphite.port:
-    description: "TCP port of Graphite"

--- a/jobs/collector/templates/config.yml.erb
+++ b/jobs/collector/templates/config.yml.erb
@@ -16,8 +16,8 @@ tsdb:
 
 <% if properties.collector && properties.collector.use_graphite %>
 graphite:
-  host: <%= properties.graphite.address %>
-  port: <%= properties.graphite.port %>
+  host: <%= properties.collector.graphite.address %>
+  port: <%= properties.collector.graphite.port %>
 <% end %>
 
 <% if properties.collector && properties.collector.use_aws_cloudwatch %>


### PR DESCRIPTION
Enables one to have 

```
properties:
  collector:
    use_graphite: true
    graphite:
      address: 10.220.0.234
      port: 2003
```

instead of

```
properties:
  collector:
    use_graphite: true

  graphite:
    address: 10.220.0.234
    port: 2003
```

in the manifest.
