### PR TITLE
Add properties to jobs/postgres/spec so it can be co-located

### DIFF
--- a/jobs/postgres/spec
+++ b/jobs/postgres/spec
@@ -7,3 +7,4 @@ templates:
 packages:
   - common
   - postgres
+properties: {}


### PR DESCRIPTION
Since job: debian_nfs_server gained properties - https://github.com/cloudfoundry/cf-release/commit/9cce7e1d0deb17953d53ea98400ebdb4cef60ac8 - you can no longer co-locate `debian_nfs_server` and `postgres` (useful in smaller CF deployments)

Eg; if your `deployment_manifest.yml` contains:

```
jobs:
  - name: data
    release: cf
    templates:
      - name: postgres
      - name: debian_nfs_server
```

`bosh deploy` will fail with:

```
Error 80010: Job `data' has specs with conflicting property definition styles between its job spec 
templates.  This may occur if colocating jobs, one of which has a spec file including `properties' and 
one which doesn't.
```

The fix is really simple; just add an empty `properties: {}` to the `postgres` job spec; which is what this PR does.
