### PR TITLE
Adding ability in spiff template to override properties.scim.userids_ena...

### DIFF
--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -119,6 +119,7 @@ properties:
     no_ssl: false
 
     scim:
+      userids_enabled: (( merge || false ))
       users: (( merge ))
 
     jwt:


### PR DESCRIPTION
Adding ability in spiff template to override properties.scim.userids_enabled property

See related thread at https://groups.google.com/a/cloudfoundry.org/d/msg/vcap-dev/xC8zK5i3s-4/94_69HXaZrwJ
