### PR TITLE
Adjust dotGit folder during uaa/login pre_packaging

### DIFF
--- a/packages/login/pre_packaging
+++ b/packages/login/pre_packaging
@@ -33,13 +33,19 @@ fi
 #setup Java and Maven paths
 export PATH=$MAVEN_HOME/bin:$JAVA_HOME/bin:$PATH
 
+#setup .git directory
+GIT_DIR=${RELEASE_DIR}/src/login/.git
+if [ -f "${GIT_DIR}" ]; then
+  GIT_DIR=$(sed "/^gitdir: / s/gitdir: //" ${GIT_DIR})
+fi
+
 #Maven options for building
 export MAVEN_OPTS='-Xmx1g -XX:MaxPermSize=512m'
 
 #build cloud foundry war
 cd ${BUILD_DIR}/login
 mvn clean
-mvn -U -e -B package -DskipTests=true -Ddot.git.directory=${RELEASE_DIR}/src/login/.git
+mvn -U -e -B package -DskipTests=true -Ddot.git.directory=${GIT_DIR}
 cp login-server/target/cloudfoundry-login-server-*.war ${BUILD_DIR}/login/cloudfoundry-login-server.war
 
 #remove build resources

--- a/packages/uaa/pre_packaging
+++ b/packages/uaa/pre_packaging
@@ -33,13 +33,19 @@ fi
 #setup Java and Maven paths
 export PATH=$MAVEN_HOME/bin:$JAVA_HOME/bin:$PATH
 
+#setup .git directory
+GIT_DIR=${RELEASE_DIR}/src/uaa/.git
+if [ -f "${GIT_DIR}" ]; then
+  GIT_DIR=$(sed "/^gitdir: / s/gitdir: //" ${GIT_DIR})
+fi
+
 #Maven options for building
 export MAVEN_OPTS='-Xmx1g -XX:MaxPermSize=512m'
 
 #build cloud foundry war
 cd ${BUILD_DIR}/uaa
 mvn clean
-mvn -U -e -B package -DskipTests=true -Ddot.git.directory=${RELEASE_DIR}/src/uaa/.git
+mvn -U -e -B package -DskipTests=true -Ddot.git.directory=${GIT_DIR}
 cp uaa/target/cloudfoundry-identity-uaa-*.war ${BUILD_DIR}/uaa/cloudfoundry-identity-uaa.war
 
 #remove build resources


### PR DESCRIPTION
I've just ran into a problem building a v164 dev release, due to an issue with the uaa pre_packaging script.

https://gist.github.com/wdneto/46ec570845f6c50c3080

This PR adjusts the dotGit directory to the actual submodule folder, and allows the release to build successfully.
