### PR TITLE
Restore max_package_size configuration for CC.

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -231,6 +231,9 @@ properties:
   ccng.packages.app_package_directory_key:
     description: "Directory (bucket) used store app packages.  It does not have be pre-created."
     default: "cc-packages"
+  ccng.packages.max_package_size:
+    description: "Maximum size of application package"
+    default: 536870912
   ccng.packages.fog_connection:
     description: "Fog connection hash"
   ccng.packages.cdn.uri:

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -234,6 +234,9 @@ properties:
   ccng.packages.app_package_directory_key:
     description: "Directory (bucket) used store app packages.  It does not have be pre-created."
     default: "cc-packages"
+  ccng.packages.max_package_size:
+    description: "Maximum size of application package"
+    default: 536870912
   ccng.packages.fog_connection:
     description: "Fog connection hash"
   ccng.packages.cdn.uri:


### PR DESCRIPTION
Refactor of cc jobs dropped max package config.
