### PR TITLE
revert uaa config change

### DIFF
--- a/jobs/uaa/templates/uaa.yml.erb
+++ b/jobs/uaa/templates/uaa.yml.erb
@@ -111,4 +111,6 @@ require_https: <%= properties.uaa.require_https %>
 <% if !properties.uaa.dump_requests.nil? %>
 dump_requests: <%= properties.uaa.dump_requests %>
 <% end %>
+<% if properties.uaa.login && !properties.uaa.login.addnew.nil? %>
 login.addnew: <%= properties.uaa.login.addnew %>
+<% end %>


### PR DESCRIPTION
About a month ago, this PR:  
  https://github.com/duglin/cf-release/commit/f15798c92cb2d32d42147fbeea393a60abe069dd
modified cf-release's uaa.ym.erb and broke the UAA login server.  This PR reverts that change.

More details:

Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'loginAuthenticationMgr' defined in ServletContext resource [/WEB-INF/spring/login-server-security.xml]: Initialization of bean failed; nested exception is org.springframework.beans.TypeMismatchException: Failed to convert property value of type 'java.lang.String' to required type 'boolean' for property 'addNewAccounts'; nested exception is java.lang.IllegalArgumentException: Invalid boolean

appears in the uaa logs, because in the uaa war file's login-server-security.xml file there's:
   <property name="addNewAccounts" value="${login.addnew:false}"

but if someone puts:
   login.addnew:
in their bosh manifest file, the value in the xml will be an empty string - which causes the parsing error.

The current uaa.yml.erb file looks like:

login.addnew: <%= properties.uaa.login.addnew %>

it used to be:

<% if properties.uaa.login && !properties.uaa.login.addnew.nil? %>
login.addnew: <%= properties.uaa.login.addnew %>
<% end %>

which doesn't put the property in the bosh yml file at all if not set with a value, and is therefore more correct.

We need to revert this for cases where people do not set properties.uaa.login.addnew in the their bosh yml.  Without this change UAA won't start properly the various CF components that try to auth to it will fail to start.  I think the referenced PR, incorrectly, assumed everyone set properties.uaa.login.addnew - which isn't the case, at least not for us :-)
