### PR TITLE
update ha_proxy_z1 in cf-job.yml to merge network config

### DIFF
--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -29,9 +29,7 @@ jobs:
     template: haproxy
     instances: 0
     resource_pool: router_z1
-    networks:
-      - name: cf1
-        static_ips: ~
+    networks: (( merge || nil ))
     properties:
       networks: (( meta.networks.z1 ))
       ha_proxy:


### PR DESCRIPTION
This is needed to support the case where we run haproxy in
an external -> internal network config. It needs two networks
and the previous config hardcodes for a single network.

TH
