### PR TITLE
Make etcd timeouts configurable

### DIFF
--- a/jobs/etcd/spec
+++ b/jobs/etcd/spec
@@ -7,6 +7,12 @@ packages:
   - etcd
 
 properties:
+  heartbeat_interval_in_milliseconds:
+    description: "Interval between heartbeats. See https://coreos.com/docs/cluster-management/debugging/etcd-tuning"
+    default: 50
+  election_timeout_in_milliseconds:
+    description: "Time without recieving a heartbeat before peer should attempt to become leader. See https://coreos.com/docs/cluster-management/debugging/etcd-tuning"
+    default: 1000
   leader_ip:
     description: "IP of ETCD cluster leader"
   networks.apps:

--- a/jobs/etcd/templates/etcd_ctl.erb
+++ b/jobs/etcd/templates/etcd_ctl.erb
@@ -29,8 +29,8 @@ case $1 in
         <% if_p("leader_ip") do |leader_ip| %>\
         -peers=<%= leader_ip %>:7001 \
         <% end %>\
-        -peer-heartbeat-timeout=50 \
-        -peer-election-timeout=1000 \
+        -peer-heartbeat-timeout=<%= p("heartbeat_interval_in_milliseconds") %>\
+        -peer-election-timeout=<%= p("election_timeout_in_milliseconds") %>\
         1>>$LOG_DIR/etcd.stdout.log \
         2>>$LOG_DIR/etcd.stderr.log
     ;;


### PR DESCRIPTION
As the [etcd docs](https://coreos.com/docs/cluster-management/debugging/etcd-tuning/) say, there are various trade-offs, including network ping time, to consider when choosing the etcd heartbeat/election timeout values which will differ between environments.

In one of our environments we experienced repeated failures on etcd cluster startup unless we upped the timeout and election values below (from 50 to 100ms). This PR retains the current defaults, but makes them configurable so that they can be overridden in environments with slower networks.
