### PR TITLE
nats_stream_forwarder

### DIFF
--- a/jobs/nats_stream_forwarder/spec
+++ b/jobs/nats_stream_forwarder/spec
@@ -21,16 +21,14 @@ properties:
     description: "Transport to be used when forwarding logs (tcp|udp|relp)."
     default: "tcp"
 
-  nats_props:
-    description:
-    default: "nats"
   networks.apps:
     description:
   nats.user:
     description: "Username for server authentication."
   nats.password:
     description: "Password for server authentication."
-  nats.address:
-    description: "NATS address"
   nats.port:
     description: "The port for the NATS server to listen on."
+  nats.machines:
+    description: "IP of each NATS cluster member."
+

--- a/jobs/nats_stream_forwarder/templates/nats_stream_forwarder_ctl.erb
+++ b/jobs/nats_stream_forwarder/templates/nats_stream_forwarder_ctl.erb
@@ -1,4 +1,5 @@
 #!/bin/bash
+<% self_ip = spec.networks.send(properties.networks.apps).ip %>
 
 RUN_DIR=/var/vcap/sys/run/nats_stream_forwarder
 LOG_DIR=/var/vcap/sys/log/nats_stream_forwarder
@@ -24,7 +25,7 @@ case $1 in
     <% end %>
 
     echo $$ > $PIDFILE
-    exec bundle exec $BIN_DIR/nats_stream_forwarder.rb 'nats://<%= p("nats.user") %>:<%= p("nats.password") %>@<%= p("nats.address") %>:<%= p("nats.port") %>' \
+    exec bundle exec $BIN_DIR/nats_stream_forwarder.rb 'nats://<%= p("nats.user") %>:<%= p("nats.password") %>@<%= self_ip %>:<%= p("nats.port") %>' \
       >>$LOG_DIR/nats_stream_forwarder.stdout.log \
       2>>$LOG_DIR/nats_stream_forwarder.stderr.log
 


### PR DESCRIPTION
Following on from the use of gnatsd, instead of nats, because the stream forwarder is deployed together with nats, we started getting duplicate messages. Both forwarders were connecting to the same nats instance which didn't make sense for the purposes of troubleshooting.

This makes the stream forwarder connect to itself, which helps being able to identify a disagreeing nats cluster.

I'm not sure, however, how much value is there in connecting to each member of the nats cluster, so its possible that we should instead move the stream_forwarder to a separate job, connecting to one of the nats.machines addresses (and falling back to another in case it goes away).
