### PR TITLE
Java Buildpack 2.1.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -517,13 +517,13 @@ uaa/openjdk-1.7.0-u40-unofficial-macosx-x86_64-bundle.tgz:
   sha: !binary |-
     YWM3ZmViYzViYmZmMmRlZGY4YWRkNjI0YTcyN2E0YzBhYzZjM2QxMA==
   size: 65991397
-java-buildpack/java-buildpack-offline-v2.1.zip:
-  object_id: ac700d8a-1d56-45eb-b184-3ed1fcf6d820
+java-buildpack/java-buildpack-2.1.1.zip:
+  object_id: 94466f81-32a7-47cd-8cd7-f38a9ac89422
   sha: !binary |-
-    ODhlOWI4ZWFmZTA0NjA2ZTM2MDg1YmU2ZGMzNGU1MWRmYWFiN2I1Nw==
-  size: 190464001
-java-buildpack/java-buildpack-v2.1.zip:
-  object_id: 8b3e910d-f4d2-41e9-ae78-d385ccf57a0c
+    YWIzYTQwOTU0OGJlNGMzZTY3NmU4MDIyODkwM2MxNTVmZTQxZGIxMQ==
+  size: 136320
+java-buildpack/java-buildpack-offline-2.1.1.zip:
+  object_id: eed2f131-966f-49e4-bef1-bf7d9facfb6d
   sha: !binary |-
-    NDVhZThjZjc1YWRhODFlNjUzZTBiMzA3NTE3ZGRlOWZmYzczNTM3NQ==
-  size: 136199
+    MDRlMzVmNGFlZGE1NzE2MTEwODJmNjk0NzNkMmE3OGJiYmJkMWNhYw==
+  size: 188483894

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -18,6 +18,7 @@ packages:
   - ruby
   - syslog_aggregator
   - buildpack_java
+  - buildpack_java_offline
   - buildpack_ruby
   - buildpack_nodejs
 

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -28,6 +28,7 @@ packages:
   - ruby
   - syslog_aggregator
   - buildpack_java
+  - buildpack_java_offline
   - buildpack_ruby
   - buildpack_nodejs
 

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -21,6 +21,7 @@ packages:
   - ruby
   - syslog_aggregator
   - buildpack_java
+  - buildpack_java_offline
   - buildpack_ruby
   - buildpack_nodejs
 

--- a/packages/buildpack_java/packaging
+++ b/packages/buildpack_java/packaging
@@ -1,3 +1,3 @@
 set -e
 
-cp java-buildpack/java-buildpack-v2.1.zip ${BOSH_INSTALL_TARGET}
+cp java-buildpack/java-buildpack-v2.1.1.zip ${BOSH_INSTALL_TARGET}

--- a/packages/buildpack_java/spec
+++ b/packages/buildpack_java/spec
@@ -2,4 +2,4 @@
 name: buildpack_java
 
 files:
-  - java-buildpack/java-buildpack-v2.1.zip
+  - java-buildpack/java-buildpack-v2.1.1.zip

--- a/packages/buildpack_java_offline/packaging
+++ b/packages/buildpack_java_offline/packaging
@@ -1,3 +1,3 @@
 set -e
 
-cp java-buildpack/java-buildpack-offline-v2.1.zip ${BOSH_INSTALL_TARGET}
+cp java-buildpack/java-buildpack-offline-v2.1.1.zip ${BOSH_INSTALL_TARGET}

--- a/packages/buildpack_java_offline/spec
+++ b/packages/buildpack_java_offline/spec
@@ -2,4 +2,4 @@
 name: buildpack_java_offline
 
 files:
-  - java-buildpack/java-buildpack-offline-v2.1.zip
+  - java-buildpack/java-buildpack-offline-v2.1.1.zip


### PR DESCRIPTION
This change updates the Java Buildpack to version `2.1.1`.  Version `2.1.1` fixes a bug running Spring Boot applications.

Both the online and offline buildpacks are updated as part of this change.
