### PR TITLE
Java Buildpack 2.1.2

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -517,13 +517,13 @@ uaa/openjdk-1.7.0-u40-unofficial-macosx-x86_64-bundle.tgz:
   sha: !binary |-
     YWM3ZmViYzViYmZmMmRlZGY4YWRkNjI0YTcyN2E0YzBhYzZjM2QxMA==
   size: 65991397
-java-buildpack/java-buildpack-v2.1.1.zip:
-  object_id: 94466f81-32a7-47cd-8cd7-f38a9ac89422
+java-buildpack/java-buildpack-offline-v2.1.2.zip:
+  object_id: 01b7885f-8040-477a-815f-df60522762ee
   sha: !binary |-
-    YWIzYTQwOTU0OGJlNGMzZTY3NmU4MDIyODkwM2MxNTVmZTQxZGIxMQ==
-  size: 136320
-java-buildpack/java-buildpack-offline-v2.1.1.zip:
-  object_id: eed2f131-966f-49e4-bef1-bf7d9facfb6d
+    NDY0NzU4NjM3NWI0MTM1MTI2MTEwZmRiN2Y1ZDlmYWFhNGVhY2U1YQ==
+  size: 218797643
+java-buildpack/java-buildpack-v2.1.2.zip:
+  object_id: b0faa1ca-cfb9-4525-b414-0a416ce1eca7
   sha: !binary |-
-    MDRlMzVmNGFlZGE1NzE2MTEwODJmNjk0NzNkMmE3OGJiYmJkMWNhYw==
-  size: 188483894
+    MGVhYzI0MWRjYzZiOGRlZjUwNjY0NDdhZTYyNDExYmZhNzA1NzJlMA==
+  size: 136315

--- a/packages/buildpack_java/packaging
+++ b/packages/buildpack_java/packaging
@@ -1,3 +1,3 @@
 set -e
 
-cp java-buildpack/java-buildpack-v2.1.1.zip ${BOSH_INSTALL_TARGET}
+cp java-buildpack/java-buildpack-v2.1.2.zip ${BOSH_INSTALL_TARGET}

--- a/packages/buildpack_java/spec
+++ b/packages/buildpack_java/spec
@@ -2,4 +2,4 @@
 name: buildpack_java
 
 files:
-  - java-buildpack/java-buildpack-v2.1.1.zip
+  - java-buildpack/java-buildpack-v2.1.2.zip

--- a/packages/buildpack_java_offline/packaging
+++ b/packages/buildpack_java_offline/packaging
@@ -1,3 +1,3 @@
 set -e
 
-cp java-buildpack/java-buildpack-offline-v2.1.1.zip ${BOSH_INSTALL_TARGET}
+cp java-buildpack/java-buildpack-offline-v2.1.2.zip ${BOSH_INSTALL_TARGET}

--- a/packages/buildpack_java_offline/spec
+++ b/packages/buildpack_java_offline/spec
@@ -2,4 +2,4 @@
 name: buildpack_java_offline
 
 files:
-  - java-buildpack/java-buildpack-offline-v2.1.1.zip
+  - java-buildpack/java-buildpack-offline-v2.1.2.zip


### PR DESCRIPTION
This change updates the Java Buildpack to version `2.1.2`.  Version `2.1.2` fixes a bug in Java Buildpack Auto-reconfiguration and adds support for Ubuntu 14.04 (Trusty Tahr).

Both the online and offline buildpacks are updated as part of this change.
