### PR TITLE
Move alert level to ~80% of restart RAM usage

### DIFF
--- a/jobs/nats/monit
+++ b/jobs/nats/monit
@@ -3,6 +3,6 @@ check process nats
   start program "/var/vcap/jobs/nats/bin/nats_ctl start"
   stop program "/var/vcap/jobs/nats/bin/nats_ctl stop"
   group vcap
-  if totalmem > 500 Mb for 2 cycles then alert
+  if totalmem > 2300 Mb for 2 cycles then alert
   if totalmem > 3000 Mb then restart
 


### PR DESCRIPTION
- When we switched to using gnatsd in a cluster, RAM usage went up and we're not sure of its ceiling. The assumption is that doing clustered operations takes more RAM.
- The RAM usage alert level was ~17% of RAM where monit will restart the app. Moving to a more reasonable ~80%.
