### PR TITLE
Switch login job to look at uaa.login.client_secret only

### DIFF
--- a/jobs/login/spec
+++ b/jobs/login/spec
@@ -85,8 +85,6 @@ properties:
     description: "IP of each NATS cluster member."
   networks.apps:
     description: "The App network name"
-  uaa.clients.login.secret:
-    description:
   uaa.dump_requests:
     description:
   uaa.login.client_secret:

--- a/jobs/login/templates/login.yml.erb
+++ b/jobs/login/templates/login.yml.erb
@@ -31,11 +31,7 @@ links: <% properties.login.links.marshal_dump.each do |id,url| %>
 <% end %>
 
 # The secret that this login server will use to authenticate to the uaa
-<% if !properties.uaa.clients || !properties.uaa.clients.login %>
 LOGIN_SECRET: <%= properties.uaa.login.client_secret %>
-<% else %>
-LOGIN_SECRET: <%= properties.uaa.clients.login.secret %>
-<% end %>
 <% if !properties.uaa.require_https.nil? %>
 require_https: <%= properties.uaa.require_https %>
 <% end %>

--- a/templates/cf-infrastructure-warden.yml
+++ b/templates/cf-infrastructure-warden.yml
@@ -88,10 +88,9 @@ properties:
     batch:
       username: batch-username
       password: batch-password
+    login:
+      client_secret: login-secret
     clients:
-      login:
-        secret: login-secret
-        redirect-uri: (( "http://login." domain ))
       cc_service_broker_client:
         secret: cc-broker-secret
         scope: cloud_controller.write,openid,cloud_controller.read

--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -150,17 +150,10 @@ properties:
       password: (( merge ))
     
     login:
-      client_secret: ~
+      client_secret: (( merge ))
       
     clients:
       <<: (( merge || nil ))
-      login:
-        override: true
-        scope: openid,oauth.approvals
-        authorities: oauth.login
-        secret: (( merge ))
-        authorized-grant-types: authorization_code,client_credentials,refresh_token
-        redirect-uri: (( "https://login." domain ))
       developer_console:
         override: true
         scope: openid,cloud_controller.read,cloud_controller.write,password.write,console.admin,console.support


### PR DESCRIPTION
This allows removal of the uaa.clients.login.secret from the login job spec,
thereby allowing the default UAA login client definition [1] to take place, if
the login client isn't present in the manifest, making login similar to other
default uaa clients.

When uaa.clients.login.secret is present in the login job spec, colocating UAA
and login on the same machine, and not specifying uaa.clients.login results in
an incorrect configuration for the login client in the uaa configuration.

This also allows for removal of clients that are specific to Pivotal's deploy
from deployment manifests without breaking default clients.

[1] https://github.com/cloudfoundry/cf-release/blob/master/jobs/uaa/templates/uaa.yml.erb#L80-L89
