### PR TITLE
UAA login client redirect-url should look at login.url property

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -118,3 +118,6 @@ properties:
     description:
   uaa_client_auth_credentials.username:
     description:
+
+  login.url:
+    description: "The URL for the login server."

--- a/jobs/uaa/templates/uaa.yml.erb
+++ b/jobs/uaa/templates/uaa.yml.erb
@@ -85,7 +85,7 @@ oauth:
       authorized-grant-types: authorization_code,client_credentials,refresh_token
       authorities: oauth.login
       scope: openid,oauth.approvals
-      redirect-uri: https://login.<%= properties.domain %>
+      redirect-uri: <%= properties.login.url %>
 <% end %>
 <% if properties.uaa.scim %>
 scim:

--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -113,7 +113,7 @@ properties:
     install_buildpacks: (( system_buildpacks user_buildpacks ))
 
   login:
-    url: ~
+    url: (( "https://login." domain ))
     catalina_opts: (( merge ))
     uaa_certificate: ~
     protocol: https


### PR DESCRIPTION
It seems to make sense to leverage the login.url property when creating the default login UAA client.
