### PR TITLE
Adding empty 'stacks' node to enable overriding in a stub.

### DIFF
--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -112,7 +112,7 @@ properties:
 
     install_buildpacks: (( system_buildpacks user_buildpacks ))
 
-    stacks:
+    stacks: ~
 
   login:
     url: ~


### PR DESCRIPTION
PR for #356

For IronFoundry, we need to be able to add in a custom stack (for Windows).

I created a stub that looks like the following:

```
properties:
  cc:
    stacks:
    - name: "lucid64"
      description: "Ubuntu 10.04"
    - name: "windows2012"
      description: "Windows Server 2012 (64-bit)"
```

But there is no placeholder in `templates/cf-properties.yml` to merge the value in.

The `stacks.yml.erb` contains:

```
stacks: <%= p("ccng.stacks", []).to_yaml.gsub("---", "") %>
```

Currently the value of the `stacks` array comes from the default value in the  `jobs/cloud_controller_ng/spec` file.

I was able to get this to work by adding a null `stacks` value to `templates/cf-properties.yml`:

```
properties:
...
  cc:
  ...
    stacks:
  ...
```

That allowed me to merge in a value via Spiff, and it still preserved the default values defined in `jobs/cloud_controller_ng/spec` if no value was provided via a Spiff stub.
