### PR TITLE
Add PWS Login Server link placeholders.

### DIFF
--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -123,6 +123,8 @@ properties:
       home: (( "https://console." domain ))
       passwd: (( "https://console." domain "/password_resets/new" ))
       signup: (( "https://console." domain "/register" ))
+      network: (( "https://network." domain ))
+      signup-network: (( "https://network." domain "/registrations/new" ))
 
   uaa:
     catalina_opts: (( merge ))


### PR DESCRIPTION
- To facilitate overriding them in cf-aws-stub (cloudfoundry/deployments-aws) for testing on A1.

This completes a pull request from @rmorgan on deployments-aws:
@see https://github.com/cloudfoundry/deployments-aws/pull/7

https://www.pivotaltracker.com/story/show/70697714

Thanks,
Rob Gallagher
