### PR TITLE
Update cf-jobs.yml

### DIFF
--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -474,7 +474,8 @@ properties:
 
   databases: ~
 
-  login: (( merge ))
+  login: (( merge || nil ))
+  saml_login (( merge || nil ))
 
   router:
     status:


### PR DESCRIPTION
add saml_login required for LDAP & SAML login-server config. Without this the base templates have to be modified. This allows the config to reside in a stub. saml_login replaces the login template as per : https://github.com/cloudfoundry/login-server/blob/4ba769242c6e069a5ab9ab9d961fac6107c4c001/login-server/README.md
