### PR TITLE
Expose ccng.directories.diagnostics config property

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -142,6 +142,7 @@ properties:
 
   ccng.directories.tmpdir:
     default: "/var/vcap/data/cloud_controller_ng/tmp"
+    description: "The directory to use for temporary files"
 
   ccng.external_protocol:
     default: "http"

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -152,6 +152,10 @@ properties:
 
   ccng.directories.tmpdir:
     default: "/var/vcap/data/cloud_controller_ng/tmp"
+    description: "The directory to use for temporary files"
+  ccng.directories.diagnostics:
+    default: "/var/vcap/data/cloud_controller_ng/diagnostics"
+    description: "The directory where operator requested diagnostic files should be placed"
 
   ccng.external_protocol:
     default: "http"

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -145,6 +145,7 @@ properties:
 
   ccng.directories.tmpdir:
     default: "/var/vcap/data/cloud_controller_ng/tmp"
+    description: "The directory to use for temporary files"
 
   ccng.external_protocol:
     default: "http"


### PR DESCRIPTION
Enable specification of output directory for USR1 diagnostic files from the cloud controller.

This is associated with story 69981718 and related to cloudfoundry/cloud_controller_ng#229
