### PR TITLE
Update template for latest warden stemcell

### DIFF
--- a/templates/cf-infrastructure-warden.yml
+++ b/templates/cf-infrastructure-warden.yml
@@ -6,7 +6,7 @@ meta:
     local_root: /var/vcap/store
 
   stemcell:
-    name: bosh-warden-boshlite-ubuntu
+    name: bosh-warden-boshlite-ubuntu-lucid-go_agent
     version: latest
 
 update:


### PR DESCRIPTION
The current `latest-bosh-stemcell-warden` is of the lucid/go-agent variety.  Update the template to reflect the new stemcell for new deployments.
