### PR TITLE
allow templating of cc.external_host

### DIFF
--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -49,6 +49,7 @@ properties:
     client_max_body_size: 1536M
 
     srv_api_uri: (( "https://api." domain ))
+    external_host: api
 
     bulk_api_password: (( merge ))
 


### PR DESCRIPTION
We use a different external host for our Cloud Controller and the current templates (as far as we can see) don't allow for overriding this unless there is this existing key set. This change adds in that key with the default value.
