### PR TITLE
updated git package to not depend on python

### DIFF
--- a/packages/git/packaging
+++ b/packages/git/packaging
@@ -4,5 +4,5 @@ tar xzf git/git-1.7.11.2.tar.gz
 
 cd git-1.7.11.2
 ./configure --prefix=${BOSH_INSTALL_TARGET}
-make NO_TCLTK=Yes
-make NO_TCLTK=Yes install
+make NO_TCLTK=Yes NO_PYTHON=Yes
+make NO_TCLTK=Yes NO_PYTHON=Yes install


### PR DESCRIPTION
needed for ubuntu trusty stemcell. cats passed after this.

@MarkKropf 
