### PR TITLE
adding postgres9 (9.3.4) as a job for migration

### DIFF
--- a/jobs/postgres9/monit
+++ b/jobs/postgres9/monit
@@ -1,0 +1,6 @@
+check process postgres
+  with pidfile /var/vcap/sys/run/postgres/postgres.pid
+  start program "/var/vcap/jobs/postgres9/bin/postgres_ctl start"
+  stop program "/var/vcap/jobs/postgres9/bin/postgres_ctl stop"
+  group vcap
+

--- a/jobs/postgres9/spec
+++ b/jobs/postgres9/spec
@@ -1,0 +1,10 @@
+---
+name: postgres9
+templates:
+  postgres_ctl.erb: bin/postgres_ctl
+  postgresql.conf.erb: config/postgresql.conf
+  pg_hba.conf.erb: config/pg_hba.conf
+  postgres_migrate.erb: bin/postgres_migrate
+packages:
+  - common
+  - postgres9

--- a/jobs/postgres9/templates/pg_hba.conf.erb
+++ b/jobs/postgres9/templates/pg_hba.conf.erb
@@ -1,0 +1,8 @@
+<% db = properties.send(properties.db) %>
+local   all             all                                     trust
+host    all             all             127.0.0.1/32            trust
+host    all             all             ::1/128                 trust
+host    all             all             0.0.0.0/0               md5
+<% db.roles.each do |role| %>
+host    all  <%= role.name %> 0.0.0.0/0 md5
+<% end %>

--- a/jobs/postgres9/templates/postgres_ctl.erb
+++ b/jobs/postgres9/templates/postgres_ctl.erb
@@ -1,0 +1,136 @@
+#!/bin/bash -e
+<% db = properties.send(properties.db) %>
+
+PACKAGE_DIR=/var/vcap/packages/postgres9
+JOB_DIR=/var/vcap/jobs/postgres9
+
+STORE_DIR=/var/vcap/store
+DATA_DIR=$STORE_DIR/postgres
+
+RUN_DIR=/var/vcap/sys/run/postgres
+LOG_DIR=/var/vcap/sys/log/postgres
+
+# external_pid_file in postgresql.conf takes care of
+# overwriting $PIDFILE with actual DB server pid
+PIDFILE=$RUN_DIR/postgres.pid
+
+HOST='0.0.0.0'
+PORT="<%= db.port %>"
+LD_LIBRARY_PATH=$PACKAGE_DIR/lib:$LD_LIBRARY_PATH
+
+source /var/vcap/packages/common/utils.sh
+
+case "$1" in
+  start)
+    pid_guard $PIDFILE "PostgreSQL"
+
+    # TODO: This script is responsible for both
+    # starting PostgreSQL and running some queries
+    # (create DBs, roles, applying grants). One problem
+    # that needs to be addressed in the future is that
+    # if some queries fail job is still considered running.
+    # Later we'll change it to use a more involved approach
+    # (i.e. script that brings DB to sync)
+
+    mkdir -p $RUN_DIR
+    chown vcap:vcap $RUN_DIR
+
+    echo $$ > $PIDFILE
+    chown vcap:vcap $PIDFILE
+
+    sysctl -w "kernel.shmmax=284934144"
+
+    if [ ! -d $STORE_DIR ]; then
+      echo "ERROR: storage directory doesn't exist"
+      echo "Please add persistent disk to this job"
+      exit 1
+    fi
+
+    if [ ! -d $LOG_DIR ]; then
+      mkdir -p $LOG_DIR
+      chown vcap:vcap $LOG_DIR
+    fi
+
+    if [ ! -d $DATA_DIR -o ! -f $DATA_DIR/postgresql.conf ]; then
+      mkdir -p $DATA_DIR
+      chown vcap:vcap $DATA_DIR
+
+      # initdb creates data directories
+      su - vcap -c "$PACKAGE_DIR/bin/initdb -E utf8 --locale en_US.UTF-8 -D $DATA_DIR"
+
+      mkdir -p $DATA_DIR/pg_log
+      chown vcap:vcap $DATA_DIR/pg_log
+    fi
+
+    cp $JOB_DIR/config/{postgresql,pg_hba}.conf $DATA_DIR
+    chown vcap:vcap $DATA_DIR/{postgresql,pg_hba}.conf
+
+    echo "Starting PostgreSQL: "
+    su - vcap -c "$PACKAGE_DIR/bin/pg_ctl -o \"-h $HOST -p $PORT\" \
+                  -w start -D $DATA_DIR -l \"$DATA_DIR/pg_log/startup.log\""
+
+    echo "PostgreSQL started successfully"
+
+    echo "Creating roles..."
+    <% db.roles.each do |role| %>
+      echo "Trying to create role <%= role.name %>..."
+      set +e
+      # TODO remove unused roles automatically
+      # Default permissions are: nosuperuser nologin inherit nocreatedb.
+      # Will fail if role already exists, which is OK
+      $PACKAGE_DIR/bin/psql -U vcap -p $PORT -d postgres \
+                            -c "CREATE ROLE \"<%= role.name %>\""
+      set -e
+
+      echo "Setting password for role <%= role.name %>..."
+      $PACKAGE_DIR/bin/psql -U vcap -p $PORT -d postgres \
+                            -c "ALTER ROLE \"<%= role.name %>\" \
+                                WITH LOGIN PASSWORD '<%= role.password %>'"
+    <% end %>
+
+    echo "Creating databases..."
+    <% db.databases.each do |database| %>
+      echo "Trying to create database <%= database.name %>..."
+      set +e
+      su - vcap -c "$PACKAGE_DIR/bin/createdb \"<%= database.name %>\" -p $PORT"
+      set -e
+
+      <% if database.citext %>
+        echo "Trying to install citext..."
+        set +e
+        $PACKAGE_DIR/bin/psql -U vcap -p $PORT \
+                              -d "<%= database.name %>" \
+                              -c "create extension citext WITH schema public"
+        set -e
+      <% end %>
+
+      <% if database.run_on_every_startup %>
+        <% database.run_on_every_startup.each do |query| %>
+          $PACKAGE_DIR/bin/psql -U vcap -p $PORT \
+                                -d "<%= database.name %>" \
+                                -c "<%= query %>"
+        <% end %>
+      <% end %>
+    <% end %>
+
+    ;;
+
+  stop)
+    echo "Stopping PostgreSQL: "
+    su - vcap -c "$PACKAGE_DIR/bin/pg_ctl stop -m fast -w -D $DATA_DIR"
+    wait_pidfile $PIDFILE
+
+    ;;
+
+  status)
+    su - vcap -c "$PACKAGE_DIR/bin/pg_ctl status -D $DATA_DIR"
+
+    ;;
+
+  *)
+    echo "Usage: $0 {start|stop|status}"
+    exit 1
+
+    ;;
+
+esac

--- a/jobs/postgres9/templates/postgres_migrate.erb
+++ b/jobs/postgres9/templates/postgres_migrate.erb
@@ -1,0 +1,41 @@
+#!/bin/bash -e
+<% db = properties.send(properties.db) %>
+
+STORE_DIR=/var/vcap/store
+DATA_DIR=$STORE_DIR/postgres
+PACKAGE_DIR=/var/vcap/packages/postgres9
+JOB_DIR=/var/vcap/jobs/postgres9
+
+LD_LIBRARY_PATH=$PACKAGE_DIR/lib:$LD_LIBRARY_PATH
+PATH=$PACKAGE_DIR/bin:$PATH
+
+source /var/vcap/packages/common/utils.sh
+
+
+cat /dev/null > ~/.pgpass
+<% db.databases.each do |database| %>
+  <% thisdb = properties.send(database.name) %> 
+
+  <% thisdb.roles.each do |role| %>
+    if [ "<%= role.tag %>" == "admin" ]; then
+      echo "<%= db.address %>:<%= db.port %>:<%= database.name %>:<%= role.name %>:<%= role.password %>" >> ~/.pgpass
+    fi
+  <% end %>
+<% end %>
+
+chmod 600 ~/.pgpass
+
+<% db.databases.each do |database| %>
+  <% thisdb = properties.send(database.name) %> 
+
+  <% thisdb.roles.each do |role| %>
+    if [ "<%= role.tag %>" == "admin" ]; then
+      $USER = <%= role.name %>
+    fi
+  <% end %>
+  
+  pg_dump  <%= database.name %>  -h <%= db.address %> -p <%= db.port %> -U $USER -f <%= database.name %>.sql
+ 
+  psql -U vcap -p <%= db.port %> -d <%= database.name %> -f  <%= database.name %>.sql
+<% end %>
+

--- a/jobs/postgres9/templates/postgresql.conf.erb
+++ b/jobs/postgres9/templates/postgresql.conf.erb
@@ -1,0 +1,40 @@
+<% db = properties.send(properties.db) %>
+
+# Control the available listen_addresses via
+# deployment manifest - add networks to the job
+#
+# For example, to attach new networks:
+#
+# jobs:
+# - name: uuadb
+# - template: postgres
+# - networks:
+#   - name: apps
+#     static_ips:
+#     - 1.2.3.4
+#   - name: management
+#     static_ips:
+#     - 9.8.7.6
+listen_addresses = '0.0.0.0'
+port = <%= db.port %>
+max_connections = <%= db.max_connections || 500 %>
+external_pid_file = '/var/vcap/sys/run/postgres/postgres.pid'
+authentication_timeout = 1min
+
+shared_buffers = 128MB
+temp_buffers = 8MB
+
+max_files_per_process = 1000
+
+logging_collector = on
+log_directory = '/var/vcap/sys/log/postgres'
+log_filename = 'postgresql.log'
+
+datestyle = 'iso, mdy'
+
+lc_messages = 'en_US.UTF-8'
+lc_monetary = 'en_US.UTF-8'
+lc_numeric = 'en_US.UTF-8'
+lc_time = 'en_US.UTF-8'
+
+default_text_search_config = 'pg_catalog.english'

--- a/packages/postgres9/packaging
+++ b/packages/postgres9/packaging
@@ -1,0 +1,43 @@
+set -e -x
+
+archive="postgresql-9.3.4.tar.gz"
+
+if [[ -f postgres9/$archive ]] ; then
+  echo "Archive found"
+else
+  echo "Archive not found"
+  exit 1
+fi
+
+echo "Extracting archive..."
+tar xzf postgres9/postgresql-9.3.4.tar.gz
+
+cd postgresql-9.3.4
+
+if [[ `uname -a` =~ "x86_64" ]] ; then
+  ./configure --prefix=${BOSH_INSTALL_TARGET}
+else
+  CFLAGS=-m32 LDFLAGS=-m32 CXXFLAGS=-m32 ./configure --prefix=${BOSH_INSTALL_TARGET}
+fi
+
+pushd src/bin/pg_config
+make
+make install
+popd
+
+cp -LR src/include ${BOSH_INSTALL_TARGET}
+pushd src/interfaces/libpq
+make
+make install
+popd
+
+pushd src
+make
+make install
+popd
+
+pushd contrib
+make
+make install
+popd
+

--- a/packages/postgres9/spec
+++ b/packages/postgres9/spec
@@ -1,0 +1,4 @@
+---
+name: postgres9
+files:
+- postgres9/postgresql-9.3.4.tar.gz

--- a/templates/cf-infrastructure-warden.yml
+++ b/templates/cf-infrastructure-warden.yml
@@ -149,7 +149,7 @@ properties:
 
   databases:
     db_scheme: postgres
-    address: (( jobs.postgres_z1.networks.cf1.static_ips.[0] ))
+    address: (( jobs.postgres9_z1.networks.cf1.static_ips.[0] ))
     port: 5524
     roles:
       - tag: admin
@@ -267,7 +267,7 @@ jobs:
     instances: 0
 
   # set up static IP for postgres
-  - name: postgres_z1
+  - name: postgres9_z1
     instances: 1
     networks:
     - name: cf1

--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -131,6 +131,18 @@ jobs:
     properties:
       db: databases
 
+  - name: postgres9_z1
+    release: (( meta.release.name ))
+    template: postgres9
+    instances: 0
+    resource_pool: medium_z1
+    persistent_disk: 4096
+    networks:
+    - name: cf1
+      static_ips: ~
+    properties:
+      db: databases
+
   - name: uaa_z1
     release: (( meta.release.name ))
     template: uaa


### PR DESCRIPTION
This pull request allows users to upgrade from postgres 9.0.3 to postgres 9.3.4. It uses psql sources available from their distribution to compile and deploy a postgres9 job with the same functionality as the original postgres job. For bosh-lite users postgres9.3.4(postgres9) is deployed in place of old postgres 9.0.3 job.
In order to deploy postgres9 we need to add blob "blobs/postgres9/postgresql-9.3.4.tar.gz" to your cf-release and then create the release.
For non-Bosh-lite environments, Postgres9 will be running as a separate job in the environment along with the old postgres 9.0.3. To switch to postgres9 simply change the the database settings to point to the ip address of the postgres9 server. 
In case where migration is needed, a migration script is shipped with postgres9 job that can be run from the postgres9 server to migrate, for example ccdb and uaadb, databases.
Migration is not automatically run as it requires adminstrative decisions on when it is best to migrate and switch without leaving inconsistencies between the two Databases.

Pivotal should add postgresql-9.3.4.tar.gz to their blobs for deployments to run smoothly.
http://www.postgresql.org/ftp/source/v9.3.4/
