### PR TITLE
Update aws to lucid go agent

### DIFF
--- a/templates/cf-deployment.yml
+++ b/templates/cf-deployment.yml
@@ -5,9 +5,7 @@ meta:
   # i.e. cf-tabasco
   environment: ~
 
-  stemcell:
-    name: bosh-aws-xen-ubuntu
-    version: latest
+  stemcell: (( merge ))
 
 name: (( meta.environment ))
 

--- a/templates/cf-infrastructure-aws.yml
+++ b/templates/cf-infrastructure-aws.yml
@@ -9,7 +9,7 @@ meta:
     aws_secret_access_key: (( properties.template_only.aws.secret_access_key ))
 
   stemcell:
-    name: bosh-aws-xen-ubuntu
+    name: bosh-aws-xen-ubuntu-lucid-go_agent
     version: latest
 
 


### PR DESCRIPTION
- Updated the stemcell for aws
- Removed the aws-specific stemcell from cf-deployments
  (At some point the stemcell info was removed from cf-deployments and then mistakenly re-added. We've removed it again, but added a merge to make it required, since the resource pools use it.)
