### PR TITLE
Java Buildpack v2.2

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -232,16 +232,6 @@ uaa/openjdk-1.7.0-u40-unofficial-macosx-x86_64-bundle.tgz:
   sha: !binary |-
     YWM3ZmViYzViYmZmMmRlZGY4YWRkNjI0YTcyN2E0YzBhYzZjM2QxMA==
   size: 65991397
-java-buildpack/java-buildpack-offline-v2.1.2.zip:
-  object_id: 01b7885f-8040-477a-815f-df60522762ee
-  sha: !binary |-
-    NDY0NzU4NjM3NWI0MTM1MTI2MTEwZmRiN2Y1ZDlmYWFhNGVhY2U1YQ==
-  size: 218797643
-java-buildpack/java-buildpack-v2.1.2.zip:
-  object_id: b0faa1ca-cfb9-4525-b414-0a416ce1eca7
-  sha: !binary |-
-    MGVhYzI0MWRjYzZiOGRlZjUwNjY0NDdhZTYyNDExYmZhNzA1NzJlMA==
-  size: 136315
 cli/cf-darwin-amd64.tgz:
   object_id: 23596b36-828e-4e98-96c9-09c4edadfc3b
   sha: !binary |-
@@ -272,3 +262,13 @@ go-buildpack/go-buildpack-online-b5.zip:
   sha: !binary |-
     NjlmMjc4Y2JmNTcyYWQwYTI2MjMzMjZjM2ViNDNkMmM3MTg0MGNlMw==
   size: 40431863
+java-buildpack/java-buildpack-offline-v2.2.zip:
+  object_id: c6f52313-f894-4816-9861-92f7a8950571
+  sha: !binary |-
+    M2Y2NzQxMTc1OGUxNTI5ODUyZWI2ZDM2NjhiMzUxMjkwMGIxM2QwOQ==
+  size: 221902410
+java-buildpack/java-buildpack-v2.2.zip:
+  object_id: db825262-e3c4-449f-a3e5-1f1a6678f18a
+  sha: !binary |-
+    OTNhMzc3MzlkMGY3NGFmODEzNTE1ZjJiZTQ0YzQyZmI1ZmEyMDIwNw==
+  size: 135918

--- a/packages/buildpack_java/packaging
+++ b/packages/buildpack_java/packaging
@@ -1,3 +1,3 @@
 set -e
 
-cp java-buildpack/java-buildpack-v2.1.2.zip ${BOSH_INSTALL_TARGET}
+cp java-buildpack/java-buildpack-v2.2.zip ${BOSH_INSTALL_TARGET}

--- a/packages/buildpack_java/spec
+++ b/packages/buildpack_java/spec
@@ -2,4 +2,4 @@
 name: buildpack_java
 
 files:
-  - java-buildpack/java-buildpack-v2.1.2.zip
+  - java-buildpack/java-buildpack-v2.2.zip

--- a/packages/buildpack_java_offline/packaging
+++ b/packages/buildpack_java_offline/packaging
@@ -1,3 +1,3 @@
 set -e
 
-cp java-buildpack/java-buildpack-offline-v2.1.2.zip ${BOSH_INSTALL_TARGET}
+cp java-buildpack/java-buildpack-offline-v2.2.zip ${BOSH_INSTALL_TARGET}

--- a/packages/buildpack_java_offline/spec
+++ b/packages/buildpack_java_offline/spec
@@ -2,4 +2,4 @@
 name: buildpack_java_offline
 
 files:
-  - java-buildpack/java-buildpack-offline-v2.1.2.zip
+  - java-buildpack/java-buildpack-offline-v2.2.zip


### PR DESCRIPTION
This change updates the Java Buildpack to version `2.2`.  Version `2.2` has the following highlights:
- Credentials in repository URIs (via Shaozhen Ding)
- Groovy 2.3 support
- Auto-reconfiguration support for Servlet 3 and distZip style applications
- Buildpack packaging on Windows (via kjhawar)

Both the online and offline buildpacks are updated as part of this change.
