### PR TITLE
Remove online go buildpack from blobs

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -267,8 +267,3 @@ go-buildpack/go-buildpack-offline-b7.zip:
   sha: !binary |-
     Y2Q2OTc5MDNiYTYxNGEyNWJiYWJkYzkwMDZjOTI4ODlhNDBkNmJiOA==
   size: 269064277
-go-buildpack/go-buildpack-online-b5.zip:
-  object_id: 2bacfe70-4a04-4571-9ec4-6564b29ab938
-  sha: !binary |-
-    NjlmMjc4Y2JmNTcyYWQwYTI2MjMzMjZjM2ViNDNkMmM3MTg0MGNlMw==
-  size: 40431863


### PR DESCRIPTION
- The online go buildpack is not used by cf-release.
- Fixes travis CI failure
