### PR TITLE
Allow to configure core_pattern and core_directory for the dea host

### DIFF
--- a/jobs/dea_next/spec
+++ b/jobs/dea_next/spec
@@ -116,6 +116,12 @@ properties:
   dea_next.zone:
     description: "The Availability Zone"
     default: "default"
+  dea_next.kernel_core_directory:
+    description: "The kenerl core file directory"
+    default: "/var/vcap/sys/cores"
+  dea_next.kernel_core_pattern:
+    description: "The kernel core file pattern"
+    default: "/var/vcap/sys/cores/core-%e-%s-%p-%t"
   disk_quota_enabled:
     description: "disk quota must be disabled to use warden-inside-warden with the warden cpi"
     default: true

--- a/jobs/dea_next/templates/dea.yml.erb
+++ b/jobs/dea_next/templates/dea.yml.erb
@@ -76,5 +76,9 @@ instance:
   disk_inode_limit: <%= p("dea_next.instance_disk_inode_limit") %>
 
 stacks: <%= p("dea_next.stacks") %>
+
+kernel:
+  core_directory: <%= p("dea_next.kernel_core_directory") %>
+
 placement_properties:
   zone: <%= p("dea_next.zone") %>

--- a/jobs/dea_next/templates/dea_ctl.erb
+++ b/jobs/dea_next/templates/dea_ctl.erb
@@ -24,10 +24,12 @@ case $1 in
 
     echo $$ > $PIDFILE
 
+    <% if_p("dea_next.kernel_core_directory") do %>
     # Configure the core file location
-    mkdir -p /var/vcap/sys/cores
-    chown vcap:vcap /var/vcap/sys/cores
-    echo /var/vcap/sys/cores/core-%e-%s-%p-%t > /proc/sys/kernel/core_pattern
+    mkdir -p <%= p("dea_next.kernel_core_directory") %>
+    chown vcap:vcap <%= p("dea_next.kernel_core_directory") %>
+    <% end %>
+    echo <%= p("dea_next.kernel_core_pattern") %> > /proc/sys/kernel/core_pattern
 
     ulimit -c unlimited
 

--- a/jobs/dea_next/templates/dir_server_ctl.erb
+++ b/jobs/dea_next/templates/dir_server_ctl.erb
@@ -17,10 +17,13 @@ case $1 in
 
     echo $$ > $PIDFILE
 
+    <% if_p("dea_next.kernel_core_directory") do %>
     # Configure the core file location
-    mkdir -p /var/vcap/sys/cores
-    chown vcap:vcap /var/vcap/sys/cores
-    echo /var/vcap/sys/cores/core-%e-%s-%p-%t > /proc/sys/kernel/core_pattern
+    mkdir -p <%= p("dea_next.kernel_core_directory") %>
+    chown vcap:vcap <%= p("dea_next.kernel_core_directory") %>
+    <% end %>
+
+    echo <%= p("dea_next.kernel_core_pattern") %> > /proc/sys/kernel/core_pattern
 
     ulimit -c unlimited
 

--- a/jobs/dea_next/templates/warden_ctl.erb
+++ b/jobs/dea_next/templates/warden_ctl.erb
@@ -17,10 +17,13 @@ case $1 in
     mkdir -p $RUN_DIR
     mkdir -p $LOG_DIR
 
+    <% if_p("dea_next.kernel_core_directory") do %>
     # Configure the core file location
-    mkdir -p /var/vcap/sys/cores
-    chown vcap:vcap /var/vcap/sys/cores
-    echo /var/vcap/sys/cores/core-%e-%s-%p-%t > /proc/sys/kernel/core_pattern
+    mkdir -p <%= p("dea_next.kernel_core_directory") %>
+    chown vcap:vcap <%= p("dea_next.kernel_core_directory") %>
+    <% end %>
+
+    echo <%= p("dea_next.kernel_core_pattern") %> > /proc/sys/kernel/core_pattern
 
     ulimit -c unlimited
 

--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -468,6 +468,8 @@ properties:
     logging_level: debug
     staging_disk_limit_mb: 4096
     staging_memory_limit_mb: 1024
+    kernel_core_directory: /var/vcap/sys/cores
+    kernel_core_pattern: /var/vcap/sys/cores/core-%e-%s-%p-%t
 
   loggregator_endpoint:
     shared_secret: (( merge ))


### PR DESCRIPTION
Sometimes, the vendor would like to configure the core_pattern and core_directory in some scenarios.
1. To customize the core_pattern, e.g. some runtime did not support %t option in the core pattern, since the warden shares the same core_pattern with the dea host. In case the runtime corrupted, the core dump file will not be generated successfully.
2. The vendor hope to use other tools to manage those generated core dump files, e.g. by default, in ubuntu, apport could be used for this purpose, so, while starting the dea/warden/file_server, it is better that different core_pattern value could be configured.
