### PR TITLE
Added login.uaa_base key to cf-properties.yml

### DIFF
--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -121,6 +121,7 @@ properties:
     uaa_certificate: ~
     protocol: https
     brand: oss
+    uaa_base: ~
 
     smtp:
       host: ~
@@ -159,10 +160,10 @@ properties:
     batch:
       username: (( merge ))
       password: (( merge ))
-    
+
     login:
       client_secret: ~
-      
+
     clients:
       <<: (( merge || nil ))
       login:


### PR DESCRIPTION
We are running two CF installations in different AWS regions. To have all user available in both installations we connected them to a central UAA. 

To make it work, together with the yml file generator, I had to add the uaa_base url to the template. 
