### PR TITLE
Generalized multi bosh lite

### DIFF
--- a/templates/cf-infrastructure-warden.yml
+++ b/templates/cf-infrastructure-warden.yml
@@ -412,7 +412,8 @@ resource_pools:
     cloud_properties:
       name: random
 
-networks:
+networks: (( merge || networks_default ))
+networks_default:
 - name: cf1
   subnets:
   - cloud_properties:

--- a/templates/warden_networks.rb
+++ b/templates/warden_networks.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 # Each Warden container is a /30 in Warden's network range, which is
 # configured as 10.244.0.0/22. There are 256 available entries.
 #
@@ -12,11 +14,13 @@
 require "yaml"
 require "netaddr"
 
+IP_ADDRESS_SUFFIX = ENV.fetch("IP_ADDRESS_SUFFIX", 4).to_i
+
 cf1_subnets = []
-cf1_start = NetAddr::CIDR.create("10.244.0.0/30")
+cf1_start = NetAddr::CIDR.create("10.24#{IP_ADDRESS_SUFFIX}.0.0/30")
 
 cf2_subnets = []
-cf2_start = NetAddr::CIDR.create("10.244.2.0/30")
+cf2_start = NetAddr::CIDR.create("10.24#{IP_ADDRESS_SUFFIX}.2.0/30")
 
 128.times do
   cf1_subnets << cf1_start


### PR DESCRIPTION
This allows us to parameterize the bosh lite environment networks. We can create networks with 

N = IP_ADDRESS_SUFFIX = 2..9

yielding:

10.(240 + N).0.0

We chose + N because of the bosh vagrant vm's default public ip:  192.168.50.4

In bosh configs, we are able to use 'N' to replace the 4:  192.168.50.N

So IP_ADDRESS_SUFFIX=4 yields the default networks 192.168.50.4 & 10.244.0.0/19

See: https://github.com/cf-buildpacks/bosh-lite-2nd-instance/commit/2bedc3e1e8a055d2b224c2462c017230d70c7068
