### PR TITLE
Configurable service dashboard client scope

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -423,6 +423,9 @@ properties:
 
   uaa.clients.cc_service_broker_client.secret:
     description: "Used for generating SSO clients for service brokers."
+  uaa.clients.cc_service_broker_client.scope:
+    description: "Used to grant scope for SSO clients for service brokers"
+    default: "openid,cloud_controller_service_permissions.read"
 
   ccng.install_buildpacks:
       description: "Set of buildpacks to install during deploy"

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -429,6 +429,9 @@ properties:
 
   uaa.clients.cc_service_broker_client.secret:
     description: "Used for generating SSO clients for service brokers."
+  uaa.clients.cc_service_broker_client.scope:
+    description: "Used to grant scope for SSO clients for service brokers"
+    default: "openid,cloud_controller_service_permissions.read"
 
   ccng.install_buildpacks:
     description: "Set of buildpacks to install during deploy" 

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -425,6 +425,9 @@ properties:
 
   uaa.clients.cc_service_broker_client.secret:
     description: "Used for generating SSO clients for service brokers."
+  uaa.clients.cc_service_broker_client.scope:
+    description: "Used to grant scope for SSO clients for service brokers"
+    default: "openid,cloud_controller_service_permissions.read"
 
   ccng.install_buildpacks:
     description: "Set of buildpacks to install during deploy"

--- a/templates/cf-infrastructure-warden.yml
+++ b/templates/cf-infrastructure-warden.yml
@@ -94,7 +94,7 @@ properties:
         redirect-uri: (( "http://login." domain ))
       cc_service_broker_client:
         secret: cc-broker-secret
-        scope: cloud_controller.write,openid,cloud_controller.read,cloud_controller_service_permissions.read
+        scope: openid,cloud_controller_service_permissions.read
         authorities: clients.read,clients.write,clients.admin
         authorized-grant-types: client_credentials
       developer_console:


### PR DESCRIPTION
Unfortunately, we were 90% done with this before we knew Cloud Controller work should be limited / halted. This can be merged whenever we are ready to start adding features again.

This depends on https://github.com/cloudfoundry/cloud_controller_ng/pull/252
