### PR TITLE
Create release on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: ruby
 rvm:
   - 1.9.3-p545
 
+before_install:
+  - git submodule update --init --recursive
 script:
   - bundle exec bosh sync blobs
+  - bundle exec bosh --non-interactive --verbose create release --dry-run
   - ./scripts/unused_blobs


### PR DESCRIPTION
This commit adds a `create release` dry run on travis. The benefit is
that it can catch a lot of errors (e.g. pre_packaging script, invalid
spec files) fairly early

Signed-off-by: Max Brunsfeld mbrunsfeld@pivotallabs.com
