### PR TITLE
Externalize uaa password lockout parameters

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -33,6 +33,12 @@ properties:
 
   uaa.admin.client_secret:
     description:
+  uaa.endpoint.lockoutAfterFailures:
+    description: "Number of allowed failures before account is locked"
+  uaa.endpoint.countFailuresWithinSeconds:
+    description: "Number of seconds in which lockoutAfterFailures failures must occur in order for account to be locked"
+  uaa.endpoint.lockoutPeriodSeconds:
+    description: "Number of seconds to lock out an account when lockoutAfterFailures failures is exceeded"
   uaa.batch.password:
     description: "Deprecated"
   uaa.batch.username:

--- a/jobs/uaa/templates/uaa.yml.erb
+++ b/jobs/uaa/templates/uaa.yml.erb
@@ -35,6 +35,18 @@ oauth:
   authorize:
     ssl: true
   <% end %>
+  <% if properties.uaa.endpoint %>
+  endpoint:
+    <% if properties.uaa.endpoint.lockoutAfterFailures %>
+      lockoutAfterFailures: <%= properties.uaa.endpoint.lockoutAfterFailures %>
+    <% end %>
+    <% if properties.uaa.endpoint.countFailuresWithinSeconds %>
+      countFailuresWithinSeconds: <%= properties.uaa.endpoint.countFailuresWithinSeconds %>
+    <% end %>
+    <% if properties.uaa.endpoint.lockoutPeriodSeconds %>
+      lockoutPeriodSeconds: <%= properties.uaa.endpoint.lockoutPeriodSeconds %>
+    <% end %>
+  <% end %>
   client:
   <% if properties.uaa.client && properties.uaa.client.autoapprove %>
     autoapprove: <% properties.uaa.client.autoapprove.each do |client_id| %>


### PR DESCRIPTION
We'd like to be able to customise some of the uaa password lockout parameters in line with corporate requirements etc.   (corresponding uaa PR: https://github.com/cloudfoundry/uaa/pull/87)
