### PR TITLE
Increase default maxRetainedLogMessages

### DIFF
--- a/jobs/loggregator/spec
+++ b/jobs/loggregator/spec
@@ -35,7 +35,7 @@ properties:
     default: 0
   loggregator.maxRetainedLogMessages:
     description: number of log messages to retain per application
-    default: 10
+    default: 100
   loggregator.incoming_port:
     description: Port for incoming log messages
     default: 3456


### PR DESCRIPTION
With only 10 lines, CF Acceptance Tests fails on a default v172
installation, because the expected Cloud Controller message rolls off.
We're requesting 100 lines, because the staging environments use this
setting.

/cc @lcddave. 

@mark-rushakoff / @ryantang
