### PR TITLE
Enable configuration of all collector historians

### DIFF
--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -507,6 +507,7 @@ properties:
     network: (( networks.cf1.subnets.[0].range ))
 
   collector:
+    <<: (( merge ))
     use_datadog: true
     datadog_api_key: ""
     datadog_application_key: ""


### PR DESCRIPTION
I added a merge to the collector configuration, to be able to configure all graphite historians. We where missing the graphite configuration, but from my perspective the  merge is the better solution, since the configuration can be quite different depending on the environment setup.
