### PR TITLE
add -stream=false to errands to get all the output in the event of failure

### DIFF
--- a/jobs/acceptance-tests/templates/run.erb
+++ b/jobs/acceptance-tests/templates/run.erb
@@ -32,7 +32,7 @@ EXITSTATUS=0
 test_command=<%= properties.acceptance_tests.include_diego ? "./bin/test_con_diego" : "./bin/test" %>
 nodes=<%= properties.acceptance_tests.nodes %>
 skips=<%= properties.acceptance_tests.include_sso ? "" : "-skip=SSO" %>
-$test_command -randomizeAllSpecs -nodes=$nodes $skips -keepGoing || EXITSTATUS=$?
+$test_command -stream=false -randomizeAllSpecs -nodes=$nodes $skips -keepGoing || EXITSTATUS=$?
 
 echo "Acceptance Tests Complete; exit status: $EXITSTATUS"
 exit $EXITSTATUS

--- a/jobs/smoke-tests/templates/run.erb
+++ b/jobs/smoke-tests/templates/run.erb
@@ -28,7 +28,7 @@ echo '##########################################################################
 echo "Running smoke tests..."
 
 EXITSTATUS=0
-./bin/test || EXITSTATUS=$?
+./bin/test -stream=false || EXITSTATUS=$?
 
 echo "Smoke Tests Complete; exit status: $EXITSTATUS"
 exit $EXITSTATUS


### PR DESCRIPTION
Ginkgo provides for `-stream=false` which will cause it to batch up output from all goroutines. This isn't the default so output can stream out as it runs, but the default behavior (non-`-stream=false`) has the downside that in the event of failure not all output from all goroutines can be recovered.
