### PR TITLE
Merge instead of making assumptions about deployments

### DIFF
--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -502,12 +502,7 @@ properties:
     address: (( jobs.nfs_z1.networks.cf1.static_ips.[0] || nil ))
     network: (( networks.cf1.subnets.[0].range ))
 
-  collector:
-    use_datadog: true
-    datadog_api_key: ""
-    datadog_application_key: ""
-    deployment_name: (( meta.environment ))
-    use_tsdb: false
+  collector: (( merge || nil ))
 
   opentsdb: (( merge || nil ))
 


### PR DESCRIPTION
Hello!

Simple PR to merge collector in the spiff-templates instead of making assumptions about deployments.

We use Graphite[1] and we need to merge, otherwise we have to manually alter the manifest after generating it.

Have a nice day,
Simon.

[1] not datadog nor tsdb, therefore we do not want them mentioned in our manifest
