### PR TITLE
Support cloud_controller job running on multiple networks. [#74544634]

### DIFF
--- a/jobs/debian_nfs_server/templates/exports.erb
+++ b/jobs/debian_nfs_server/templates/exports.erb
@@ -1,2 +1,2 @@
 <% no_root_squash = (properties.debian_nfs_server && properties.debian_nfs_server.no_root_squash) ? ',no_root_squash' : '' %>
-/var/vcap/store       <%= properties.nfs_server.network %>(rw,fsid=0,no_subtree_check,sync<%= no_root_squash %>)
+/var/vcap/store       <% properties.nfs_server.allowed_ips.each do |allowed_ip| %><%= allowed_ip %>(rw,fsid=0,no_subtree_check,sync<%= no_root_squash %>)<% end %>


### PR DESCRIPTION
Ops Manager 1.3 allows jobs to be deployed on multiple networks. The NFS
server used by the cloud_controller job should allow connections from any
address it could be running on. cc/@d
