### PR TITLE
Enable no_root_squash by default

### DIFF
--- a/jobs/debian_nfs_server/spec
+++ b/jobs/debian_nfs_server/spec
@@ -12,7 +12,7 @@ packages:
 properties:
   debian_nfs_server.no_root_squash:
     description: "Exports /var/vcap/store with no_root_squash when set to true"
-    default: false
+    default: true
   nfs_server.network:
     description: "Network prefix when exporting /var/vcap/store"
   nfs_server.idmapd_domain:


### PR DESCRIPTION
I can't point to any build artifact or anything except just to say that I've never had this successfully work without changing this value.
