### PR TITLE
Java Buildpack v2.4

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -267,16 +267,6 @@ nodejs-buildpack/nodejs-buildpack-offline-b29.zip:
   sha: !binary |-
     NGViMGQ1ZTVlYmVkODhiOWYxMTIzOGNiYjA4MmI3OWIyMjA2NDQ4OA==
   size: 393231066
-java-buildpack/java-buildpack-offline-v2.3.zip:
-  object_id: 61225a3a-f66c-4bac-94fe-fb15aff0c888
-  sha: !binary |-
-    YTk4MzM1ODI4YmI2MjAxZDNkMjAzODVjM2ZmNmUyNjdmZDlmYzlhYw==
-  size: 225894207
-java-buildpack/java-buildpack-v2.3.zip:
-  object_id: 8df97db0-624e-493f-8bc0-0b5f046a3d90
-  sha: !binary |-
-    MmM2NTA2NTNhYjlmYTM0MjFlZmNiNGZjYTdlYTA4M2JjNTBiMDQ3Yg==
-  size: 136323
 ruby-buildpack/ruby-buildpack-offline-b53.zip:
   object_id: e6deac43-97c9-46b0-a3b3-9e2666db08aa
   sha: !binary |-
@@ -287,3 +277,13 @@ php-buildpack/php-buildpack-offline-b26.zip:
   sha: !binary |-
     ZGY1YzBiZmNlMjAwYzkyNDVhNGM3MjVmOGJhYWViMzI0MjRhMzcxMQ==
   size: 191244760
+java-buildpack/java-buildpack-offline-v2.4.zip:
+  object_id: 7498b6ad-60f5-4400-9f3a-35321a458e6d
+  sha: !binary |-
+    ZTAwZWJiZmRiZWJkNTQ3NWVjZmM0M2Y5ZmI4NjU4ZmMxZjYxOGRiNg==
+  size: 225928527
+java-buildpack/java-buildpack-v2.4.zip:
+  object_id: d5502109-bbe4-4794-8cc1-0f7cbd108fcf
+  sha: !binary |-
+    N2EwN2Q2MTYyODczZmRhMjlhMGFjZWIwM2FhYTUzZjZmMGVmZjI1YQ==
+  size: 137582

--- a/packages/buildpack_java/packaging
+++ b/packages/buildpack_java/packaging
@@ -1,3 +1,3 @@
 set -e
 
-cp java-buildpack/java-buildpack-v2.3.zip ${BOSH_INSTALL_TARGET}
+cp java-buildpack/java-buildpack-v2.4.zip ${BOSH_INSTALL_TARGET}

--- a/packages/buildpack_java/spec
+++ b/packages/buildpack_java/spec
@@ -2,4 +2,4 @@
 name: buildpack_java
 
 files:
-  - java-buildpack/java-buildpack-v2.3.zip
+  - java-buildpack/java-buildpack-v2.4.zip

--- a/packages/buildpack_java_offline/packaging
+++ b/packages/buildpack_java_offline/packaging
@@ -1,3 +1,3 @@
 set -e
 
-cp java-buildpack/java-buildpack-offline-v2.3.zip ${BOSH_INSTALL_TARGET}
+cp java-buildpack/java-buildpack-offline-v2.4.zip ${BOSH_INSTALL_TARGET}

--- a/packages/buildpack_java_offline/spec
+++ b/packages/buildpack_java_offline/spec
@@ -2,4 +2,4 @@
 name: buildpack_java_offline
 
 files:
-  - java-buildpack/java-buildpack-offline-v2.3.zip
+  - java-buildpack/java-buildpack-offline-v2.4.zip


### PR DESCRIPTION
This change updates the Java Buildpack to version`2.4`.  Version `2.4` has the following highlights:
- Configurable Access Logging in Tomcat (via Guillaume Berche)
- Session Replication working with Pivotal Redis Service (via John McTeague)

Both the online and offline buildpacks are updated as part of this change.
