### PR TITLE
Increase login-server and uaa pre-packaging reliability for os x

### DIFF
--- a/packages/login/pre_packaging
+++ b/packages/login/pre_packaging
@@ -16,7 +16,7 @@ export PATH=$PATH:/bin:/usr/bin
 if [ `uname` = "Darwin" ]; then
   mkdir java
   cd java
-  tar zxvf ../uaa/openjdk-1.7.0-u40-unofficial-macosx-x86_64-bundle.tgz
+  tar zxvf ../uaa/openjdk-1.7.0-u40-unofficial-macosx-x86_64-bundle.tgz --exclude="._*"
   export JAVA_HOME=${BUILD_DIR}/java/Contents/Home
 elif [ `uname` = "Linux" ]; then
   mkdir java

--- a/packages/uaa/pre_packaging
+++ b/packages/uaa/pre_packaging
@@ -16,7 +16,7 @@ export PATH=$PATH:/bin:/usr/bin
 if [ `uname` = "Darwin" ]; then
   mkdir java
   cd java
-  tar zxvf ../uaa/openjdk-1.7.0-u40-unofficial-macosx-x86_64-bundle.tgz
+  tar zxvf ../uaa/openjdk-1.7.0-u40-unofficial-macosx-x86_64-bundle.tgz --exclude="._*"
   export JAVA_HOME=${BUILD_DIR}/java/Contents/Home
 elif [ `uname` = "Linux" ]; then
   mkdir java


### PR DESCRIPTION
Exclude dot underscore files from openjdk archive when building on os x

Signed-off-by: Philip Kuryloski pkuryloski@pivotallabs.com
