### PR TITLE
Adds UAA client for notifications service

### DIFF
--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -248,3 +248,7 @@ properties:
         authorized-grant-types: client_credentials
         access-token-validity: 1209600
         refresh-token-validity: 1209600
+      notifications:
+        secret: (( merge ))
+        authorities: cloud_controller.admin,scim.read
+        authorized-grant-types: client_credentials


### PR DESCRIPTION
The new notifications service (https://github.com/cloudfoundry-incubator/notifications) needs a UAA client to talk to both CC and UAA.
