### PR TITLE
Fix uaa.yml.erb and cf-properties.yml to allow uaa ldap config

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -65,8 +65,6 @@ properties:
     default: false
   uaa.scim.users:
     description:
-  uaa.spring_profiles:
-    description:
   ccdb.address:
     description: "The CloudController database IP address"
   ccdb.databases:

--- a/jobs/uaa/templates/uaa.yml.erb
+++ b/jobs/uaa/templates/uaa.yml.erb
@@ -9,14 +9,12 @@ database:
   username: <%= uaa_role.name %>
   password: "<%= uaa_role.password %>"
 
-<% if properties.uaa && properties.uaa.spring_profiles && properties.uaa.spring_profiles.eql?('ldap') && properties.uaa.ldap %>
-spring_profiles: <%= properties.uaa.spring_profiles %>,<%=properties.uaadb.db_scheme%>
-<% elsif properties.uaa && properties.uaa.spring_profiles && properties.uaa.spring_profiles.include?('ldap') && properties.uaa.ldap %>
-spring_profiles: <%= properties.uaa.spring_profiles ? properties.uaa.spring_profiles : properties.uaadb.db_scheme %>
-<% elsif properties.login && properties.login.spring_profiles && properties.login.spring_profiles.include?('ldap') &&  properties.login.ldap %>
-spring_profiles: <%= properties.uaa.spring_profiles ? properties.uaa.spring_profiles : properties.uaadb.db_scheme %>,ldap
+<% if properties.uaa && properties.uaa.ldap && properties.uaa.ldap.profile_type %>
+spring_profiles: <%= properties.uaadb.db_scheme %>,ldap
+<% elsif properties.login && properties.login.spring_profiles && properties.login.spring_profiles.include?('ldap') &&  properties.login.ldap && properties.login.ldap.profile_type %>
+spring_profiles: <%= properties.uaadb.db_scheme %>,ldap
 <% else %>
-spring_profiles: <%= properties.uaa.spring_profiles ? properties.uaa.spring_profiles : properties.uaadb.db_scheme %>
+spring_profiles: <%= properties.uaadb.db_scheme %>
 <% end %>
 
 logging:
@@ -122,7 +120,7 @@ require_https: <%= properties.uaa.require_https %>
 <% if !properties.uaa.dump_requests.nil? %>
 dump_requests: <%= properties.uaa.dump_requests %>
 <% end %>
-<% if properties.uaa && properties.uaa.spring_profiles && properties.uaa.spring_profiles.include?('ldap') && properties.uaa.ldap && properties.uaa.ldap.profile_type %>
+<% if properties.uaa && properties.uaa.ldap && properties.uaa.ldap.profile_type %>
 ldap:
   ldapdebug: 'Ldap configured through UAA'
   profile:

--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -199,6 +199,8 @@ properties:
     login:
       client_secret: ~
 
+    ldap: ~
+
     clients:
       <<: (( merge || nil ))
       login:


### PR DESCRIPTION
A spec for uaa.spring_profiles existed, but never worked because the property was never present in cf-properties.  It is now removed.

[#75285350] https://www.pivotaltracker.com/story/show/75285350
