### PR TITLE
Upgrading go buildpack to v1.0.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -45,28 +45,23 @@ libyaml/yaml-0.1.4.tgz:
   size: 471759
 buildpack_cache/ruby-1.8.7.tgz:
   object_id: ffc863f6-5894-43bb-bd74-684a2931f840
-  sha: !binary |-
-    MzcwNWY0Zjg5NTUwZjZmNTgyZGE5ZjI1YWYxYTcxNWM3MTZhNDM5NA==
+  sha: 3705f4f89550f6f582da9f25af1a715c716a4394
   size: 4402111
 buildpack_cache/ruby-1.9.2.tgz:
   object_id: ae2f9381-a54b-47bf-a7d1-eb561eb365ae
-  sha: !binary |-
-    ZWNkYzhiYjg5NzVlNjg2ZDBmMWIwYWM0NDdiMmI1ZmZjMGI0ZWExZA==
+  sha: ecdc8bb8975e686d0f1b0ac447b2b5ffc0b4ea1d
   size: 10143524
 buildpack_cache/ruby-1.9.3.tgz:
   object_id: 592c86e7-07fe-4106-a55f-b8c190935fa4
-  sha: !binary |-
-    MmE2NTMwMWYzYTI4YTdlZGY3N2MwN2VjY2M0ZDlhNTdjOTUxMzQ5MQ==
+  sha: 2a65301f3a28a7edf77c07eccc4d9a57c9513491
   size: 10823804
 buildpack_cache/ruby-build-1.8.7.tgz:
   object_id: e9e587a7-d9c1-4791-bb6d-423c6aa2028e
-  sha: !binary |-
-    NWM3NWExYTU1M2Q5Yjc0ZDUyOWI2OTI5YzJkMWI4OWIyMWVmZjUyOA==
+  sha: 5c75a1a553d9b74d529b6929c2d1b89b21eff528
   size: 4400433
 buildpack_cache/ruby-build-1.9.2.tgz:
   object_id: f4fc6c65-967a-4b59-bb31-2ee1848bcd1f
-  sha: !binary |-
-    NjUzYjk0YTcwYWQ2MWQ4NDQ5MzRjMGIwZDZlMmQzZjlmM2I2YTg5Mg==
+  sha: 653b94a70ad61d844934c0b0d6e2d3f9f3b6a892
   size: 10148015
 buildpack_cache/bundler-1.3.0.pre.5.tgz:
   object_id: rest/objects/4e4e78bca51e122004e4e8ec68407705135451b3613c
@@ -78,8 +73,7 @@ buildpack_cache/libyaml-0.1.4.tgz:
   size: 61085
 buildpack_cache/ruby_versions.yml:
   object_id: 48273e57-a228-4e75-9ab4-42bc743dd0ca
-  sha: !binary |-
-    ZTQzMzViM2FiNGNiYjhkMWMwNDU2ZjhjMzYxZGJlNzNmZDZiYjYxZg==
+  sha: e4335b3ab4cbb8d1c0456f8c361dbe73fd6bb61f
   size: 56
 buildpack_cache/bundler-1.3.1.tgz:
   object_id: rest/objects/4e4e78bca51e121004e4e7d51906cd05138e626d7fde
@@ -87,8 +81,7 @@ buildpack_cache/bundler-1.3.1.tgz:
   size: 231
 buildpack_cache/ruby-2.0.0.tgz:
   object_id: 5a0cf225-33f3-4952-8c38-e8b8b1336270
-  sha: !binary |-
-    MjA3Yjk2NDBhNTQyZmM2OWEyOGNlNGY1YThlMjlkZjExZWM5MGNlNQ==
+  sha: 207b9640a542fc69a28ce4f5a8e29df11ec90ce5
   size: 11855025
 buildpack_cache/apache-tomcat-7.0.37.tar.gz:
   object_id: rest/objects/4e4e78bca11e121204e4e86ee15294051391912aabfc
@@ -124,166 +117,133 @@ buildpack_cache/play-jpa-plugin-0.6.6.jar:
   size: 4320
 rootfs/lucid64.tar.gz:
   object_id: 516f96b7-9d57-4642-baf8-d6ebd6bc5098
-  sha: !binary |-
-    NjQyMjhjMGJjNDgzZDcxNjBkNmZiMTdhY2VlM2RiZDY3YzUzMzk1ZQ==
+  sha: 64228c0bc483d7160d6fb17acee3dbd67c53395e
   size: 200478897
 buildpack_cache/openjdk-1.6.0_27.tar.gz:
   object_id: 51513056-c453-44af-a77c-1fdad381d6ad
-  sha: !binary |-
-    YTQ1YjZmODliYTU0ZDIzMGNiNDc5OTJiZDgxNzdkMjExZjY0YmQ5Mw==
+  sha: a45b6f89ba54d230cb47992bd8177d211f64bd93
   size: 28917046
 buildpack_cache/openjdk-1.7.0_21.tar.gz:
   object_id: c40ed53f-2fd2-433c-bf50-cae768348ccd
-  sha: !binary |-
-    OTQ5NjUyOWMzZmJiOWJiZTIyMjVkMDhmOTk5YjA3N2MyYWRjYmYxMg==
+  sha: 9496529c3fbb9bbe2225d08f999b077c2adcbf12
   size: 31171473
 buildpack_cache/openjdk-1.8.0_M7.tar.gz:
   object_id: 4a52e8ee-08c1-4dde-a4f0-cbbc96e8c393
-  sha: !binary |-
-    ZGZmZDhhYTA3NTA0NzU0ZTI1YWRmZjk1NDdkY2U2YTM2NmM0NWQxNA==
+  sha: dffd8aa07504754e25adff9547dce6a366c45d14
   size: 38150032
 buildpack_cache/apache-tomcat-7.0.40.tar.gz:
   object_id: 3094e931-972d-4430-abd5-2da9700a0151
-  sha: !binary |-
-    MmZlMTg1ODQyMDc2NDU4ZGE1N2I1NGYwYTJjYzNmNWI0MWFlMDA3ZA==
+  sha: 2fe185842076458da57b54f0a2cc3f5b41ae007d
   size: 7843733
 buildpack_cache/apache-tomcat-7.0.41.tar.gz:
   object_id: bd326ac9-6287-4fa2-980c-966d3ad11dc6
-  sha: !binary |-
-    ODc5NzRmY2MyNDcxMWVhMjUzZmI0M2UzZGI0NTA2NjRlMDJlMWFkZg==
+  sha: 87974fcc24711ea253fb43e3db450664e02e1adf
   size: 7946142
 buildpack_cache/auto-reconfiguration-0.6.7.jar:
   object_id: f793a3c6-fd8d-47af-9e90-4a966b3d2ed2
-  sha: !binary |-
-    NzI4MjI4ZjM2NDhkNjc5NzU5ZGYwNGZjZTYyMjBkNDQ2ZTVmZGQ5Zg==
+  sha: 728228f3648d679759df04fce6220d446e5fdd9f
   size: 708374
 buildpack_cache/openjdk-1.7.0_25.tar.gz:
   object_id: 3e47e45f-2f65-42f6-ac29-bc9782c3714e
-  sha: !binary |-
-    MzdiNGNiYjJlODgyZjhkYTk5NDQ3MjllOWYzMTFmOGY3MWNjN2ZkZg==
+  sha: 37b4cbb2e882f8da9944729e9f311f8f71cc7fdf
   size: 31516851
 buildpack_cache/auto-reconfiguration-0.6.8.jar:
   object_id: a7381813-ffd3-44d4-b5b8-8cd47449239d
-  sha: !binary |-
-    MjY4MjYwMDM5YzZmMjU4N2M1Y2M0M2MyYjU3M2VlODhiNGRiZWMwYw==
+  sha: 268260039c6f2587c5cc43c2b573ee88b4dbec0c
   size: 709165
 haproxy/haproxy-1.5-dev19.tar.gz:
   object_id: 4832cdff-951f-4e76-b7b9-d7b126ddef8d
-  sha: !binary |-
-    NWMxNjY4NmM1MTZkYmVhYWI4YWRhNmMxN2MyNWU5NjI5YWI0ZjdkMw==
+  sha: 5c16686c516dbeaab8ada6c17c25e9629ab4f7d3
   size: 1143258
 haproxy/pcre-8.33.tar.gz:
   object_id: 2bf0743b-c496-4022-837d-2bbeaa83f32d
-  sha: !binary |-
-    YmNlYWZiNTM1NTMyMTlkYWQyNTkzYmI4YWYwNmRhNGQwN2ZkMzgyOA==
+  sha: bceafb53553219dad2593bb8af06da4d07fd3828
   size: 1889401
 maven/apache-maven-3.1.1-bin.tar.gz:
   object_id: 6f015bd2-aefb-4996-a9d7-1ac8c3411ad6
-  sha: !binary |-
-    NjMwZWVhMjEwN2IwNzQyYWNiMzE1YjIxNDAwOWJhMDg2MDJkZGE1Zg==
+  sha: 630eea2107b0742acb315b214009ba08602dda5f
   size: 5494427
 nginx/headers-more-v0.25.tgz:
   object_id: a621718d-df24-4205-ba31-6ed8a212732e
-  sha: !binary |-
-    NTE0YmMzZGYzMGIyNGViMGEwNjUzM2YxZWJhYTU3OWI4OTg5OTBmNQ==
+  sha: 514bc3df30b24eb0a06533f1ebaa579b898990f5
   size: 27973
 nginx/nginx-1.4.5.tar.gz:
   object_id: 8001e14c-1629-4305-bd5a-02e6ec9faa04
-  sha: !binary |-
-    OTZjMWFlY2QzMTRmNzNhM2MzMGEwZGI4YzM5YWQxNWRkYWNiMDc0ZQ==
+  sha: 96c1aecd314f73a3c30a0db8c39ad15ddacb074e
   size: 768728
 nginx/nginx-upload-module-2.2.tar.gz:
   object_id: 502854f1-9823-468f-baef-1a8d68823ead
-  sha: !binary |-
-    NzRjY2QxMTY1MjVhMTU1ZGI3NmY5MmExY2Q0ODRkOTUxNmE3MDM5OA==
+  sha: 74ccd116525a155db76f92a1cd484d9516a70398
   size: 28505
 nginx/pcre-8.34.tar.gz:
   object_id: ee5bee99-dda0-4d81-be88-a7a1a901dae7
-  sha: !binary |-
-    ZDQ2ZTUzNzMzN2VlNzBkZjE5MDg0MDAxYTRiNjgxNWIzZDY5ZmU2Yw==
+  sha: d46e537337ee70df19084001a4b6815b3d69fe6c
   size: 1933734
 nginx/newrelic_nginx_agent.tar.gz:
   object_id: cad4fada-4a11-4b1a-a884-c6f58dacead9
-  sha: !binary |-
-    OThhMWIxMDQ3NTM3MTcwNTkzMmZlYTQ3NjlmOGFjMWIwNDUxMTA2Zg==
+  sha: 98a1b10475371705932fea4769f8ac1b0451106f
   size: 5222
 golang/go1.2.1.linux-amd64.tar.gz:
   object_id: a5a3eaf9-54ac-47b6-bcf7-5ad59eafe787
-  sha: !binary |-
-    NzYwNWY1NzdmZjZhYzJkNjA4YTNhNGU4MjliMjU1YWUyZWJjOGRjZg==
+  sha: 7605f577ff6ac2d608a3a4e829b255ae2ebc8dcf
   size: 56123695
 uaa/openjdk-1.7.0_51.tar.gz:
   object_id: 67b767f3-4032-4970-8535-05dbf7c696a5
-  sha: !binary |-
-    MGY0ZDM3MDVlM2E0ZTE0NTIyNTBkZWY1N2NmYzM2YWI2Y2MzNzM1NQ==
+  sha: 0f4d3705e3a4e1452250def57cfc36ab6cc37355
   size: 34729532
 uaa/openjdk-1.7.0-u40-unofficial-linux-amd64.tgz:
   object_id: 869c365a-7c65-4454-8c09-212d01fa0fb1
-  sha: !binary |-
-    YmI0MWM2OGUwZGMyNmFkNzE2MzVkNGJmZjhkYTE2MjQ2ZGVkMTBmMA==
+  sha: bb41c68e0dc26ad71635d4bff8da16246ded10f0
   size: 42574624
 uaa/apache-tomcat-7.0.52.tar.gz:
   object_id: 3156c5be-fde0-43ba-917b-6222c9c6d86e
-  sha: !binary |-
-    YWRiMTcxYzQyMGE2YjBhMDQyZTIxMDJhNzZmYjcwYWM0ZGEwNmE0NA==
+  sha: adb171c420a6b0a042e2102a76fb70ac4da06a44
   size: 8340063
 uaa/openjdk-1.7.0-u40-unofficial-macosx-x86_64-bundle.tgz:
   object_id: 4cfb77f4-ea89-4d3d-85ad-2d0f3d84e676
-  sha: !binary |-
-    YWM3ZmViYzViYmZmMmRlZGY4YWRkNjI0YTcyN2E0YzBhYzZjM2QxMA==
+  sha: ac7febc5bbff2dedf8add624a727a4c0ac6c3d10
   size: 65991397
 cli/cf-darwin-amd64.tgz:
   object_id: 23596b36-828e-4e98-96c9-09c4edadfc3b
-  sha: !binary |-
-    NzJjMmE1Y2U4NTZjZWEwMTliNjNmNTgzODQ4N2YwNGVjZmYzNmM2Nw==
+  sha: 72c2a5ce856cea019b63f5838487f04ecff36c67
   size: 3795133
 cli/cf-linux-amd64.tgz:
   object_id: 44ab9fca-4463-4a78-a5fb-ff86de1654fb
-  sha: !binary |-
-    ZmJlYjk5ZjJkZjcwYTI4MmI3N2JiMTM0NTQ0NjFjNzBjNDJmNzVlYQ==
+  sha: fbeb99f2df70a282b77bb13454461c70c42f75ea
   size: 3830793
 ruby/yaml-0.1.6.tar.gz:
   object_id: 3b33cc37-7522-44cd-a068-ab61c5df746e
-  sha: !binary |-
-    ZjNkNDA0ZTExYmVjM2M0ZWZjZGRmZDE0YzQyZDQ2ZjFhYWJlMGI1ZA==
+  sha: f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d
   size: 503012
-go-buildpack/go-buildpack-offline-b7.zip:
-  object_id: 98842827-a5a9-4db2-8f63-598636b671bb
-  sha: !binary |-
-    Y2Q2OTc5MDNiYTYxNGEyNWJiYWJkYzkwMDZjOTI4ODlhNDBkNmJiOA==
-  size: 269064277
 ruby/ruby-1.9.3-p547.tar.gz:
   object_id: 82ec5a34-c6f5-46ba-8420-d927020a2a41
-  sha: !binary |-
-    MDFhNzkyZjk3MmY1Nzg3Y2U1MjZhMWFhZDYyOTc2YzU2YzkzMTc0Yg==
+  sha: 01a792f972f5787ce526a1aad62976c56c93174b
   size: 12582375
 python-buildpack/python-buildpack-offline-b10.zip:
   object_id: e31547f1-7d05-48a4-a917-4c8754fd0902
-  sha: !binary |-
-    MTU2MjM2MDU5MzQxYzcyNjNiZGZlMDdkM2EwYjVhNTE1ZDBjNjdiYw==
+  sha: 156236059341c7263bdfe07d3a0b5a515d0c67bc
   size: 259090962
 nodejs-buildpack/nodejs-buildpack-offline-b29.zip:
   object_id: 891514ac-a6ce-454b-9b3d-e7611b6db9f0
-  sha: !binary |-
-    NGViMGQ1ZTVlYmVkODhiOWYxMTIzOGNiYjA4MmI3OWIyMjA2NDQ4OA==
+  sha: 4eb0d5e5ebed88b9f11238cbb082b79b22064488
   size: 393231066
 ruby-buildpack/ruby-buildpack-offline-b53.zip:
   object_id: e6deac43-97c9-46b0-a3b3-9e2666db08aa
-  sha: !binary |-
-    YmY5YzliMzllN2Q4MTYwZDA4NjRkMDAzYmMyMTg0MDdhMTlhMzIzMQ==
+  sha: bf9c9b39e7d8160d0864d003bc218407a19a3231
   size: 747817037
 java-buildpack/java-buildpack-offline-v2.4.zip:
   object_id: 7498b6ad-60f5-4400-9f3a-35321a458e6d
-  sha: !binary |-
-    ZTAwZWJiZmRiZWJkNTQ3NWVjZmM0M2Y5ZmI4NjU4ZmMxZjYxOGRiNg==
+  sha: e00ebbfdbebd5475ecfc43f9fb8658fc1f618db6
   size: 225928527
 java-buildpack/java-buildpack-v2.4.zip:
   object_id: d5502109-bbe4-4794-8cc1-0f7cbd108fcf
-  sha: !binary |-
-    N2EwN2Q2MTYyODczZmRhMjlhMGFjZWIwM2FhYTUzZjZmMGVmZjI1YQ==
+  sha: 7a07d6162873fda29a0aceb03aaa53f6f0eff25a
   size: 137582
 php-buildpack/php_buildpack-offline-v1.0.1.zip:
   object_id: 94d12887-f035-43c0-b377-c8f4de9bf3da
-  sha: !binary |-
-    OWExOWViNTk0YTAzZDk4MGRkYzJkZTY4MjIwOTFlMGU1ZWVmYTgyNA==
+  sha: 9a19eb594a03d980ddc2de6822091e0e5eefa824
   size: 295649294
+go_buildpack-offline-v1.0.1.zip:
+  object_id: 4b260fdf-ca05-4896-8e0b-c12047ae975a
+  sha: ffd2cbda097b1f28e1350cf36e8fc37fbc408cc2
+  size: 375528925

--- a/packages/buildpack_go/packaging
+++ b/packages/buildpack_go/packaging
@@ -1,3 +1,3 @@
-set -e
+set -e -x
 
-cp go-buildpack/go-buildpack-offline-b7.zip ${BOSH_INSTALL_TARGET}
+cp go-buildpack/go_buildpack-offline-v1.0.1.zip ${BOSH_INSTALL_TARGET}

--- a/packages/buildpack_go/spec
+++ b/packages/buildpack_go/spec
@@ -1,4 +1,4 @@
 ---
 name: buildpack_go
 files:
-- go-buildpack/go-buildpack-offline-b7.zip
+- go-buildpack/go_buildpack-offline-v1.0.1.zip


### PR DESCRIPTION
Upgrading to latest stable version of go buildpack
 --Buildpacks Team
