### PR TITLE
bump persistent disk for api node in warden template

### DIFF
--- a/templates/cf-infrastructure-warden.yml
+++ b/templates/cf-infrastructure-warden.yml
@@ -286,7 +286,7 @@ jobs:
 
   # add a persistent disk to the CC, and only need one
   - name: api_z1
-    persistent_disk: 4096
+    persistent_disk: 8192
     templates:
       - name: cloud_controller_ng
       - name: cloud_controller_clock


### PR DESCRIPTION
Original value of 4096 is no longer sufficient, probably due to admin buildpacks
Bumping to 8192
