### PR TITLE
Update cf-jobs.yml

### DIFF
--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -20,29 +20,41 @@ meta:
 
   api_templates:
   - name: cloud_controller_ng
+    release: (( meta.release.name )) 
   - name: metron_agent
+    release: (( meta.release.name ))
 
   api_worker_templates:
   - name: cloud_controller_worker
+    release: (( meta.release.name ))
   - name: metron_agent
+    release: (( meta.release.name ))
 
   clock_templates:
   - name: cloud_controller_clock
+    release: (( meta.release.name ))
   - name: metron_agent
+    release: (( meta.release.name ))
 
   nats_templates:
   - name: nats
+    release: (( meta.release.name ))
   - name: nats_stream_forwarder
+    release: (( meta.release.name ))
 
   dea_templates:
   - name: dea_next
+    release: (( meta.release.name ))
   - name: dea_logging_agent
+    release: (( meta.release.name ))
   - name: metron_agent
+    release: (( meta.release.name ))
 
   router_templates:
   - name: gorouter
-    release: cf
+    release: (( meta.release.name ))
   - name: metron_agent
+    release: (( meta.release.name ))
 
   loggregator:
     servers:
@@ -51,10 +63,9 @@ meta:
 
 jobs:
   - name: ha_proxy_z1
-    release: (( meta.release.name ))
     templates:
     - name: haproxy
-      release: cf
+      release: (( meta.release.name ))
     instances: 0
     resource_pool: router_z1
     default_networks:
@@ -71,7 +82,6 @@ jobs:
           z2: (( jobs.router_z2.networks.cf2.static_ips ))
 
   - name: nats_z1
-    release: (( meta.release.name ))
     templates: (( merge || meta.nats_templates ))
     instances: 1
     resource_pool: medium_z1
@@ -82,7 +92,6 @@ jobs:
       networks: (( meta.networks.z1 ))
 
   - name: nats_z2
-    release: (( meta.release.name ))
     templates: (( merge || meta.nats_templates ))
     instances: 1
     resource_pool: medium_z2
@@ -93,10 +102,9 @@ jobs:
       networks: (( meta.networks.z2 ))
 
   - name: logs_z1
-    release: (( meta.release.name ))
     templates:
     - name: syslog_aggregator
-      release: cf
+      release: (( meta.release.name ))
     instances: 0
     resource_pool: medium_z1
     persistent_disk: 100000
@@ -107,10 +115,9 @@ jobs:
       networks: (( meta.networks.z1 ))
 
   - name: logs_z2
-    release: (( meta.release.name ))
     templates:
     - name: syslog_aggregator
-      release: cf
+      release: (( meta.release.name ))
     instances: 0
     resource_pool: medium_z2
     persistent_disk: 100000
@@ -121,10 +128,9 @@ jobs:
       networks: (( meta.networks.z2 ))
 
   - name: stats_z1
-    release: (( meta.release.name ))
     templates:
     - name: collector
-      release: cf
+      release: (( meta.release.name ))
     instances: 1
     resource_pool: small_z1
     networks:
@@ -133,10 +139,9 @@ jobs:
       networks: (( meta.networks.z1 ))
 
   - name: nfs_z1
-    release: (( meta.release.name ))
     templates:
     - name: debian_nfs_server
-      release: cf
+      release: (( meta.release.name ))
     instances: 0
     resource_pool: medium_z1
     persistent_disk: 102400
@@ -145,10 +150,9 @@ jobs:
         static_ips: ~
 
   - name: postgres_z1
-    release: (( meta.release.name ))
     templates:
     - name: postgres
-      release: cf
+      release: (( meta.release.name ))
     instances: 0
     resource_pool: medium_z1
     persistent_disk: 4096
@@ -157,10 +161,9 @@ jobs:
       static_ips: ~
 
   - name: uaa_z1
-    release: (( meta.release.name ))
     templates:
     - name: uaa
-      release: cf
+      release: (( meta.release.name ))
     instances: 1
     resource_pool: medium_z1
     networks:
@@ -169,10 +172,9 @@ jobs:
       networks: (( meta.networks.z1 ))
 
   - name: uaa_z2
-    release: (( meta.release.name ))
     templates:
     - name: uaa
-      release: cf
+      release: (( meta.release.name ))
     instances: 1
     resource_pool: medium_z2
     networks:
@@ -181,10 +183,9 @@ jobs:
       networks: (( meta.networks.z2 ))
 
   - name: login_z1
-    release: (( meta.release.name ))
     templates:
     - name: login
-      release: cf
+      release: (( meta.release.name ))
     instances: 1
     resource_pool: medium_z1
     networks:
@@ -193,10 +194,9 @@ jobs:
       networks: (( meta.networks.z1 ))
 
   - name: login_z2
-    release: (( meta.release.name ))
     templates:
     - name: login
-      release: cf
+      release: (( meta.release.name ))
     instances: 1
     resource_pool: medium_z2
     networks:
@@ -205,7 +205,6 @@ jobs:
       networks: (( meta.networks.z2 ))
 
   - name: api_z1
-    release: (( meta.release.name ))
     templates: (( merge || meta.api_templates ))
     instances: 1
     resource_pool: large_z1
@@ -219,7 +218,6 @@ jobs:
       nfs_server: (( meta.nfs_server ))
 
   - name: api_z2
-    release: (( meta.release.name ))
     templates: (( merge || meta.api_templates ))
     instances: 1
     resource_pool: large_z2
@@ -233,7 +231,6 @@ jobs:
       nfs_server: (( meta.nfs_server ))
 
   - name: clock_global
-    release: (( meta.release.name ))
     templates: (( merge || meta.clock_templates ))
     instances: 1
     resource_pool: medium_z1
@@ -246,7 +243,6 @@ jobs:
         zone: z1
 
   - name: api_worker_z1
-    release: (( meta.release.name ))
     templates: (( merge || meta.api_worker_templates ))
     instances: 1
     resource_pool: small_z1
@@ -260,7 +256,6 @@ jobs:
       nfs_server: (( meta.nfs_server ))
 
   - name: api_worker_z2
-    release: (( meta.release.name ))
     templates: (( merge || meta.api_worker_templates ))
     instances: 1
     resource_pool: small_z2
@@ -274,7 +269,6 @@ jobs:
       nfs_server: (( meta.nfs_server ))
 
   - name: etcd_z1
-    release: (( meta.release.name ))
     templates:
       - name: etcd
         release: (( meta.release.name ))
@@ -290,7 +284,6 @@ jobs:
       networks: (( meta.networks.z1 ))
 
   - name: etcd_z2
-    release: (( meta.release.name ))
     templates:
       - name: etcd
         release: (( meta.release.name ))
@@ -306,10 +299,9 @@ jobs:
       networks: (( meta.networks.z2 ))
 
   - name: hm9000_z1
-    release: (( meta.release.name ))
     templates:
     - name: hm9000
-      release: cf
+      release: (( meta.release.name ))
     instances: 1
     resource_pool: medium_z1
     networks:
@@ -318,10 +310,9 @@ jobs:
       networks: (( meta.networks.z1 ))
 
   - name: hm9000_z2
-    release: (( meta.release.name ))
     templates:
     - name: hm9000
-      release: cf
+      release: (( meta.release.name ))
     instances: 1
     resource_pool: medium_z2
     networks:
@@ -330,7 +321,6 @@ jobs:
       networks: (( meta.networks.z2 ))
 
   - name: runner_z1
-    release: (( meta.release.name ))
     templates: (( merge || meta.dea_templates ))
     instances: 1
     update:
@@ -345,7 +335,6 @@ jobs:
         zone: z1
 
   - name: runner_z2
-    release: (( meta.release.name ))
     templates: (( merge || meta.dea_templates ))
     instances: 1
     update:
@@ -360,10 +349,9 @@ jobs:
         zone: z2
 
   - name: loggregator_z1
-    release: (( meta.release.name ))
     templates:
     - name: loggregator
-      release: cf
+      release: (( meta.release.name ))
     instances: 2
     resource_pool: medium_z1
     networks:
@@ -375,10 +363,9 @@ jobs:
         zone: z1
 
   - name: loggregator_z2
-    release: (( meta.release.name ))
     templates:
     - name: loggregator
-      release: cf
+      release: (( meta.release.name ))
     instances: 2
     resource_pool: medium_z2
     networks:
@@ -390,10 +377,9 @@ jobs:
         zone: z2
 
   - name: loggregator_trafficcontroller_z1
-    release: (( meta.release.name ))
     templates:
     - name: loggregator_trafficcontroller
-      release: cf
+      release: (( meta.release.name ))
     instances: 1
     resource_pool: small_z1
     networks:
@@ -405,10 +391,9 @@ jobs:
         zone: z1
 
   - name: loggregator_trafficcontroller_z2
-    release: (( meta.release.name ))
     templates:
     - name: loggregator_trafficcontroller
-      release: cf
+      release: (( meta.release.name ))
     instances: 1
     resource_pool: small_z2
     networks:
@@ -444,10 +429,9 @@ jobs:
         zone: z2
 
   - name: acceptance_tests
-    release: (( meta.release.name ))
     templates:
     - name: acceptance-tests
-      release: cf
+      release: (( meta.release.name ))
     instances: 0
     resource_pool: small_errand
     lifecycle: errand
@@ -455,10 +439,9 @@ jobs:
       - name: cf1
 
   - name: smoke_tests
-    release: (( meta.release.name ))
     templates:
     - name: smoke-tests
-      release: cf
+      release: (( meta.release.name ))
     instances: 0
     resource_pool: small_errand
     lifecycle: errand


### PR DESCRIPTION
Remove duplication of the release key which previously existed at both the job and job template level. Moved release declaration to job templates only.
