### PR TITLE
Send nats logs to stderr so they end up in syslog.

### DIFF
--- a/jobs/nats/templates/nats.conf.erb
+++ b/jobs/nats/templates/nats.conf.erb
@@ -7,7 +7,6 @@ monitor_port: <%= p("nats.monitor_port") %>
 
 pid_file: "/var/vcap/sys/run/nats/nats.pid"
 
-log_file: "/var/vcap/sys/log/nats/nats.log"
 debug: <%= p("nats.debug") %>
 trace: <%= p("nats.trace") %>
 


### PR DESCRIPTION
GNats currently doesn't support syslog and it appears telling gnats to log to a file stops it from logging to stderr.  So this change removes nats logging to a file so that it logs to `/var/vcap/sys/log/nats_ctl.err.log` instead and also to syslog.
