### PR TITLE
Increase CC memory limit

### DIFF
--- a/jobs/cloud_controller_ng/monit
+++ b/jobs/cloud_controller_ng/monit
@@ -3,8 +3,8 @@ check process cloud_controller_ng
   start program "/var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng_ctl start"
   stop program "/var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng_ctl stop"
   group vcap
-  if totalmem > 2250 Mb then alert
-  if totalmem > 2450 Mb then restart
+  if totalmem > 3800 Mb then alert
+  if totalmem > 4000 Mb then restart
   if failed host <%= spec.networks.send(properties.networks.apps).ip %> port <%= p("cc.external_port") %> protocol http
       and request '/v2/info'
       with timeout 60 seconds for 5 cycles


### PR DESCRIPTION
CC in PWS has been getting restarted by monit several times a day.

Note that we haven't changed the memory limits on the workers; they never go close to their limits. We took a quick look before submitting this PR and saw one worker at 250mb and another at 400mb.

Thanks,
Chris && Jason
