### PR TITLE
Upgrading go buildpack to v1.0.2

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -257,11 +257,6 @@ php-buildpack/php_buildpack-offline-v1.0.1.zip:
   sha: !binary |-
     OWExOWViNTk0YTAzZDk4MGRkYzJkZTY4MjIwOTFlMGU1ZWVmYTgyNA==
   size: 295649294
-go-buildpack/go_buildpack-offline-v1.0.1.zip:
-  object_id: a2d815f9-e4df-48a9-9d8f-d933b0d0f0cf
-  sha: !binary |-
-    OTk3YWQwMWUwYjllZWRkNTU2NmM3MDQ4MGM3NjI0YzY0ZDQ1YWUwZQ==
-  size: 375528925
 python-buildpack/python_buildpack-offline-v1.0.2.zip:
   object_id: 7f087975-5304-4a32-9175-4a1868e88514
   sha: !binary |-
@@ -287,3 +282,8 @@ nodejs-buildpack/nodejs_buildpack-offline-v1.0.2.zip:
   sha: !binary |-
     NDIyNGJhYjU3ODdjMTYyMjUwNWFjOTQ3ZTAyYTU2YTQ1ZWFlMjIwNg==
   size: 425672760
+go-buildpack/go_buildpack-offline-v1.0.2.zip:
+  object_id: 27bac09d-67c3-4799-836b-6ee62db62e22
+  sha: !binary |-
+    MmQ3NmEyMGZmYmU3NWNkZWFmZjQ4ZGE3MWQ0NGJkMWI3YmUwZDFiNg==
+  size: 380867344

--- a/packages/buildpack_go/packaging
+++ b/packages/buildpack_go/packaging
@@ -1,3 +1,3 @@
 set -e -x
 
-cp go-buildpack/go_buildpack-offline-v1.0.1.zip ${BOSH_INSTALL_TARGET}
+cp go-buildpack/go_buildpack-offline-v1.0.2.zip ${BOSH_INSTALL_TARGET}

--- a/packages/buildpack_go/spec
+++ b/packages/buildpack_go/spec
@@ -1,4 +1,4 @@
 ---
 name: buildpack_go
 files:
-- go-buildpack/go_buildpack-offline-v1.0.1.zip
+- go-buildpack/go_buildpack-offline-v1.0.2.zip


### PR DESCRIPTION
Upgrading to latest stable version of go buildpack
 --Buildpacks Team
