### PR TITLE
Java Buildpack v2.5

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -247,16 +247,6 @@ java-buildpack/java-buildpack-offline-v2.4.zip:
   sha: !binary |-
     ZTAwZWJiZmRiZWJkNTQ3NWVjZmM0M2Y5ZmI4NjU4ZmMxZjYxOGRiNg==
   size: 225928527
-java-buildpack/java-buildpack-v2.4.zip:
-  object_id: d5502109-bbe4-4794-8cc1-0f7cbd108fcf
-  sha: !binary |-
-    N2EwN2Q2MTYyODczZmRhMjlhMGFjZWIwM2FhYTUzZjZmMGVmZjI1YQ==
-  size: 137582
-php-buildpack/php_buildpack-offline-v1.0.1.zip:
-  object_id: 94d12887-f035-43c0-b377-c8f4de9bf3da
-  sha: !binary |-
-    OWExOWViNTk0YTAzZDk4MGRkYzJkZTY4MjIwOTFlMGU1ZWVmYTgyNA==
-  size: 295649294
 go-buildpack/go_buildpack-offline-v1.0.1.zip:
   object_id: a2d815f9-e4df-48a9-9d8f-d933b0d0f0cf
   sha: !binary |-
@@ -287,3 +277,13 @@ nodejs-buildpack/nodejs_buildpack-offline-v1.0.2.zip:
   sha: !binary |-
     NDIyNGJhYjU3ODdjMTYyMjUwNWFjOTQ3ZTAyYTU2YTQ1ZWFlMjIwNg==
   size: 425672760
+java-buildpack/java-buildpack-offline-v2.5.zip:
+  object_id: 2c6c5479-4adb-44a3-b068-e015dee20d80
+  sha: !binary |-
+    ZTg3NjEzZTM2YzZmN2QzM2I0ZDNkNDQ0NDc5YTBlZDQ2YzRmNmM0Ng==
+  size: 260373206
+java-buildpack/java-buildpack-v2.5.zip:
+  object_id: 2c4ed48f-4154-49af-b98d-199558fc8ea0
+  sha: !binary |-
+    YjRhZGVkNDY5NTg4MzA1YmU2NWM2NDU1MGNjZjAxMTU5MzQyNDk0ZQ==
+  size: 138186

--- a/packages/buildpack_java/packaging
+++ b/packages/buildpack_java/packaging
@@ -1,3 +1,3 @@
 set -e
 
-cp java-buildpack/java-buildpack-v2.4.zip ${BOSH_INSTALL_TARGET}
+cp java-buildpack/java-buildpack-v2.5.zip ${BOSH_INSTALL_TARGET}

--- a/packages/buildpack_java/spec
+++ b/packages/buildpack_java/spec
@@ -2,4 +2,4 @@
 name: buildpack_java
 
 files:
-  - java-buildpack/java-buildpack-v2.4.zip
+  - java-buildpack/java-buildpack-v2.5.zip

--- a/packages/buildpack_java_offline/packaging
+++ b/packages/buildpack_java_offline/packaging
@@ -1,3 +1,3 @@
 set -e
 
-cp java-buildpack/java-buildpack-offline-v2.4.zip ${BOSH_INSTALL_TARGET}
+cp java-buildpack/java-buildpack-offline-v2.5.zip ${BOSH_INSTALL_TARGET}

--- a/packages/buildpack_java_offline/spec
+++ b/packages/buildpack_java_offline/spec
@@ -2,4 +2,4 @@
 name: buildpack_java_offline
 
 files:
-  - java-buildpack/java-buildpack-offline-v2.4.zip
+  - java-buildpack/java-buildpack-offline-v2.5.zip


### PR DESCRIPTION
This change updates the Java Buildpack to version 2.5.  Version 2.5 has the following highlights:
- Improved Access Logging (via Guillaume Berche and and Kevin Kessler)
- Improved AppDynamics Integration (via Troy Astle, Max Brunsfeld, Mike Youngstrom, and Shaozhen Ding)
- New Relic on Java 8
- Secure Dependency Retrieval via HTTPS
- Java 8 as Default
- Tomcat 8 as Default (via Dave Head-Rapson)

Both the online and offline buildpacks are updated as part of this change.
