### PR TITLE
Upgrading Go buildpack to v1.0.4

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -277,13 +277,13 @@ nodejs-buildpack/nodejs_buildpack-offline-v1.0.4.zip:
   sha: !binary |-
     ZjdlMzUzMjJmNWMyMGYxZTNmNzk2NDlmNDQzZDNjMzQzZDlkNjdlMw==
   size: 432322734
-go-buildpack/go_buildpack-offline-v1.0.3.zip:
-  object_id: e4b4e5f0-d426-4c2f-b8ce-8118f665b246
-  sha: !binary |-
-    ZWFiM2MyMjU5MzgzZGI1YjIxMTk5OTdiNGQ5NjY2OWQ5NTNkM2I0MA==
-  size: 380867418
 php-buildpack/php_buildpack-offline-v1.0.2.zip:
   object_id: e4c91c19-a19d-4c50-82b4-616796375957
   sha: !binary |-
     YjMwZGQ4YzgwMDE2ZWZmNzA0NTAyZWNlNjQxYTQ5N2I4N2EyMTc3NA==
   size: 295649665
+go-buildpack/go_buildpack-offline-v1.0.4.zip:
+  object_id: af418810-e826-4c71-a73d-781b1e4ff2f7
+  sha: !binary |-
+    ZjFiZDNlNGNlODcxZmViODM3M2EyYzIwOTVkN2Y0ZDQ0ZWIzNWEwOA==
+  size: 537934076

--- a/packages/buildpack_go/packaging
+++ b/packages/buildpack_go/packaging
@@ -1,3 +1,3 @@
 set -e -x
 
-cp go-buildpack/go_buildpack-offline-v1.0.3.zip ${BOSH_INSTALL_TARGET}
+cp go-buildpack/go_buildpack-offline-v1.0.4.zip ${BOSH_INSTALL_TARGET}

--- a/packages/buildpack_go/spec
+++ b/packages/buildpack_go/spec
@@ -1,4 +1,4 @@
 ---
 name: buildpack_go
 files:
-- go-buildpack/go_buildpack-offline-v1.0.3.zip
+- go-buildpack/go_buildpack-offline-v1.0.4.zip


### PR DESCRIPTION
Upgrading to latest stable version of Go buildpack
 --Buildpacks Team
