### PR TITLE
add comments for CF Docs 'code_snippet' to spec/fixtures/aws/cf-stub.yml

### DIFF
--- a/spec/fixtures/aws/cf-stub.yml
+++ b/spec/fixtures/aws/cf-stub.yml
@@ -1,3 +1,5 @@
+# The following line helps maintain current documentation at http://docs.cloudfoundry.org.
+# code_snippet cf-stub-aws start
 ---
 director_uuid: DIRECTOR_UUID
 meta:
@@ -39,7 +41,7 @@ properties:
     databases:
     - tag: cc
       name: ccdb
-    address: ccdb.example.com 
+    address: ccdb.example.com
     port: 0
   dea_next:
     disk_mb: 2048
@@ -98,5 +100,8 @@ properties:
     databases:
     - tag: uaa
       name: uaadb
-    address: uaadb.example.com 
+    address: uaadb.example.com
     port: 0
+
+# code_snippet cf-stub-aws end
+# The previous line helps maintain current documentation at http://docs.cloudfoundry.org.


### PR DESCRIPTION
The 'code_snippet' comments allows the full yml to be pulled into CF documentation when we build them instead of having to cut-and-paste yml manually. Outdated yml examples in our documentation will be a thing of the past!  
