### PR TITLE
vsphere template: increase RAM used by jobs using large pool resource po...

### DIFF
--- a/templates/cf-infrastructure-vsphere.yml
+++ b/templates/cf-infrastructure-vsphere.yml
@@ -38,13 +38,13 @@ resource_pools:
 
   - name: large_z1
     cloud_properties:
-      ram: 1024
+      ram: 2048
       disk: 10240
       cpu: 1
 
   - name: large_z2
     cloud_properties:
-      ram: 1024
+      ram: 2048
       disk: 10240
       cpu: 1
 


### PR DESCRIPTION
We have had API crashes due to API job consuming whole system memory. We are deploying cloud foundry V188 on VCloud director, using stemcell vcloud_esxi_ubuntu_trusty_go_agent, build 2732.

API jobs use the large resource pool, which involve only 1Gb of RAM (the same as what is defined in small and medium resource pools).

On a fresh install, launching "bosh vms --vitals", we see that
- api_z1/0 already use  1,1G
- api_z2/0 700M.

Increasing the RAM size from 1G to 2G on large resource pool solve the problem.
