### PR TITLE
allow login-server to be disabled via spiff templates

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -716,6 +716,7 @@ properties:
   loggregator_endpoint:
     shared_secret: secret
   login:
+    enabled: true
     analytics:
       code: null
       domain: null
@@ -991,4 +992,3 @@ update:
   max_in_flight: 1
   serial: true
   update_watch_time: 5000-600000
-

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -709,6 +709,7 @@ properties:
   loggregator_endpoint:
     shared_secret: loggregator_endpoint_secret
   login:
+    enabled: true
     analytics:
       code: null
       domain: null
@@ -967,4 +968,3 @@ update:
   max_in_flight: 1
   serial: true
   update_watch_time: 5000-600000
-

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -719,6 +719,7 @@ properties:
   loggregator_endpoint:
     shared_secret: loggregator_endpoint_secret
   login:
+    enabled: true
     analytics:
       code: null
       domain: null
@@ -1003,4 +1004,3 @@ update:
   max_in_flight: 1
   serial: true
   update_watch_time: 5000-600000
-

--- a/spec/fixtures/warden/cf-manifest.yml
+++ b/spec/fixtures/warden/cf-manifest.yml
@@ -2451,6 +2451,7 @@ properties:
   loggregator_endpoint:
     shared_secret: PLACEHOLDER-LOGGREGATOR-SECRET
   login:
+    enabled: true
     analytics:
       code: null
       domain: null
@@ -2765,4 +2766,3 @@ update:
   max_in_flight: 50
   serial: true
   update_watch_time: 1000-180000
-

--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -164,6 +164,7 @@ properties:
         restart_if_above_mb: ~
 
   login:
+    enabled: true
     analytics:
       code: ~
       domain: ~


### PR DESCRIPTION
Allow a BOSH deployment of CF to not include the login-server; and result in the CCNG deferring to the UAA instead of a Login Server.
