### PR TITLE
Ability to customize login server messages

### DIFF
--- a/jobs/login/spec
+++ b/jobs/login/spec
@@ -14,6 +14,7 @@ templates:
   # Updates to Tomcat must also check web.xml
   web.xml.erb: config/tomcat/web.xml
   uaa.crt.erb: config/uaa.crt
+  messages.properties.erb: config/messages.properties
 
 packages:
   - common
@@ -173,3 +174,23 @@ properties:
     description: "Analytics code"
   login.analytics.domain:
     description: "Analytics domain"
+  login.messages:
+    description: |
+      A nested or flat hash of messages that the login server uses to display UI message
+      This will be flattened into a java.util.Properties file. The example below will lead
+      to four properties, where the key is the concatenated value delimited by dot, for example scope.tokens.read=message
+      Nested example:
+      messages:
+        scope:
+          tokens:
+            read: View details of your approvals you have granted to this and other applications
+            write: Cancel the approvals like this one that you have granted to this and other applications
+          cloud_controller:
+            read: View details of your applications and services
+            write: Push applications to your account and create and bind services
+      Flat example:
+      messages:
+        scope.tokens.read: View details of your approvals you have granted to this and other applications
+        scope.tokens.write: Cancel the approvals like this one that you have granted to this and other applications
+        scope.cloud_controller.read: View details of your applications and services
+        scope.cloud_controller.write: Push applications to your account and create and bind services

--- a/jobs/login/templates/messages.properties.erb
+++ b/jobs/login/templates/messages.properties.erb
@@ -1,0 +1,21 @@
+<%
+def flatten_keys(key, value, flathash)
+  if value.is_a?(OpenStruct) then
+    value.marshal_dump.each {|newkey, newvalue|
+      flatten_keys(key.to_s + "." + newkey.to_s, newvalue, flathash)
+    }
+  else
+    flathash.store(key,value)
+  end
+end
+
+if properties.login && !properties.login.messages.nil? then
+  flathash = Hash.new
+  properties.login.messages.marshal_dump.each do |msgKey,msgText|
+    flatten_keys(msgKey, msgText, flathash)
+  end
+  flathash.each do |msgKey, msgText| %>
+<%= msgKey %>=<%= msgText %><%
+  end
+end
+%>

--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -741,6 +741,7 @@ properties:
     uaa_base: null
     uaa_certificate: null
     url: null
+    messages: null
   metron_endpoint:
     shared_secret: secret
   nats:

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -734,6 +734,7 @@ properties:
     uaa_base: null
     uaa_certificate: null
     url: null
+    messages: null
   metron_endpoint:
     shared_secret: loggregator_endpoint_secret
   nats:

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -744,6 +744,7 @@ properties:
     uaa_base: null
     uaa_certificate: null
     url: null
+    messages: null
   metron_endpoint:
     shared_secret: loggregator_endpoint_secret
   nats:

--- a/spec/fixtures/warden/cf-manifest.yml
+++ b/spec/fixtures/warden/cf-manifest.yml
@@ -2476,6 +2476,7 @@ properties:
     uaa_base: null
     uaa_certificate: null
     url: null
+    messages: null
   metron_endpoint:
     shared_secret: PLACEHOLDER-LOGGREGATOR-SECRET
   nats:

--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -176,6 +176,7 @@ properties:
     uaa_base: ~
     signups_enabled: ~
     spring_profiles: ~
+    messages: ~
 
     smtp:
       host: ~


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/71871918
This commit allows a new file to be configured
$CLOUD_COUNDRY_CONFIG_PATH/messages.properties
to contains custom messages for the login server.
This is useful when there is a need to display a description for a scope
during the OAuth user approval process of scopes/permissions
