### PR TITLE
add comments for CF Docs 'code_snippet' to cf-stub.yml files in spec/fix...

### DIFF
--- a/spec/fixtures/openstack/cf-stub.yml
+++ b/spec/fixtures/openstack/cf-stub.yml
@@ -1,3 +1,5 @@
+# The following line helps maintain current documentation at http://docs.cloudfoundry.org.
+# code_snippet cf-stub-openstack start
 ---
 director_uuid: DIRECTOR_UUID
 meta:
@@ -86,3 +88,6 @@ properties:
     - name: uaaadmin
       password: admin_password
       tag: admin
+
+# code_snippet cf-stub-openstack end
+# The previous line helps maintain current documentation at http://docs.cloudfoundry.org.

--- a/spec/fixtures/vsphere/cf-stub.yml
+++ b/spec/fixtures/vsphere/cf-stub.yml
@@ -1,3 +1,5 @@
+# The following line helps maintain current documentation at http://docs.cloudfoundry.org.
+# code_snippet cf-stub-vsphere start
 ---
 director_uuid: DIRECTOR_UUID
 
@@ -68,3 +70,6 @@ properties:
     scim:
       users:
       - admin|fakepassword|scim.write,scim.read,openid,cloud_controller.admin,doppler.firehose
+
+# code_snippet cf-stub-vsphere end
+# The previous line helps maintain current documentation at http://docs.cloudfoundry.org.

--- a/spec/fixtures/warden/cf-stub.yml
+++ b/spec/fixtures/warden/cf-stub.yml
@@ -1,3 +1,5 @@
+# The following line helps maintain current documentation at http://docs.cloudfoundry.org.
+# code_snippet cf-stub-warden start
 ---
 name: cf-warden
 director_uuid: DIRECTOR_UUID
@@ -42,3 +44,6 @@ properties:
         - protocol: all
           destination: 10.244.3.0/24
     default_running_security_groups: ["public_networks", "dns", "services"]
+
+# code_snippet cf-stub-warden end
+# The previous line helps maintain current documentation at http://docs.cloudfoundry.org.


### PR DESCRIPTION
The 'code_snippet' comments allows the full yml to be pulled into CF documentation when we build them instead of having to cut-and-paste yml manually.
