### PR TITLE
Adds notification_templates.admin to UAA admin user

### DIFF
--- a/templates/cf-infrastructure-warden.yml
+++ b/templates/cf-infrastructure-warden.yml
@@ -116,7 +116,7 @@ properties:
         secret: doppler-secret
     scim:
       users:
-      - admin|admin|scim.write,scim.read,openid,cloud_controller.admin,clients.read,clients.write,doppler.firehose
+      - admin|admin|scim.write,scim.read,openid,cloud_controller.admin,clients.read,clients.write,doppler.firehose,notification_templates.admin
     no_ssl: true
 
   login:


### PR DESCRIPTION
The notifications service has an API that allows clients to modify their
own notification templates. Modification requires the
notification_templates.admin scope. We have added the scope for
warden infrastructures as a convenience.

[#80596206]
