### PR TITLE
Add in the ability to configure IP restrictions for the UAA and Login Server

### DIFF
--- a/jobs/login/spec
+++ b/jobs/login/spec
@@ -198,3 +198,6 @@ properties:
         scope.tokens.write: Cancel the approvals like this one that you have granted to this and other applications
         scope.cloud_controller.read: View details of your applications and services
         scope.cloud_controller.write: Push applications to your account and create and bind services
+  login.restricted_ips_regex:
+    description: "A pipe delimited set of regular expressions of IP addresses that can reach the listening HTTP port of the server."
+    default: "10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}"

--- a/jobs/login/templates/tomcat.server.xml.erb
+++ b/jobs/login/templates/tomcat.server.xml.erb
@@ -15,9 +15,8 @@
         <Valve className="org.apache.catalina.valves.RemoteIpValve"
                remoteIpHeader="x-forwarded-for"
                protocolHeader="x-forwarded-proto"
-               internalProxies="10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}" 
+               internalProxies="<%= properties.login.restricted_ips_regex ? properties.login.restricted_ips_regex : "10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}" %>" 
         />
-
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="/var/vcap/sys/log/login"
                prefix="localhost_access." suffix=".log" rotatable="true" pattern="%h %l %u %t &quot;%r&quot; %s %b"/>
 

--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -228,3 +228,6 @@ properties:
     description: "See uaa.spring_profiles - login.spring_profiles is used for backwards compatibility to enable ldap from login config"
   login.protocol:
     description: "The protocol that the Login Server uses. http/https"
+  uaa.restricted_ips_regex:
+    description: "A pipe delimited set of regular expressions of IP addresses that can reach the listening HTTP port of the server."
+    default: "10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}"

--- a/jobs/uaa/templates/tomcat.server.xml.erb
+++ b/jobs/uaa/templates/tomcat.server.xml.erb
@@ -15,9 +15,8 @@
         <Valve className="org.apache.catalina.valves.RemoteIpValve"
                remoteIpHeader="x-forwarded-for"
                protocolHeader="x-forwarded-proto"
-               internalProxies="10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}" 
+               internalProxies="<%= properties.uaa.restricted_ips_regex ? properties.uaa.restricted_ips_regex : "10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}" %>" 
         />
-
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="/var/vcap/sys/log/uaa"
                prefix="localhost_access." suffix=".log" rotatable="true" pattern="%h %l %u %t &quot;%r&quot; %s %b"/>
 

--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -802,6 +802,7 @@ properties:
     notifications:
       url: null
     protocol: https
+    restricted_ips_regex: null
     saml: null
     signups_enabled: null
     smtp:
@@ -926,6 +927,7 @@ properties:
     ldap: null
     login: null
     no_ssl: false
+    restricted_ips_regex: null
     scim:
       external_groups: null
       userids_enabled: false

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -797,6 +797,7 @@ properties:
     notifications:
       url: null
     protocol: https
+    restricted_ips_regex: null
     saml: null
     signups_enabled: null
     smtp:
@@ -920,6 +921,7 @@ properties:
     ldap: null
     login: null
     no_ssl: false
+    restricted_ips_regex: null
     scim:
       external_groups: null
       userids_enabled: false

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -807,6 +807,7 @@ properties:
     notifications:
       url: null
     protocol: http
+    restricted_ips_regex: null
     saml: null
     signups_enabled: null
     smtp:
@@ -929,6 +930,7 @@ properties:
     ldap: null
     login: null
     no_ssl: false
+    restricted_ips_regex: null
     scim:
       external_groups: null
       userids_enabled: false

--- a/spec/fixtures/warden/cf-manifest.yml
+++ b/spec/fixtures/warden/cf-manifest.yml
@@ -2538,6 +2538,7 @@ properties:
     notifications:
       url: null
     protocol: http
+    restricted_ips_regex: null
     saml: null
     signups_enabled: null
     smtp:
@@ -2716,6 +2717,7 @@ properties:
     ldap: null
     login: null
     no_ssl: true
+    restricted_ips_regex: null
     scim:
       external_groups: null
       userids_enabled: false

--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -208,6 +208,8 @@ properties:
 
     saml: ~
 
+    restricted_ips_regex: ~
+
   uaa:
     catalina_opts: (( merge ))
 
@@ -305,3 +307,5 @@ properties:
         override: true
         authorities: uaa.resource
         secret: (( merge ))
+
+    restricted_ips_regex: ~


### PR DESCRIPTION
Add in the ability to configure IP restrictions for the UAA and Login Server HTTP ports.

These have til date been preconfigured with a set of private ranges
https://www.pivotaltracker.com/story/show/81048758
[#81048758]
