### PR TITLE
Adds notification_templates.admin to UAA admin user

### DIFF
--- a/spec/fixtures/warden/cf-manifest.yml
+++ b/spec/fixtures/warden/cf-manifest.yml
@@ -2720,7 +2720,7 @@ properties:
       external_groups: null
       userids_enabled: false
       users:
-      - admin|admin|scim.write,scim.read,openid,cloud_controller.admin,clients.read,clients.write,doppler.firehose
+      - admin|admin|scim.write,scim.read,openid,cloud_controller.admin,clients.read,clients.write,doppler.firehose,notification_templates.admin
     spring_profiles: null
     url: https://uaa.10.244.0.34.xip.io
     user: null

--- a/templates/cf-infrastructure-warden.yml
+++ b/templates/cf-infrastructure-warden.yml
@@ -120,7 +120,7 @@ properties:
         secret: doppler-secret
     scim:
       users:
-      - admin|admin|scim.write,scim.read,openid,cloud_controller.admin,clients.read,clients.write,doppler.firehose
+      - admin|admin|scim.write,scim.read,openid,cloud_controller.admin,clients.read,clients.write,doppler.firehose,notification_templates.admin
     no_ssl: true
 
   login:


### PR DESCRIPTION
The notifications service has an API that allows clients to modify their
own notification templates. Modification requires the
notification_templates.admin scope. We have added the scope for
warden infrastructures as a convenience.

[#80596206]
