### PR TITLE
adding default overrideable AWS region

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -552,6 +552,7 @@ properties:
         aws_access_key_id: AWS_ACCESS_KEY
         aws_secret_access_key: AWS_SECRET_ACCESS_KEY
         provider: AWS
+        region: us-east-1
     bulk_api_password: password
     internal_api_user: internal_user
     internal_api_password: password
@@ -595,6 +596,7 @@ properties:
         aws_access_key_id: AWS_ACCESS_KEY
         aws_secret_access_key: AWS_SECRET_ACCESS_KEY
         provider: AWS
+        region: us-east-1
     external_host: api
     install_buildpacks:
     - name: java_buildpack
@@ -647,6 +649,7 @@ properties:
         aws_access_key_id: AWS_ACCESS_KEY
         aws_secret_access_key: AWS_SECRET_ACCESS_KEY
         provider: AWS
+        region: us-east-1
       max_package_size: 1073741824
     quota_definitions:
       default:
@@ -660,6 +663,7 @@ properties:
         aws_access_key_id: AWS_ACCESS_KEY
         aws_secret_access_key: AWS_SECRET_ACCESS_KEY
         provider: AWS
+        region: us-east-1
       resource_directory_key: example.com-cc-resources
     security_group_definitions:
     - name: public_networks

--- a/templates/cf-infrastructure-aws.yml
+++ b/templates/cf-infrastructure-aws.yml
@@ -7,6 +7,7 @@ meta:
     provider: AWS
     aws_access_key_id: (( properties.template_only.aws.access_key_id ))
     aws_secret_access_key: (( properties.template_only.aws.secret_access_key ))
+    region: us-east-1
 
   stemcell:
     name: bosh-aws-xen-ubuntu-trusty-go_agent


### PR DESCRIPTION
Allows fog connections to non US-EAST regions of AWS by
allowing this property to be overriden in stub files (meta.fog_config.region).

Without adding a region entry to the template, the manifest needs to modified after generation to add a regions for non us east regions. Just adding just a meta.fog_config.region value to the stub will not work.

Note: sorry for doubling up on pull requests - i hosed my for with a badly thought out force push.
