### PR TITLE
Allow core files to be generated in warden

### DIFF
--- a/jobs/dea_next/templates/warden.yml.erb
+++ b/jobs/dea_next/templates/warden.yml.erb
@@ -5,6 +5,8 @@ server:
   container_klass: Warden::Container::Linux
   container_rootfs_path: /var/vcap/packages/rootfs_lucid64
   container_depot_path: /var/vcap/data/warden/depot
+  container_rlimits:
+    core: -1
   pidfile: /var/vcap/sys/run/warden/warden.pid
   quota:
     disk_quota_enabled: <%= p("disk_quota_enabled") %>


### PR DESCRIPTION
https://www.pivotaltracker.com/s/projects/1151414/stories/80448324

The current core limit is the default 0, which prevent user to generate a java system dump in warden container.
