### PR TITLE
Enable logging and fix syntax errors

### DIFF
--- a/jobs/nfs_mounter/templates/nfs_mounter_ctl.erb
+++ b/jobs/nfs_mounter/templates/nfs_mounter_ctl.erb
@@ -8,6 +8,7 @@ LOG_DIR=/var/vcap/sys/log/nfs_mounter
 export CONFIG_DIR=$NFS_JOB_DIR/config
 export NFS_SHARE=<% properties.nfs_server.share_path %>
 
+source /var/vcap/packages/common/utils.sh
 source $NFS_JOB_DIR/bin/handle_nfs_blobstore.sh
 
 case $1 in
@@ -16,10 +17,11 @@ case $1 in
     mkdir -p $LOG_DIR
     chown vcap:vcap $LOG_DIR
 
-    mount_nfs()
+    mount_nfs
+    ;;
 
   stop)
-    unmount_nfs()
+    unmount_nfs
     ;;
 
   *)


### PR DESCRIPTION
Currently, this script errors out with a syntax error since "mount_nfs()" is syntax for creating a function, not invoking one. The same problem exists with "unmount_nfs()". Also, the "start)" case wasn't terminated.

Additionally, this job should log its output like the other jobs in CF so I added the inclusion of comm/utils.sh which enables this.
