### PR TITLE
Add possibility to specify postgres role permissions in manifest

### DIFF
--- a/jobs/postgres/templates/postgres_ctl.erb
+++ b/jobs/postgres/templates/postgres_ctl.erb
@@ -85,6 +85,13 @@ case "$1" in
       $PACKAGE_DIR/bin/psql -U vcap -p $PORT -d postgres \
                             -c "ALTER ROLE \"<%= role["name"] %>\" \
                                 WITH LOGIN PASSWORD '<%= role["password"] %>'"
+
+      <% if role["permissions"] %>
+        echo "Adding permissions <%= role["permissions"].join(' ') %>  for for role <%= role["name"] %>..."
+        $PACKAGE_DIR/bin/psql -U vcap -p $PORT -d postgres \
+                          -c "ALTER ROLE \"<%= role["name"] %>\" \
+                              WITH <%= role["permissions"].join(' ') %>"
+      <% end %>
     <% end %>
 
     echo "Creating databases..."


### PR DESCRIPTION
I am working on an automation for backup and restore of a cf instance and I need a powerful enough user for remote management of the database.
The proposed path enables me to declare a new role in my manifest and assign whatever permissions are needed. For example:

```
   - tag: admin
           name: power_user
           password: admin
           permissions:
           - SUPERUSER
           - CREATEDB
           - CREATEROLE
```
