### PR TITLE
Allow core files to be generated in warden

### DIFF
--- a/jobs/dea_next/spec
+++ b/jobs/dea_next/spec
@@ -106,10 +106,12 @@ properties:
   dea_next.heartbeat_interval_in_seconds:
     description: "frequency of heartbeats in seconds."
     default: 10
-
   dea_next.zone:
     description: "The Availability Zone"
     default: "default"
+  dea_next.rlimit_core:
+    description: "Maximum size of core file. 0 represents no core dump files can be created, and -1 represents no size limits."
+    default: 0
   disk_quota_enabled:
     description: "disk quota must be disabled to use warden-inside-warden with the warden cpi"
     default: true

--- a/jobs/dea_next/templates/warden.yml.erb
+++ b/jobs/dea_next/templates/warden.yml.erb
@@ -5,6 +5,8 @@ server:
   container_klass: Warden::Container::Linux
   container_rootfs_path: /var/vcap/packages/rootfs_lucid64
   container_depot_path: /var/vcap/data/warden/depot
+  container_rlimits:
+    core: <%= p("dea_next.rlimit_core") %>
   pidfile: /var/vcap/sys/run/warden/warden.pid
   quota:
     disk_quota_enabled: <%= p("disk_quota_enabled") %>


### PR DESCRIPTION
The change in https://github.com/cloudfoundry/stacks/pull/11 adds a matching /var/vcap/sys/cores directory
inside the container so that core dumps work. However, that this still
prevents core dumps by default because the standard warden configuration sets the
max core dump size to 0.

So we need make the rlimit_core configurable.
