### PR TITLE
Adds default scopes for all UAA user tokens

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -54,6 +54,8 @@ properties:
       - uaa.user
       - approvals.me
       - oauth.approvals
+      - notification_preferences.read
+      - notification_preferences.write
   uaa.clients:
     description:
   uaa.jwt.signing_key:


### PR DESCRIPTION
When CF ships with notifications, users will need a couple new scopes to
be able to manage their notifications preferences. We are including
these scopes here so that all future users will have them.

[#83221726]