### PR TITLE
Java Buildpack v2.6

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -252,16 +252,6 @@ rootfs/lucid64.tar.gz:
   sha: !binary |-
     OWQ4YTgyMjI3YTU1ZjI4YmE2ZWE2ZGE5ZTJjOWQ2NGM2NGJhMzhkNg==
   size: 202427263
-java-buildpack/java-buildpack-offline-v2.5.zip:
-  object_id: 2c6c5479-4adb-44a3-b068-e015dee20d80
-  sha: !binary |-
-    ZTg3NjEzZTM2YzZmN2QzM2I0ZDNkNDQ0NDc5YTBlZDQ2YzRmNmM0Ng==
-  size: 260373206
-java-buildpack/java-buildpack-v2.5.zip:
-  object_id: 2c4ed48f-4154-49af-b98d-199558fc8ea0
-  sha: !binary |-
-    YjRhZGVkNDY5NTg4MzA1YmU2NWM2NDU1MGNjZjAxMTU5MzQyNDk0ZQ==
-  size: 138186
 nodejs-buildpack/nodejs_buildpack-offline-v1.0.4.zip:
   object_id: c38a663c-04b8-4a56-a5aa-217deb3b7b75
   sha: !binary |-
@@ -307,3 +297,13 @@ ruby-buildpack/ruby_buildpack-offline-v1.1.4.zip:
   sha: !binary |-
     MDk4MTM0NWVhNjMyMTYwN2Y1Nzk1OWFlYWU1NDZlODFlNWM3YzQyYw==
   size: 801585761
+java-buildpack/java-buildpack-offline-v2.6.zip:
+  object_id: 9cee25a1-ddef-42c8-8b42-00631eb83414
+  sha: !binary |-
+    NWEyNGI3MGIzNDQ5YmFkNmU1NDY2YTg1ZGJiNDUyMTg3Mzg5ZDlmMg==
+  size: 260620470
+java-buildpack/java-buildpack-v2.6.zip:
+  object_id: 35e3995c-d12d-41ae-b0c3-e817f9837415
+  sha: !binary |-
+    MjM1NDBlOGM4MjBlYjM2NTc1N2Y0M2IxM2ZmNjU1NDY4YzE1YjI1Mg==
+  size: 138301

--- a/packages/buildpack_java/packaging
+++ b/packages/buildpack_java/packaging
@@ -1,3 +1,3 @@
 set -e
 
-cp java-buildpack/java-buildpack-v2.5.zip ${BOSH_INSTALL_TARGET}
+cp java-buildpack/java-buildpack-v2.6.zip ${BOSH_INSTALL_TARGET}

--- a/packages/buildpack_java/spec
+++ b/packages/buildpack_java/spec
@@ -2,4 +2,4 @@
 name: buildpack_java
 
 files:
-  - java-buildpack/java-buildpack-v2.5.zip
+  - java-buildpack/java-buildpack-v2.6.zip

--- a/packages/buildpack_java_offline/packaging
+++ b/packages/buildpack_java_offline/packaging
@@ -1,3 +1,3 @@
 set -e
 
-cp java-buildpack/java-buildpack-offline-v2.5.zip ${BOSH_INSTALL_TARGET}
+cp java-buildpack/java-buildpack-offline-v2.6.zip ${BOSH_INSTALL_TARGET}

--- a/packages/buildpack_java_offline/spec
+++ b/packages/buildpack_java_offline/spec
@@ -2,4 +2,4 @@
 name: buildpack_java_offline
 
 files:
-  - java-buildpack/java-buildpack-offline-v2.5.zip
+  - java-buildpack/java-buildpack-offline-v2.6.zip


### PR DESCRIPTION
This change updates the Java Buildpack to version `2.6`.  Version `2.6` has the following highlights:
- Print `OutOfMemory` diagnostics to Loggregator (via Troy Astle)
- Support for custom CA certificates when download from a repository (via Dave Head-Rapson)
- Tomcat Redis Session Replication support for alternate Redis services (via Neil Aitken)
- Improved SSL Diagnostics

Both the online and offline buildpacks are updated as part of this change.
