### PR TITLE
Fix: NFS_SHARE not set properly in nfs_mounter_ctl.erb

### DIFF
--- a/jobs/nfs_mounter/templates/nfs_mounter_ctl.erb
+++ b/jobs/nfs_mounter/templates/nfs_mounter_ctl.erb
@@ -6,7 +6,7 @@ RUN_DIR=/var/vcap/sys/run/nfs_mounter
 LOG_DIR=/var/vcap/sys/log/nfs_mounter
 
 export CONFIG_DIR=$NFS_JOB_DIR/config
-export NFS_SHARE=<% properties.nfs_server.share_path %>
+export NFS_SHARE=<%= properties.nfs_server.share_path %>
 
 source $NFS_JOB_DIR/bin/handle_nfs_blobstore.sh
 

--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -19,6 +19,7 @@ meta:
       - (( .networks.cf1.subnets.[0].range || nil ))
       - (( .networks.cf2.subnets.[0].range || nil ))
     share: ~
+    share_path: ~    
 
   api_templates:
   - name: cloud_controller_ng


### PR DESCRIPTION
NFS_SHARE is not set properly due lack of a "=". Also properties.nfs_server.share_path is missing in the template cf-jobs.yml.
