### PR TITLE
Fix bucket names in templates

### DIFF
--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -99,18 +99,18 @@ properties:
     broker_client_timeout_seconds: 70
 
     resource_pool:
-      resource_directory_key: (( meta.environment "-cc-resources" ))
+      resource_directory_key: (( merge || meta.environment "-cc-resources" ))
       fog_connection: ~
       cdn: ~
 
     packages:
-      app_package_directory_key: (( meta.environment "-cc-packages" ))
+      app_package_directory_key: (( merge || meta.environment "-cc-packages" ))
       fog_connection: ~
       cdn: ~
       max_package_size: 1073741824
 
     droplets:
-      droplet_directory_key: (( meta.environment "-cc-droplets" ))
+      droplet_directory_key: (( merge || meta.environment "-cc-droplets" ))
       fog_connection: ~
       cdn: ~
 
@@ -127,7 +127,7 @@ properties:
         record_sql: "obfuscated"
 
     buildpacks:
-      buildpack_directory_key: (( domain "-cc-buildpacks" ))
+      buildpack_directory_key: (( merge || meta.environment "-cc-buildpacks" ))
       fog_connection: ~
       cdn: ~
     quota_definitions: (( merge || meta.default_quota_definitions ))


### PR DESCRIPTION
Hi, everyone.

Not long ago my friend had hard to detect issue with AWS deployment. He used templates from this repo to get final manifest. Finally the reason was that S3 Blobstore doesn't support bucket names that use dots, this is discussed in https://github.com/cloudfoundry/cloud_controller_ng/issues/175. 

I've found [some](https://groups.google.com/a/cloudfoundry.org/forum/#!topic/vcap-dev/h4ZwbAQDyEw) [amount](https://groups.google.com/a/cloudfoundry.org/forum/#!topic/bosh-users/0waAA386RuI) of questions on vcap-dev on this question, but not always they had an answers. I'm sure such things should be fixed in cf-release to prevent such kind of issues.  

I've used `meta.environment` instead of `domain` because I didn't find a way how to replace/remove dots with spiff syntax.
