### PR TITLE
Upgrading go buildpack to v1.1.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -302,8 +302,8 @@ python-buildpack/python_buildpack-offline-v1.1.0.zip:
   sha: !binary |-
     NTE5YzljMTEyMDFmNDU3MDVjYzNiYjZkM2U2NGNmZGFhZDU2ODEyZA==
   size: 300234930
-go-buildpack/go_buildpack-offline-v1.1.0.zip:
-  object_id: 57111f3a-e9ad-47a7-b6eb-94bd9984299e
+go-buildpack/go_buildpack-offline-v1.1.1.zip:
+  object_id: dd567f9f-5bae-4cee-b9d2-c9c42da942e1
   sha: !binary |-
-    YjU3YThjMjJhMDcwYzY2N2QwYTZiMTY1OTBhYTY3ZjAzMDhkM2EyYg==
-  size: 538691448
+    ODAwYzcyYWQ1ZDBhODA3ZjdlMTA4YzM5YTI2ZjQ4NmEwMjlkZTUzMw==
+  size: 601475619

--- a/packages/buildpack_go/packaging
+++ b/packages/buildpack_go/packaging
@@ -1,3 +1,3 @@
 set -e -x
 
-cp go-buildpack/go_buildpack-offline-v1.1.0.zip ${BOSH_INSTALL_TARGET}
+cp go-buildpack/go_buildpack-offline-v1.1.1.zip ${BOSH_INSTALL_TARGET}

--- a/packages/buildpack_go/spec
+++ b/packages/buildpack_go/spec
@@ -1,4 +1,4 @@
 ---
 name: buildpack_go
 files:
-- go-buildpack/go_buildpack-offline-v1.1.0.zip
+- go-buildpack/go_buildpack-offline-v1.1.1.zip


### PR DESCRIPTION
Upgrading to latest stable version of go buildpack
 --Buildpacks Team
