### PR TITLE
Better monitoring for Identity Services

### DIFF
--- a/jobs/login/monit
+++ b/jobs/login/monit
@@ -3,6 +3,10 @@ check process login
   start program "/var/vcap/jobs/login/bin/login_ctl start"
   stop program "/var/vcap/jobs/login/bin/login_ctl stop"
   group vcap
+  if failed port <%= p('login.port') %> protocol http
+    request "/healthz"
+    with timeout 60 seconds for 10 cycles
+  then restart
 
 check process login_cf-registrar
   with pidfile /var/vcap/sys/run/login/cf-registrar.pid

--- a/jobs/uaa/monit
+++ b/jobs/uaa/monit
@@ -6,7 +6,7 @@ check process uaa
   if failed port <%= p('uaa.port') %> protocol http
     request "/healthz"
     with timeout 60 seconds for 10 cycles
-  then exec "/var/vcap/jobs/uaa/bin/uaa_ctl stop"
+  then restart
 
 check process uaa_cf-registrar
   with pidfile /var/vcap/sys/run/uaa/cf-registrar.pid


### PR DESCRIPTION
This PR:

- Uses the healthz endpoint for Login Server for health
- Uses `then restart` as opposed to the stop script for UAA