### PR TITLE
Add HAProxy to default security groups on bosh-lite

### DIFF
--- a/bosh-lite/cf-stub-spiff.yml
+++ b/bosh-lite/cf-stub-spiff.yml
@@ -33,6 +33,8 @@ properties:
       - name: services
         rules:
         - protocol: all
+          destination: 10.244.0.34
+        - protocol: all
           destination: 10.244.1.0/24
         - protocol: all
           destination: 10.244.3.0/24

--- a/bosh-lite/cf-stub-spiff.yml
+++ b/bosh-lite/cf-stub-spiff.yml
@@ -33,9 +33,11 @@ properties:
       - name: services
         rules:
         - protocol: all
-          destination: 10.244.0.34
-        - protocol: all
           destination: 10.244.1.0/24
         - protocol: all
           destination: 10.244.3.0/24
-    default_running_security_groups: ["public_networks", "dns", "services"]
+      - name: load_balancer
+        rules:
+        - procotol: all
+          destination: 10.244.0.34
+    default_running_security_groups: ["public_networks", "dns", "services", "load_balancer"]


### PR DESCRIPTION
- for riak-cs, which needs to access the proxy and router as it uses http traffic.

[#79975532]