### PR TITLE
Add merge to all _templates in cf-jobs.yml so they can be overridden

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -30,6 +30,7 @@ jobs:
         - 0.0.1.5
   resource_pool: router_z1
   templates:
+  - {}
   - name: haproxy
     release: cf
   - name: metron_agent
@@ -47,6 +48,7 @@ jobs:
       apps: cf1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: nats
     release: cf
   - name: nats_stream_forwarder
@@ -66,6 +68,7 @@ jobs:
       zone: z2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: nats
     release: cf
   - name: nats_stream_forwarder
@@ -87,6 +90,7 @@ jobs:
       zone: z1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: etcd
     release: cf
   - name: etcd_metrics_server
@@ -107,6 +111,7 @@ jobs:
       zone: z2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: etcd
     release: cf
   - name: etcd_metrics_server
@@ -124,6 +129,7 @@ jobs:
       zone: z1
   resource_pool: small_z1
   templates:
+  - {}
   - name: collector
     release: cf
   - name: metron_agent
@@ -139,6 +145,7 @@ jobs:
   persistent_disk: 102400
   resource_pool: medium_z1
   templates:
+  - {}
   - name: debian_nfs_server
     release: cf
   - name: metron_agent
@@ -154,6 +161,7 @@ jobs:
   persistent_disk: 4096
   resource_pool: medium_z1
   templates:
+  - {}
   - name: postgres
     release: cf
   - name: metron_agent
@@ -169,6 +177,7 @@ jobs:
       zone: z1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: uaa
     release: cf
   - name: metron_agent
@@ -184,6 +193,7 @@ jobs:
       zone: z2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: uaa
     release: cf
   - name: metron_agent
@@ -199,6 +209,7 @@ jobs:
       zone: z1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: login
     release: cf
   - name: metron_agent
@@ -214,6 +225,7 @@ jobs:
       zone: z2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: login
     release: cf
   - name: metron_agent
@@ -236,6 +248,7 @@ jobs:
       share: null
   resource_pool: large_z1
   templates:
+  - {}
   - name: cloud_controller_ng
     release: cf
   - name: metron_agent
@@ -260,6 +273,7 @@ jobs:
       share: null
   resource_pool: large_z2
   templates:
+  - {}
   - name: cloud_controller_ng
     release: cf
   - name: metron_agent
@@ -278,6 +292,7 @@ jobs:
       apps: cf1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: cloud_controller_clock
     release: cf
   - name: metron_agent
@@ -300,6 +315,7 @@ jobs:
       share: null
   resource_pool: small_z1
   templates:
+  - {}
   - name: cloud_controller_worker
     release: cf
   - name: metron_agent
@@ -324,6 +340,7 @@ jobs:
       share: null
   resource_pool: small_z2
   templates:
+  - {}
   - name: cloud_controller_worker
     release: cf
   - name: metron_agent
@@ -341,6 +358,7 @@ jobs:
       zone: z1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: hm9000
     release: cf
   - name: metron_agent
@@ -356,6 +374,7 @@ jobs:
       zone: z2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: hm9000
     release: cf
   - name: metron_agent
@@ -374,6 +393,7 @@ jobs:
       apps: cf1
   resource_pool: runner_z1
   templates:
+  - {}
   - name: dea_next
     release: cf
   - name: dea_logging_agent
@@ -396,6 +416,7 @@ jobs:
       apps: cf2
   resource_pool: runner_z2
   templates:
+  - {}
   - name: dea_next
     release: cf
   - name: dea_logging_agent
@@ -415,6 +436,7 @@ jobs:
       apps: cf1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: doppler
     release: cf
 - instances: 2
@@ -428,6 +450,7 @@ jobs:
       apps: cf2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: doppler
     release: cf
 - instances: 1
@@ -443,6 +466,7 @@ jobs:
       zone: z1
   resource_pool: small_z1
   templates:
+  - {}
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent
@@ -460,6 +484,7 @@ jobs:
       zone: z2
   resource_pool: small_z2
   templates:
+  - {}
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent
@@ -477,6 +502,7 @@ jobs:
       apps: cf1
   resource_pool: router_z1
   templates:
+  - {}
   - name: gorouter
     release: cf
   - name: metron_agent
@@ -494,6 +520,7 @@ jobs:
       apps: cf2
   resource_pool: router_z2
   templates:
+  - {}
   - name: gorouter
     release: cf
   - name: metron_agent

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -33,6 +33,7 @@ jobs:
         z2: []
   resource_pool: router_z1
   templates:
+  - {}
   - name: haproxy
     release: cf
   - name: metron_agent
@@ -50,6 +51,7 @@ jobs:
       zone: z1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: nats
     release: cf
   - name: nats_stream_forwarder
@@ -68,6 +70,7 @@ jobs:
       zone: z2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: nats
     release: cf
   - name: nats_stream_forwarder
@@ -88,6 +91,7 @@ jobs:
       zone: z1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: etcd
     release: cf
   - name: etcd_metrics_server
@@ -107,6 +111,7 @@ jobs:
       zone: z2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: etcd
     release: cf
   - name: etcd_metrics_server
@@ -124,6 +129,7 @@ jobs:
       zone: z1
   resource_pool: small_z1
   templates:
+  - {}
   - name: collector
     release: cf
   - name: metron_agent
@@ -140,6 +146,7 @@ jobs:
   persistent_disk: 102400
   resource_pool: medium_z1
   templates:
+  - {}
   - name: debian_nfs_server
     release: cf
   - name: metron_agent
@@ -156,6 +163,7 @@ jobs:
   persistent_disk: 4096
   resource_pool: medium_z1
   templates:
+  - {}
   - name: postgres
     release: cf
   - name: metron_agent
@@ -171,6 +179,7 @@ jobs:
       zone: z1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: uaa
     release: cf
   - name: metron_agent
@@ -186,6 +195,7 @@ jobs:
       zone: z2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: uaa
     release: cf
   - name: metron_agent
@@ -201,6 +211,7 @@ jobs:
       zone: z1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: login
     release: cf
   - name: metron_agent
@@ -216,6 +227,7 @@ jobs:
       zone: z2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: login
     release: cf
   - name: metron_agent
@@ -238,6 +250,7 @@ jobs:
       share: null
   resource_pool: large_z1
   templates:
+  - {}
   - name: cloud_controller_ng
     release: cf
   - name: metron_agent
@@ -262,6 +275,7 @@ jobs:
       share: null
   resource_pool: large_z2
   templates:
+  - {}
   - name: cloud_controller_ng
     release: cf
   - name: metron_agent
@@ -280,6 +294,7 @@ jobs:
       apps: cf1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: cloud_controller_clock
     release: cf
   - name: metron_agent
@@ -302,6 +317,7 @@ jobs:
       share: null
   resource_pool: small_z1
   templates:
+  - {}
   - name: cloud_controller_worker
     release: cf
   - name: metron_agent
@@ -326,6 +342,7 @@ jobs:
       share: null
   resource_pool: small_z2
   templates:
+  - {}
   - name: cloud_controller_worker
     release: cf
   - name: metron_agent
@@ -343,6 +360,7 @@ jobs:
       zone: z1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: hm9000
     release: cf
   - name: metron_agent
@@ -358,6 +376,7 @@ jobs:
       zone: z2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: hm9000
     release: cf
   - name: metron_agent
@@ -376,6 +395,7 @@ jobs:
       apps: cf1
   resource_pool: runner_z1
   templates:
+  - {}
   - name: dea_next
     release: cf
   - name: dea_logging_agent
@@ -398,6 +418,7 @@ jobs:
       apps: cf2
   resource_pool: runner_z2
   templates:
+  - {}
   - name: dea_next
     release: cf
   - name: dea_logging_agent
@@ -417,6 +438,7 @@ jobs:
       apps: cf1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: doppler
     release: cf
 - instances: 0
@@ -430,6 +452,7 @@ jobs:
       apps: cf2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: doppler
     release: cf
 - instances: 1
@@ -445,6 +468,7 @@ jobs:
       zone: z1
   resource_pool: small_z1
   templates:
+  - {}
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent
@@ -462,6 +486,7 @@ jobs:
       zone: z2
   resource_pool: small_z2
   templates:
+  - {}
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent
@@ -479,6 +504,7 @@ jobs:
       apps: cf1
   resource_pool: router_z1
   templates:
+  - {}
   - name: gorouter
     release: cf
   - name: metron_agent
@@ -495,6 +521,7 @@ jobs:
       apps: cf2
   resource_pool: router_z2
   templates:
+  - {}
   - name: gorouter
     release: cf
   - name: metron_agent

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -32,6 +32,7 @@ jobs:
         - 0.0.1.5
   resource_pool: router_z1
   templates:
+  - {}
   - name: haproxy
     release: cf
   - name: metron_agent
@@ -49,6 +50,7 @@ jobs:
       zone: z1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: nats
     release: cf
   - name: nats_stream_forwarder
@@ -68,6 +70,7 @@ jobs:
       zone: z2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: nats
     release: cf
   - name: nats_stream_forwarder
@@ -89,6 +92,7 @@ jobs:
       zone: z1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: etcd
     release: cf
   - name: etcd_metrics_server
@@ -109,6 +113,7 @@ jobs:
       zone: z2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: etcd
     release: cf
   - name: etcd_metrics_server
@@ -126,6 +131,7 @@ jobs:
       zone: z1
   resource_pool: small_z1
   templates:
+  - {}
   - name: collector
     release: cf
   - name: metron_agent
@@ -142,6 +148,7 @@ jobs:
   persistent_disk: 102400
   resource_pool: medium_z1
   templates:
+  - {}
   - name: debian_nfs_server
     release: cf
   - name: metron_agent
@@ -158,6 +165,7 @@ jobs:
   persistent_disk: 4096
   resource_pool: medium_z1
   templates:
+  - {}
   - name: postgres
     release: cf
   - name: metron_agent
@@ -173,6 +181,7 @@ jobs:
       zone: z1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: uaa
     release: cf
   - name: metron_agent
@@ -188,6 +197,7 @@ jobs:
       zone: z2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: uaa
     release: cf
   - name: metron_agent
@@ -203,6 +213,7 @@ jobs:
       zone: z1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: login
   - name: metron_agent
     release: cf
@@ -217,6 +228,7 @@ jobs:
       zone: z2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: login
     release: cf
   - name: metron_agent
@@ -239,6 +251,7 @@ jobs:
       share: null
   resource_pool: large_z1
   templates:
+  - {}
   - name: cloud_controller_ng
     release: cf
   - name: metron_agent
@@ -263,6 +276,7 @@ jobs:
       share: null
   resource_pool: large_z2
   templates:
+  - {}
   - name: cloud_controller_ng
     release: cf
   - name: metron_agent
@@ -281,6 +295,7 @@ jobs:
       apps: cf1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: cloud_controller_clock
     release: cf
   - name: metron_agent
@@ -303,6 +318,7 @@ jobs:
       share: null
   resource_pool: small_z1
   templates:
+  - {}
   - name: cloud_controller_worker
     release: cf
   - name: metron_agent
@@ -327,6 +343,7 @@ jobs:
       share: null
   resource_pool: small_z2
   templates:
+  - {}
   - name: cloud_controller_worker
     release: cf
   - name: metron_agent
@@ -344,6 +361,7 @@ jobs:
       zone: z1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: hm9000
     release: cf
   - name: metron_agent
@@ -359,6 +377,7 @@ jobs:
       zone: z2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: hm9000
     release: cf
   - name: metron_agent
@@ -377,6 +396,7 @@ jobs:
       apps: cf1
   resource_pool: runner_z1
   templates:
+  - {}
   - name: dea_next
     release: cf
   - name: dea_logging_agent
@@ -399,6 +419,7 @@ jobs:
       apps: cf2
   resource_pool: runner_z2
   templates:
+  - {}
   - name: dea_next
     release: cf
   - name: dea_logging_agent
@@ -418,6 +439,7 @@ jobs:
       apps: cf1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: doppler
     release: cf
 - instances: 2
@@ -431,6 +453,7 @@ jobs:
       apps: cf2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: doppler
     release: cf
 - instances: 1
@@ -446,6 +469,7 @@ jobs:
       zone: z1
   resource_pool: small_z1
   templates:
+  - {}
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent
@@ -463,6 +487,7 @@ jobs:
       zone: z2
   resource_pool: small_z2
   templates:
+  - {}
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent
@@ -480,6 +505,7 @@ jobs:
       apps: cf1
   resource_pool: router_z1
   templates:
+  - {}
   - name: gorouter
     release: cf
   - name: metron_agent
@@ -497,6 +523,7 @@ jobs:
       apps: cf2
   resource_pool: router_z2
   templates:
+  - {}
   - name: gorouter
     release: cf
   - name: metron_agent

--- a/spec/fixtures/warden/cf-manifest.yml
+++ b/spec/fixtures/warden/cf-manifest.yml
@@ -87,6 +87,7 @@ jobs:
         z2: []
   resource_pool: router_z1
   templates:
+  - {}
   - name: haproxy
     release: cf
   - name: metron_agent
@@ -104,6 +105,7 @@ jobs:
       zone: z1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: nats
     release: cf
   - name: nats_stream_forwarder
@@ -122,6 +124,7 @@ jobs:
       zone: z2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: nats
     release: cf
   - name: nats_stream_forwarder
@@ -142,6 +145,7 @@ jobs:
       zone: z1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: etcd
     release: cf
   - name: etcd_metrics_server
@@ -161,6 +165,7 @@ jobs:
       zone: z2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: etcd
     release: cf
   - name: etcd_metrics_server
@@ -178,6 +183,7 @@ jobs:
       zone: z1
   resource_pool: small_z1
   templates:
+  - {}
   - name: collector
     release: cf
   - name: metron_agent
@@ -193,6 +199,7 @@ jobs:
   persistent_disk: 102400
   resource_pool: medium_z1
   templates:
+  - {}
   - name: debian_nfs_server
     release: cf
   - name: metron_agent
@@ -209,6 +216,7 @@ jobs:
   persistent_disk: 4096
   resource_pool: medium_z1
   templates:
+  - {}
   - name: postgres
     release: cf
   - name: metron_agent
@@ -224,6 +232,7 @@ jobs:
       zone: z1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: uaa
     release: cf
   - name: metron_agent
@@ -239,6 +248,7 @@ jobs:
       zone: z2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: uaa
     release: cf
   - name: metron_agent
@@ -254,6 +264,7 @@ jobs:
       zone: z1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: login
     release: cf
   - name: metron_agent
@@ -269,6 +280,7 @@ jobs:
       zone: z2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: login
     release: cf
   - name: metron_agent
@@ -291,6 +303,7 @@ jobs:
       share: null
   resource_pool: large_z1
   templates:
+  - {}
   - name: cloud_controller_ng
   - name: cloud_controller_clock
   - name: cloud_controller_worker
@@ -314,6 +327,7 @@ jobs:
       share: null
   resource_pool: large_z2
   templates:
+  - {}
   - name: cloud_controller_ng
     release: cf
   - name: metron_agent
@@ -332,6 +346,7 @@ jobs:
       apps: cf1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: cloud_controller_clock
     release: cf
   - name: metron_agent
@@ -354,6 +369,7 @@ jobs:
       share: null
   resource_pool: small_z1
   templates:
+  - {}
   - name: cloud_controller_worker
     release: cf
   - name: metron_agent
@@ -378,6 +394,7 @@ jobs:
       share: null
   resource_pool: small_z2
   templates:
+  - {}
   - name: cloud_controller_worker
     release: cf
   - name: metron_agent
@@ -395,6 +412,7 @@ jobs:
       zone: z1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: hm9000
     release: cf
   - name: metron_agent
@@ -410,6 +428,7 @@ jobs:
       zone: z2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: hm9000
     release: cf
   - name: metron_agent
@@ -429,6 +448,7 @@ jobs:
       apps: cf1
   resource_pool: runner_z1
   templates:
+  - {}
   - name: dea_next
     release: cf
   - name: dea_logging_agent
@@ -451,6 +471,7 @@ jobs:
       apps: cf2
   resource_pool: runner_z2
   templates:
+  - {}
   - name: dea_next
     release: cf
   - name: dea_logging_agent
@@ -470,6 +491,7 @@ jobs:
       apps: cf1
   resource_pool: medium_z1
   templates:
+  - {}
   - name: doppler
     release: cf
 - instances: 0
@@ -483,6 +505,7 @@ jobs:
       apps: cf2
   resource_pool: medium_z2
   templates:
+  - {}
   - name: doppler
     release: cf
 - instances: 1
@@ -498,6 +521,7 @@ jobs:
       zone: z1
   resource_pool: small_z1
   templates:
+  - {}
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent
@@ -515,6 +539,7 @@ jobs:
       zone: z2
   resource_pool: small_z2
   templates:
+  - {}
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent
@@ -532,6 +557,7 @@ jobs:
       apps: cf1
   resource_pool: router_z1
   templates:
+  - {}
   - name: gorouter
     release: cf
   - name: metron_agent
@@ -548,6 +574,7 @@ jobs:
       apps: cf2
   resource_pool: router_z2
   templates:
+  - {}
   - name: gorouter
     release: cf
   - name: metron_agent

--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -21,6 +21,7 @@ meta:
     share: ~
 
   api_templates:
+  - <<: (( merge ))
   - name: cloud_controller_ng
     release: (( meta.release.name ))
   - name: metron_agent
@@ -29,6 +30,7 @@ meta:
     release: (( meta.release.name ))
 
   api_worker_templates:
+  - <<: (( merge ))
   - name: cloud_controller_worker
     release: (( meta.release.name ))
   - name: metron_agent
@@ -37,12 +39,14 @@ meta:
     release: (( meta.release.name ))
 
   clock_templates:
+  - <<: (( merge ))
   - name: cloud_controller_clock
     release: (( meta.release.name ))
   - name: metron_agent
     release: (( meta.release.name ))
 
   nats_templates:
+  - <<: (( merge ))
   - name: nats
     release: (( meta.release.name ))
   - name: nats_stream_forwarder
@@ -51,6 +55,7 @@ meta:
     release: (( meta.release.name ))
 
   dea_templates:
+  - <<: (( merge ))
   - name: dea_next
     release: (( meta.release.name ))
   - name: dea_logging_agent
@@ -59,18 +64,21 @@ meta:
     release: (( meta.release.name ))
 
   router_templates:
+  - <<: (( merge ))
   - name: gorouter
     release: (( meta.release.name ))
   - name: metron_agent
     release: (( meta.release.name ))
 
   ha_proxy_templates:
+  - <<: (( merge ))
   - name: haproxy
     release: (( meta.release.name ))
   - name: metron_agent
     release: (( meta.release.name ))
 
   etcd_templates:
+  - <<: (( merge ))
   - name: etcd
     release: (( meta.release.name ))
   - name: etcd_metrics_server
@@ -79,46 +87,54 @@ meta:
     release: (( meta.release.name ))
 
   stats_templates:
+  - <<: (( merge ))
   - name: collector
     release: (( meta.release.name ))
   - name: metron_agent
     release: (( meta.release.name ))
 
   nfs_templates:
+  - <<: (( merge ))
   - name: debian_nfs_server
     release: (( meta.release.name ))
   - name: metron_agent
     release: (( meta.release.name ))
 
   postgres_templates:
+  - <<: (( merge ))
   - name: postgres
     release: (( meta.release.name ))
   - name: metron_agent
     release: (( meta.release.name ))
 
   uaa_templates:
+  - <<: (( merge ))
   - name: uaa
     release: (( meta.release.name ))
   - name: metron_agent
     release: (( meta.release.name ))
 
   login_templates:
+  - <<: (( merge ))
   - name: login
     release: (( meta.release.name ))
   - name: metron_agent
     release: (( meta.release.name ))
 
   hm9000_templates:
+  - <<: (( merge ))
   - name: hm9000
     release: (( meta.release.name ))
   - name: metron_agent
     release: (( meta.release.name ))
 
   loggregator_templates:
+  - <<: (( merge ))
   - name: doppler
     release: (( meta.release.name ))
 
   loggregator_trafficcontroller_templates:
+  - <<: (( merge ))
   - name: loggregator_trafficcontroller
     release: (( meta.release.name ))
   - name: metron_agent


### PR DESCRIPTION
I have been working on a cf release that uses a much reduced number of VMs (I'm attempting to get down to 4 + runners). My first approach was to not use cf-jobs.yml at all, just recreating the jobs myself. After being smacked down for that approach by @rkoster, I'm now attempting to use cf-jobs.yml, but "zero out" a bunch of the jobs, while redefining other templates (say, api_templates) to have more things it in (like gorouter and haproxy). However, unless the templates use '- <<: (( merge ))', they do not "pick up" my changes. As this will only affect those - like me - who are trying to override the existing configs, this should be a safe change to merge.

Thank you for your time and consideration.