### PR TITLE
Add bosh custom passwords

### DIFF
--- a/templates/cf-deployment.yml
+++ b/templates/cf-deployment.yml
@@ -5,6 +5,12 @@ meta:
   # i.e. cf-tabasco
   environment: ~
 
+  default_env:
+    # Default vcap & root password on deployed VMs (ie c1oudc0w)
+    # Generated using mkpasswd -m sha-512
+    bosh:
+      password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
+
   releases:
   - name: cf
     version: latest
@@ -42,69 +48,82 @@ resource_pools:
     size: (( auto ))
     stemcell: (( meta.stemcell ))
     cloud_properties: (( merge ))
+    env: (( merge || meta.default_env ))
 
   - name: small_z2
     network: cf2
     size: (( auto ))
     stemcell: (( meta.stemcell ))
     cloud_properties: (( merge ))
+    env: (( merge || meta.default_env ))
 
   - name: medium_z1
     network: cf1
     size: (( auto ))
     stemcell: (( meta.stemcell ))
     cloud_properties: (( merge ))
+    env: (( merge || meta.default_env ))
 
   - name: medium_z2
     network: cf2
     size: (( auto ))
     stemcell: (( meta.stemcell ))
     cloud_properties: (( merge ))
+    env: (( merge || meta.default_env ))
 
   - name: large_z1
     network: cf1
     size: (( auto ))
     stemcell: (( meta.stemcell ))
     cloud_properties: (( merge ))
+    env: (( merge || meta.default_env ))
 
   - name: large_z2
     network: cf2
     size: (( auto ))
     stemcell: (( meta.stemcell ))
     cloud_properties: (( merge ))
+    env: (( merge || meta.default_env ))
 
   - name: runner_z1
     network: cf1
     size: (( auto ))
     stemcell: (( meta.stemcell ))
     cloud_properties: (( merge ))
+    env: (( merge || meta.default_env ))
 
   - name: runner_z2
     network: cf2
     size: (( auto ))
     stemcell: (( meta.stemcell ))
     cloud_properties: (( merge ))
+    env: (( merge || meta.default_env ))
 
   - name: router_z1
     network: cf1
     size: (( auto ))
     stemcell: (( meta.stemcell ))
     cloud_properties: (( merge ))
+    env: (( merge || meta.default_env ))
 
   - name: router_z2
     network: cf2
     size: (( auto ))
     stemcell: (( meta.stemcell ))
     cloud_properties: (( merge ))
+    env: (( merge || meta.default_env ))
 
   - name: small_errand
     network: cf1
     size: (( auto ))
     stemcell: (( meta.stemcell ))
     cloud_properties: (( merge || resource_pools.small_z1.cloud_properties ))
+    env: (( merge || meta.default_env ))
 
   - name: xlarge_errand
     network: cf1
     size: (( auto ))
     stemcell: (( meta.stemcell ))
     cloud_properties: (( merge || resource_pools.large_z1.cloud_properties ))
+    env: (( merge || meta.default_env ))
+

--- a/templates/cf-deployment.yml
+++ b/templates/cf-deployment.yml
@@ -9,7 +9,7 @@ meta:
     # Default vcap & root password on deployed VMs (ie c1oudc0w)
     # Generated using mkpasswd -m sha-512
     bosh:
-      password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
+      password: (( merge || "$6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0" ))
 
   releases:
   - name: cf


### PR DESCRIPTION
We found that VMs deployed by Bosh for CloudFoundry were not sufficiently secure: the default password for root/vcap users (c1oudc0w) could not be changed easily.

What we want:
   - Possibility to change the password easily by resource_pool
   - Keep the use of Spiff to generate the final template

Our patch:
   - By default, the password is still c1oudc0w
   - Ability to set a new password overall

```
meta:
  ...
  default_env:
    # Default vcap & root password on deployed VMs (ie c1oudc0w)
    # Generated using mkpasswd -m sha-512
    bosh:
      password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
    ...
```

   - Ability to set a password for each resource_pool

```
resource_pools:
    name: small_z1
    ...
    bosh:
      # Change default password:
      #   hashed password - Generate SHA hash using mkpasswd -m sha-512
      #   Generated hash for FT9KDyDoBqmeKQqEKoap
      password: $6$DVhgWycGMhiQYKsH$py04MGy0HVislvOLxtg/fx1RhycpbH7bSHBjxwZYC/KYg6gc59uN6LulsEk33WzggDQPBDjm0BM9iQXSzjITi1
    ...
```