### PR TITLE
Add support for customizing ciphers in haproxy [Closes #596]

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -13,6 +13,9 @@ properties:
   ha_proxy.ssl_pem:
     description: "SSL certificate (PEM file)"
     default: ~
+  ha_proxy.ssl_ciphers:
+    default: ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:DES-CBC3-SHA:!NULL:!aNULL:!RC4:!RC2:!MEDIUM:!LOW:!EXPORT:!DES:!MD5:!PSK:!3DES
+    description: "List of SSL Ciphers that are passed to HAProxy"
 
   request_timeout_in_seconds:
     description: "Server and client timeouts in seconds"

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -25,7 +25,7 @@ frontend http-in
 <% if p("ha_proxy.ssl_pem") %>
 frontend https-in
     mode http
-    bind :443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3
+    bind :443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
     option httplog
     option forwardfor
     option http-server-close
@@ -34,7 +34,7 @@ frontend https-in
 
 frontend ssl-in
     mode tcp
-    bind :4443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3
+    bind :4443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
     default_backend tcp-routers
 <% end %>
 

--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -19,6 +19,7 @@ jobs:
     metron_agent:
       zone: z1
     ha_proxy:
+      ssl_ciphers: null
       ssl_pem: null
     networks:
       apps: cf1

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -23,6 +23,7 @@ jobs:
     metron_agent:
       zone: z1
     ha_proxy:
+      ssl_ciphers: null
       ssl_pem: null
     networks:
       apps: cf1

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -21,6 +21,7 @@ jobs:
     metron_agent:
       zone: z1
     ha_proxy:
+      ssl_ciphers: null
       ssl_pem: null
     networks:
       apps: cf1

--- a/spec/fixtures/warden/cf-manifest.yml
+++ b/spec/fixtures/warden/cf-manifest.yml
@@ -19,6 +19,7 @@ jobs:
     metron_agent:
       zone: z1
     ha_proxy:
+      ssl_ciphers: null
       ssl_pem: '-----BEGIN CERTIFICATE-----
 
         MIICLzCCAZgCCQCSoIG3LoeSMTANBgkqhkiG9w0BAQUFADBcMQswCQYDVQQGEwJV

--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -139,6 +139,7 @@ jobs:
       networks: (( meta.networks.z1 ))
       ha_proxy:
         ssl_pem: ~
+        ssl_ciphers: ~
       router:
         servers:
           z1: (( jobs.router_z1.networks.cf1.static_ips ))


### PR DESCRIPTION
As discussed in #596, this pull request adds a default set of ciphers (they're my preference, but obviously y'all can change them if you want). I also updated the fixtures so that the tests pass. And I tested that setting ha_proxy.ssl_ciphers in your own manifest will override the defaults.