### PR TITLE
The BASH gods found your lack of quotes disturbing

### DIFF
--- a/generate_deployment_manifest
+++ b/generate_deployment_manifest
@@ -19,4 +19,4 @@ spiff merge \
   $templates/cf-jobs.yml \
   $templates/cf-properties.yml \
   $templates/cf-infrastructure-${infrastructure}.yml \
-  $*
+  "$@"


### PR DESCRIPTION
In more than one occasion we needed to pass in paths with spaces, and
`$*` bit us. This commit makes the remainder expand properly