### PR TITLE
Change UAA port to allow Login and UAA to colocate

### DIFF
--- a/example_manifests/minimal-aws.yml
+++ b/example_manifests/minimal-aws.yml
@@ -188,6 +188,7 @@ jobs:
     login:
       catalina_opts: -Xmx768m -XX:MaxPermSize=256m
     uaa:
+      port: 8081
       admin:
         client_secret: PASSWORD
       batch:


### PR DESCRIPTION
We're pretty certain this is required to successfully deploy the minimal aws cf.