### PR TITLE
Allow load_balancer security group to be spiff-merged on bosh-lite.

### DIFF
--- a/bosh-lite/cf-stub-spiff.yml
+++ b/bosh-lite/cf-stub-spiff.yml
@@ -39,5 +39,5 @@ properties:
       - name: load_balancer
         rules:
         - protocol: all
-          destination: 10.244.0.34
+          destination: (( merge || "10.244.0.34" ))
     default_running_security_groups: ["public_networks", "dns", "services", "load_balancer"]


### PR DESCRIPTION
[#79975532]