### PR TITLE
Set default to 64000 max conn

### DIFF
--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -9,6 +9,7 @@ global
 defaults
     log global
     timeout connect 30000ms
+    maxconn 64000
     <% if p("request_timeout_in_seconds").to_i > 0 %>
         timeout client <%= p("request_timeout_in_seconds").to_i * 1000 %>ms
         timeout server <%= p("request_timeout_in_seconds").to_i * 1000 %>ms


### PR DESCRIPTION
This is because even though it set in global it limit is only 2000. Refer to http://stackoverflow.com/questions/8750518/difference-between-global-maxconn-and-server-maxconn-haproxy for more info.