### PR TITLE
Enable explicit configuration of uaa.issuer

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -110,6 +110,8 @@ properties:
     default: false
   uaa.url:
     description:
+  uaa.issuer:
+    description: "The url to use as the issuer URI"
   uaa.dump_requests:
     description:
   uaa.login.client_secret:

--- a/jobs/uaa/templates/uaa.yml.erb
+++ b/jobs/uaa/templates/uaa.yml.erb
@@ -53,9 +53,6 @@ jwt:
     verification-key: "<%= properties.uaa.cc.token_secret %>"
 <% end %>
 
-<% scheme = p("uaa.no_ssl") ? "http" : "https"
-   domain = p("domain") %>
-
 <% if properties.uaa.authentication && properties.uaa.authentication.policy %>
 authentication:
   policy:
@@ -64,7 +61,8 @@ authentication:
     lockoutPeriodSeconds: <%= properties.uaa.authentication.policy.lockoutPeriodSeconds ? properties.uaa.authentication.policy.lockoutPeriodSeconds : 300%>
 <% end %>
 
-issuer.uri: <%= p("uaa.url", "#{scheme}://uaa.#{domain}") %>
+<% scheme = p("uaa.no_ssl") ? "http" : "https" %>
+issuer.uri: <%= p("uaa.issuer", p("uaa.url", "#{scheme}://uaa.#{properties.domain}")) %>
 
 oauth:
   <% unless properties.uaa.no_ssl %>

--- a/spec/fixtures/aws/cf-manifest.yml.erb
+++ b/spec/fixtures/aws/cf-manifest.yml.erb
@@ -908,6 +908,7 @@ properties:
         authorities: scim.userids
         secret: cloud_controller_username_lookup_secret
         authorized-grant-types: client_credentials
+    issuer: https://uaa.example.com
     jwt:
       signing_key: sk
       verification_key: vk

--- a/spec/fixtures/openstack/cf-manifest.yml.erb
+++ b/spec/fixtures/openstack/cf-manifest.yml.erb
@@ -900,6 +900,7 @@ properties:
         authorities: scim.userids
         secret: cloud_controller_username_lookup_secret
         authorized-grant-types: client_credentials
+    issuer: https://uaa.example.com
     jwt:
       signing_key: sk
       verification_key: vk

--- a/spec/fixtures/vsphere/cf-manifest.yml.erb
+++ b/spec/fixtures/vsphere/cf-manifest.yml.erb
@@ -909,6 +909,7 @@ properties:
         authorities: scim.userids
         secret: cloud_controller_username_lookup_secret
         authorized-grant-types: client_credentials
+    issuer: https://uaa.0.0.0.3.xip.io
     jwt:
       signing_key: sk
       verification_key: vk

--- a/spec/fixtures/warden/cf-manifest.yml.erb
+++ b/spec/fixtures/warden/cf-manifest.yml.erb
@@ -2674,6 +2674,7 @@ properties:
         authorities: scim.userids
         secret: cloud_controller_username_lookup_secret
         authorized-grant-types: client_credentials
+    issuer: https://uaa.10.244.0.34.xip.io
     jwt:
       signing_key: '-----BEGIN RSA PRIVATE KEY-----
 

--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -219,6 +219,7 @@ properties:
     catalina_opts: (( merge ))
 
     url: (( "https://uaa." domain ))
+    issuer: (( url ))
 
     no_ssl: false
 


### PR DESCRIPTION
In some multi-instance deployments, there can be multiple uaa url's associated with a single issuer. This allows for explicit configuration of an issuer url that is separate and distinct from the uaa url.

[#87270332]