### PR TITLE
Adding optional config to HAProxy for logging, buffer size, and stats socket.

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -8,6 +8,7 @@ packages:
 
 templates:
   haproxy.config.erb:        config/haproxy.config
+  haproxy_syslog.conf.erb:   config/haproxy_syslog.conf
   haproxy_ctl:               bin/haproxy_ctl
   cert.pem.erb:              config/cert.pem
 
@@ -21,6 +22,18 @@ properties:
   ha_proxy.ssl_ciphers:
     default: ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-ECDSA-RC4-SHA:AES128:AES256:RC4-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK
     description: "List of SSL Ciphers that are passed to HAProxy"
+  ha_proxy.log_to_file:
+    description: "Whether to send logs to a file instead of the default syslog"
+    default: false
+  ha_proxy.dontlognull:
+    description: "Whether to disable logging of requests with no traffic (usually load-balancer TCP checks)"
+    default: false
+  ha_proxy.buffer_size:
+    description: "Buffer size to use for requests, any requests larger than this (large cookies or query strings) will result in a gateway error"
+    default: 16384
+  ha_proxy.enable_stats_socket:
+    description: "Whether to enable a socket that can be used to query errors and status"
+    default: false
   request_timeout_in_seconds:
     description: "Server and client timeouts in seconds"
     default: 900

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -5,13 +5,20 @@ global
     group vcap
     maxconn 64000
     spread-checks 4
+    tune.bufsize <%= p("ha_proxy.buffer_size") %>
+    <% if p("ha_proxy.enable_stats_socket") %>
+    stats socket /var/vcap/sys/run/haproxy/stats
+    <% end %>
 
 defaults
     log global
     timeout connect 30000ms
     <% if p("request_timeout_in_seconds").to_i > 0 %>
-        timeout client <%= p("request_timeout_in_seconds").to_i * 1000 %>ms
-        timeout server <%= p("request_timeout_in_seconds").to_i * 1000 %>ms
+    timeout client <%= p("request_timeout_in_seconds").to_i * 1000 %>ms
+    timeout server <%= p("request_timeout_in_seconds").to_i * 1000 %>ms
+    <% end %>
+    <% if p("ha_proxy.dontlognull") %>
+    option dontlognull
     <% end %>
 
 <% unless p("ha_proxy.disable_http") %>
@@ -30,7 +37,6 @@ frontend https-in
     bind :443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
     option httplog
     option forwardfor
-    option http-server-close
     reqadd X-Forwarded-Proto:\ https
     default_backend http-routers
 

--- a/jobs/haproxy/templates/haproxy_ctl
+++ b/jobs/haproxy/templates/haproxy_ctl
@@ -41,9 +41,6 @@ remove_pid() {
 }
 
 configure_syslog() {
-    chmod 755 /var/vcap/sys
-    chmod 755 /var/vcap/sys/log
-
     if [ ! -d "${LOG_DIR}" ] ; then
         mkdir -p "${LOG_DIR}"
         chown -R "syslog":"adm" "${LOG_DIR}"

--- a/jobs/haproxy/templates/haproxy_ctl
+++ b/jobs/haproxy/templates/haproxy_ctl
@@ -4,10 +4,12 @@
 set -e
 
 PATH=/var/vcap/packages/haproxy/bin:$PATH
+LOG_DIR=/var/vcap/sys/log/haproxy
 
 NAME=haproxy
 DAEMON=$(which haproxy)
 CONFIG=/var/vcap/jobs/haproxy/config/haproxy.config
+SYSLOG_CONFIG=/var/vcap/jobs/haproxy/config/haproxy_syslog.conf
 DESC="HAProxy"
 USER=vcap
 
@@ -38,6 +40,20 @@ remove_pid() {
     rmdir "$(dirname "${PID_FILE}")" || :
 }
 
+configure_syslog() {
+    chmod 755 /var/vcap/sys
+    chmod 755 /var/vcap/sys/log
+
+    if [ ! -d "${LOG_DIR}" ] ; then
+        mkdir -p "${LOG_DIR}"
+        chown -R "syslog":"adm" "${LOG_DIR}"
+        chmod 755 "${LOG_DIR}"
+    fi
+
+    cp $SYSLOG_CONFIG /etc/rsyslog.d/01-haproxy_syslog.conf
+    /usr/sbin/service rsyslog restart
+}
+
 start_haproxy() {
     status_haproxy
     if [ "${RETVAL}" = 0 ]; then
@@ -45,6 +61,7 @@ start_haproxy() {
     else
         RETVAL=0
         ensure_dirs
+        configure_syslog
         echo "$("${TIMESTAMP}"): Starting HAProxy"
         set +e
         "${DAEMON}" -f "${CONFIG}" -D -p "${PID_FILE}" 0<&-

--- a/jobs/haproxy/templates/haproxy_syslog.conf.erb
+++ b/jobs/haproxy/templates/haproxy_syslog.conf.erb
@@ -1,0 +1,9 @@
+# Send HAProxy logs to file if configured
+#
+<% if p("ha_proxy.log_to_file") %>
+$template VcapComponentLogFile, "/var/vcap/sys/log/haproxy/haproxy.log"
+$template VcapComponentLogFormat, "%msg%\n"
+
+:programname, startswith, "haproxy" -?VcapComponentLogFile;VcapComponentLogFormat
+:programname, startswith, "haproxy" ~
+<% end %>


### PR DESCRIPTION
This pull request was discussed in two group threads:

https://groups.google.com/a/cloudfoundry.org/forum/?utm_medium=email&utm_source=footer#!msg/vcap-dev/70MYeQbDnQc/mmSRWfKM0a0J
https://groups.google.com/a/cloudfoundry.org/forum/?utm_medium=email&utm_source=footer#!msg/vcap-dev/iWO7QDqt0AM/RqQslk_QYcYJ

This will also close two current trackers:

https://www.pivotaltracker.com/n/projects/966314/stories/88373146
https://www.pivotaltracker.com/n/projects/966314/stories/87802174

Changes:

* Add optional config to log HAProxy to /var/vcap/sys/log via rsyslog configuration (default is /var/log/syslog)
  * This requires some permissions changes to /var/vcap/sys and /var/vcap/sys/log so rsyslog can traverse the folders
* Add optional config to enable a stats socket for HAProxy
* Add optional config to enable the "dontlognull" setting
  * Upstream load balancers that use TCP checks to HAProxy result in larger numbers of "null" requests that get added to the logs
  * Enabling this option will disable logging of the null requests, but that will also eliminate logging of port scanning requests or anything else that hits HAProxy without actually transmitting data
* Add configuration for the buffer size, with the default value being the HAProxy default
  * Increasing the buffer size is required to handle requests with large query strings or cookies

The new configuration is optional and no manifest changes are required, and if the new settings aren't added to the manifest then the new config will be identical to the old config.

In addition, the "http-server-close" option was removed. This was required in older HAProxy versions in order to make the X-Forwarded-Proto header work correctly, but it resulted in disabling server-side keep-alive.  The new HAProxy version does not require this entry and removing it should result in a (potentially significant) performance improvement as HAProxy can now keep a pool of connections to the routers open instead of initiating new connections for every request.

Aaron Huber
Intel Corporation