### PR TITLE
Adding X-Forwarded-Proto header to HTTP check.

### DIFF
--- a/jobs/login/monit
+++ b/jobs/login/monit
@@ -3,8 +3,9 @@ check process login
   start program "/var/vcap/jobs/login/bin/login_ctl start"
   stop program "/var/vcap/jobs/login/bin/login_ctl stop"
   group vcap
-  if failed port <%= p('login.port') %> protocol http
-    request "/healthz"
+  if failed port <%= p('login.port') %>
+    send "GET /healthz HTTP/1.1\r\nHost: 127.0.0.1\r\nX-Forwarded-Proto: https\r\nConnection: close\r\n\r\n\"
+    expect "ok"
     with timeout 60 seconds for 10 cycles
   then restart
 

--- a/jobs/uaa/monit
+++ b/jobs/uaa/monit
@@ -3,8 +3,9 @@ check process uaa
   start program "/var/vcap/jobs/uaa/bin/uaa_ctl start"
   stop program "/var/vcap/jobs/uaa/bin/uaa_ctl stop"
   group vcap
-  if failed port <%= p('uaa.port') %> protocol http
-    request "/healthz"
+  if failed port <%= p('uaa.port') %>
+    send "GET /healthz HTTP/1.1\r\nHost: 127.0.0.1\r\nX-Forwarded-Proto: https\r\nConnection: close\r\n\r\n\"
+    expect "ok"
     with timeout 60 seconds for 10 cycles
   then restart
 


### PR DESCRIPTION
Modifying the HTTP check in monit for UAA and Login to include the X-Forwarded-Proto header.  This ensures that the check will function when uaa.require_https = true and login.protocol = https in the configuration.  This change was discussed and approved in https://github.com/cloudfoundry/uaa/issues/127.