### PR TITLE
Java Buildpack v2.7.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -235,11 +235,11 @@ golang/go1.4.2.linux-amd64.tar.gz:
   object_id: bfaf73b1-de68-4c94-9a02-555245b2eb8d
   sha: 5020af94b52b65cc9b6f11d50a67e4bae07b0aff
   size: 62442704
-java-buildpack/java-buildpack-offline-v2.7.zip:
-  object_id: 94d62653-6eef-4067-8617-592637ad4ca2
-  sha: e724ff3a87f7a549206dce8438d14ff9327b9168
-  size: 295400134
-java-buildpack/java-buildpack-v2.7.zip:
-  object_id: f669ef7e-31bf-4ceb-b775-4ea029c73c63
-  sha: cb523dc4095c894cf5f558fb794bc92a57ddc372
-  size: 149529
+java-buildpack/java-buildpack-offline-v2.7.1.zip:
+  object_id: 32b45915-97ab-409f-ba5e-03ee1b8395f8
+  sha: 76020e0ce6797418e4e486a6477b86f771417da1
+  size: 298273819
+java-buildpack/java-buildpack-v2.7.1.zip:
+  object_id: 33190dc8-e960-4b91-8892-e94c1cca672b
+  sha: cf07d48f2d45a0eeb02b56c56e9a39cee81044b3
+  size: 149526

--- a/packages/buildpack_java/packaging
+++ b/packages/buildpack_java/packaging
@@ -1,3 +1,3 @@
 set -e
 
-cp java-buildpack/java-buildpack-v2.7.zip ${BOSH_INSTALL_TARGET}
+cp java-buildpack/java-buildpack-v2.7.1.zip ${BOSH_INSTALL_TARGET}

--- a/packages/buildpack_java/spec
+++ b/packages/buildpack_java/spec
@@ -2,4 +2,4 @@
 name: buildpack_java
 
 files:
-  - java-buildpack/java-buildpack-v2.7.zip
+  - java-buildpack/java-buildpack-v2.7.1.zip

--- a/packages/buildpack_java_offline/packaging
+++ b/packages/buildpack_java_offline/packaging
@@ -1,3 +1,3 @@
 set -e
 
-cp java-buildpack/java-buildpack-offline-v2.7.zip ${BOSH_INSTALL_TARGET}
+cp java-buildpack/java-buildpack-offline-v2.7.1.zip ${BOSH_INSTALL_TARGET}

--- a/packages/buildpack_java_offline/spec
+++ b/packages/buildpack_java_offline/spec
@@ -2,4 +2,4 @@
 name: buildpack_java_offline
 
 files:
-  - java-buildpack/java-buildpack-offline-v2.7.zip
+  - java-buildpack/java-buildpack-offline-v2.7.1.zip


### PR DESCRIPTION
This change updates the Java Buildpack to version 2.7.1.

Both the online and offline buildpacks are updated as part of this change.