### PR TITLE
Removing unnecessary meta.openstack in openstack stub

### DIFF
--- a/templates/cf-infrastructure-openstack.yml
+++ b/templates/cf-infrastructure-openstack.yml
@@ -3,8 +3,6 @@ meta:
   environment: ~
   networks: ~
 
-  openstack: (( merge ))
-
   stemcell:
     name: bosh-openstack-kvm-ubuntu-lucid-go_agent
     version: latest


### PR DESCRIPTION
See related thread at https://groups.google.com/a/cloudfoundry.org/d/msg/vcap-dev/pGqlNn_MOO0/C1bU8vHPwIMJ

This is a prereq to submitting a docs PR as it is sourcing this file, see https://github.com/cloudfoundry/docs-deploying-cf/blob/master/cf-stub-openstack.html.md.erb#L18