### PR TITLE
Remove unneeded notification_templates.admin scope from admin user

### DIFF
--- a/spec/fixtures/warden/cf-manifest.yml.erb
+++ b/spec/fixtures/warden/cf-manifest.yml.erb
@@ -2947,7 +2947,7 @@ properties:
       external_groups: null
       userids_enabled: true
       users:
-      - admin|admin|scim.write,scim.read,openid,cloud_controller.admin,clients.read,clients.write,doppler.firehose,notification_templates.admin
+      - admin|admin|scim.write,scim.read,openid,cloud_controller.admin,clients.read,clients.write,doppler.firehose
     spring_profiles: null
     url: https://uaa.10.244.0.34.xip.io
     user: null

--- a/templates/cf-infrastructure-warden.yml
+++ b/templates/cf-infrastructure-warden.yml
@@ -130,7 +130,7 @@ properties:
         secret: cloud-controller-username-lookup-secret
     scim:
       users:
-      - admin|admin|scim.write,scim.read,openid,cloud_controller.admin,clients.read,clients.write,doppler.firehose,notification_templates.admin
+      - admin|admin|scim.write,scim.read,openid,cloud_controller.admin,clients.read,clients.write,doppler.firehose
     no_ssl: true
 
   login:


### PR DESCRIPTION
Revert "Adds notification_templates.admin to UAA admin user"
This reverts commit 0e82444728bce9ebf699f68f5a16c918ba6b5b63.

This scope no longer exists in the notifications codebase.

[#90304904]