### PR TITLE
HAProxy: Always set X-Forwarded-For header

### DIFF
--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -20,6 +20,7 @@ frontend http-in
     mode http
     bind :80
     option httplog
+    option httpclose
     option forwardfor
     reqadd X-Forwarded-Proto:\ http
     default_backend http-routers


### PR DESCRIPTION
From the [HAProxy 1.2 doc](http://www.haproxy.org/download/1.2/doc/architecture.txt):
 
- if the application needs to log the original client's IP, use the
   "forwardfor" option which will add an "X-Forwarded-For" header with the
   original client's IP address. You must also use "httpclose" to ensure
   that you will rewrite every requests and not only the first one of each
   session :

        option httpclose
        option forwardfor

This also works for CF's packaged HAProxy(1.5).