### PR TITLE
Expose signRequest and signMetaData via the login job

### DIFF
--- a/jobs/login/spec
+++ b/jobs/login/spec
@@ -117,6 +117,12 @@ properties:
     description: "Deprecated: Use login.saml.providers list objects"
   login.entity_id:
     description: "Deprecated: Use login.saml.entityid"
+  login.saml.signMetaData:
+    description: "Whether to sign XML metadata"
+    default: true
+  login.saml.signRequest:
+    description: "Whether to sign authentication requests"
+    default:true
   login.saml.keystore_name:
     description: "Name of the SAML login server keystore."
     default: "samlKeystore.jks"

--- a/jobs/login/templates/login.yml.erb
+++ b/jobs/login/templates/login.yml.erb
@@ -126,6 +126,8 @@ login:
   selfServiceLinksEnabled: <%= properties.login.self_service_links_enabled.nil? ? properties.login.signups_enabled : properties.login.self_service_links_enabled %>
   <% end %>
   saml:
+    signMetaData: <%= properties.login.saml.signMetaData %>
+    signRequest: <%= properties.login.saml.signRequest %>
     providers: <% if properties.login.saml.providers then properties.login.saml.providers.marshal_dump.reject {|k,_| k.to_s == ''}.each do |idpAlias,idpProvider| %>
       <%= idpAlias %>: <% idpProvider.marshal_dump.reject {|k,_| ["idpMetadata", "idpMetadataXML", "idpMetadataURL"].include?(k.to_s)}.each do |key,value|%>
         <%= key %>: <%= value.is_a?(String) && value.match("\n") ? "| \n          " + value.gsub("\n", "\n          ") + "" : value %><% end %>


### PR DESCRIPTION
signRequest and signMetaData are config options of login.saml (see https://github.com/cloudfoundry/uaa/blob/4ae9109107102bcf0b3849f5aa964abde4629548/uaa/src/main/webapp/WEB-INF/spring/saml-providers.xml#L94 and https://github.com/cloudfoundry/uaa/blob/4ae9109107102bcf0b3849f5aa964abde4629548/uaa/src/main/webapp/WEB-INF/spring/saml-providers.xml#L86)

However there is no way to configure these via login job.

This PR adds two new options to the login spec file and maps them through to the login.yml  template.