### PR TITLE
Allow to specify slowSpecThreshold for the acceptance tests.

### DIFF
--- a/jobs/acceptance-tests/spec
+++ b/jobs/acceptance-tests/spec
@@ -51,3 +51,6 @@ properties:
   acceptance_tests.include_v3:
     default: false
     description: Flag to include the v3 API test suite.
+  acceptance_tests.slow_spec_threshold:
+    default: 120
+    description: Maximum number of seconds before a testcase times out.

--- a/jobs/acceptance-tests/templates/run.erb
+++ b/jobs/acceptance-tests/templates/run.erb
@@ -49,7 +49,9 @@ skips=<%= properties.acceptance_tests.include_sso ? "" : "-skip=SSO"  %>
 
 verbose=<%= properties.acceptance_tests.verbose ? "-v" : "" %>
 
-$test_command -noColor -slowSpecThreshold=120 -randomizeAllSpecs $verbose -nodes=$nodes $skipPackages $skips -keepGoing || EXITSTATUS=$?
+slow_spec_threshold=<%= properties.acceptance_tests.slow_spec_threshold %>
+
+$test_command -noColor -slowSpecThreshold=$slow_spec_threshold -randomizeAllSpecs $verbose -nodes=$nodes $skipPackages $skips -keepGoing || EXITSTATUS=$?
 
 echo "Acceptance Tests Complete; exit status: $EXITSTATUS"
 


### PR DESCRIPTION
Title says it all. :)

Solves https://github.com/cloudfoundry/cf-acceptance-tests/issues/52