### PR TITLE
Add timeout related options for acceptance tests.

### DIFF
--- a/jobs/acceptance-tests/spec
+++ b/jobs/acceptance-tests/spec
@@ -51,3 +51,15 @@ properties:
   acceptance_tests.include_v3:
     default: false
     description: Flag to include the v3 API test suite.
+  acceptance_tests.default_timeout:
+    default: 30
+    description: Seconds to wait before cf cli interactions will time out.
+  acceptance_tests.cf_push_timeout:
+    default: 120
+    description: Seconds to wait before cf cli interactions against an app will time out.
+  acceptance_tests.long_curl_timeout:
+    default: 120
+    description: Seconds to wait before a curl against an app will time out.
+  acceptance_tests.broker_start_timeout:
+    default: 300
+    description: Seconds to wait before cf cli interations in the context of service brokers will time out

--- a/jobs/acceptance-tests/templates/config.json.erb
+++ b/jobs/acceptance-tests/templates/config.json.erb
@@ -15,12 +15,16 @@
   my_ip = discover_external_ip
 %>
 {
-  "api"                : "<%= properties.acceptance_tests.api %>",
-  "apps_domain"        : "<%= Array(properties.acceptance_tests.apps_domain).first %>",
-  "admin_user"         : "<%= properties.acceptance_tests.admin_user %>",
-  "admin_password"     : "<%= properties.acceptance_tests.admin_password %>",
-  "skip_ssl_validation": <%= properties.acceptance_tests.skip_ssl_validation %>,
-  "artifacts_directory": "/var/vcap/sys/log/acceptance_tests/",
-  "syslog_drain_port"  : 1234,
-  "syslog_ip_address"  : "<%= my_ip %>"
+  "api"                 : "<%= properties.acceptance_tests.api %>",
+  "apps_domain"         : "<%= Array(properties.acceptance_tests.apps_domain).first %>",
+  "admin_user"          : "<%= properties.acceptance_tests.admin_user %>",
+  "admin_password"      : "<%= properties.acceptance_tests.admin_password %>",
+  "skip_ssl_validation" : <%= properties.acceptance_tests.skip_ssl_validation %>,
+  "artifacts_directory" : "/var/vcap/sys/log/acceptance_tests/",
+  "syslog_drain_port"   : 1234,
+  "syslog_ip_address"   : "<%= my_ip %>",
+  "default_timeout"     : "<%= properties.acceptance_tests.default_timeout %>",
+  "cf_push_timeout"     : "<%= properties.acceptance_tests.cf_push_timeout %>",
+  "long_curl_timeout"   : "<%= properties.acceptance_tests.long_curl_timeout %>",
+  "broker_start_timeout": "<%= properties.acceptance_tests.broker_start_timeout %>"
 }

--- a/jobs/acceptance-tests/templates/config.json.erb
+++ b/jobs/acceptance-tests/templates/config.json.erb
@@ -23,8 +23,8 @@
   "artifacts_directory" : "/var/vcap/sys/log/acceptance_tests/",
   "syslog_drain_port"   : 1234,
   "syslog_ip_address"   : "<%= my_ip %>",
-  "default_timeout"     : "<%= properties.acceptance_tests.default_timeout %>",
-  "cf_push_timeout"     : "<%= properties.acceptance_tests.cf_push_timeout %>",
-  "long_curl_timeout"   : "<%= properties.acceptance_tests.long_curl_timeout %>",
-  "broker_start_timeout": "<%= properties.acceptance_tests.broker_start_timeout %>"
+  "default_timeout"     : <%= properties.acceptance_tests.default_timeout %>,
+  "cf_push_timeout"     : <%= properties.acceptance_tests.cf_push_timeout %>,
+  "long_curl_timeout"   : <%= properties.acceptance_tests.long_curl_timeout %>,
+  "broker_start_timeout": <%= properties.acceptance_tests.broker_start_timeout %>
 }


### PR DESCRIPTION
I got the default values from

https://github.com/cloudfoundry/cf-acceptance-tests/blob/fa899ceaa17c4f1fde50218eac1a5cad4ee17a28/apps/init_test.go#L14
and
https://github.com/cloudfoundry/cf-acceptance-tests/blob/e097be328c334647b812b5f49ebbab40899d714f/services/init_test.go#L14
