### PR TITLE
Updating AWS Infrastructure to be current generation of instance types

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml.erb
+++ b/spec/fixtures/aws/cf-manifest.yml.erb
@@ -1,7 +1,7 @@
 compilation:
   cloud_properties:
     availability_zone: zone_1
-    instance_type: c1.medium
+    instance_type: c3.medium
   network: cf1
   reuse_compilation_vms: true
   workers: 6
@@ -1174,7 +1174,7 @@ releases:
 resource_pools:
 - cloud_properties:
     availability_zone: zone_1
-    instance_type: m1.small
+    instance_type: m3.medium
   name: small_z1
   network: cf1
   size: 3
@@ -1186,7 +1186,7 @@ resource_pools:
       password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 - cloud_properties:
     availability_zone: zone_2
-    instance_type: m1.small
+    instance_type: m3.medium
   name: small_z2
   network: cf2
   size: 2
@@ -1198,7 +1198,7 @@ resource_pools:
       password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 - cloud_properties:
     availability_zone: zone_1
-    instance_type: m1.medium
+    instance_type: m3.medium
   name: medium_z1
   network: cf1
   size: 9
@@ -1210,7 +1210,7 @@ resource_pools:
       password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 - cloud_properties:
     availability_zone: zone_2
-    instance_type: m1.medium
+    instance_type: m3.medium
   name: medium_z2
   network: cf2
   size: 8
@@ -1222,7 +1222,7 @@ resource_pools:
       password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 - cloud_properties:
     availability_zone: zone_1
-    instance_type: m1.large
+    instance_type: m3.large
   name: large_z1
   network: cf1
   size: 1
@@ -1234,7 +1234,7 @@ resource_pools:
       password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 - cloud_properties:
     availability_zone: zone_2
-    instance_type: m1.large
+    instance_type: m3.large
   name: large_z2
   network: cf2
   size: 1
@@ -1246,7 +1246,7 @@ resource_pools:
       password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 - cloud_properties:
     availability_zone: zone_1
-    instance_type: m1.large
+    instance_type: m3.large
   name: runner_z1
   network: cf1
   size: 1
@@ -1258,7 +1258,7 @@ resource_pools:
       password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 - cloud_properties:
     availability_zone: zone_2
-    instance_type: m1.large
+    instance_type: m3.large
   name: runner_z2
   network: cf2
   size: 1
@@ -1272,7 +1272,7 @@ resource_pools:
     availability_zone: zone_1
     elbs:
     - cfrouter
-    instance_type: m1.medium
+    instance_type: m3.medium
   name: router_z1
   network: cf1
   size: 1
@@ -1286,7 +1286,7 @@ resource_pools:
     availability_zone: zone_2
     elbs:
     - cfrouter
-    instance_type: m1.medium
+    instance_type: m3.medium
   name: router_z2
   network: cf2
   size: 1
@@ -1298,7 +1298,7 @@ resource_pools:
       password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 - cloud_properties:
     availability_zone: zone_1
-    instance_type: m1.small
+    instance_type: m3.medium
   name: small_errand
   network: cf1
   stemcell:

--- a/spec/fixtures/aws/cf-manifest.yml.erb
+++ b/spec/fixtures/aws/cf-manifest.yml.erb
@@ -1,7 +1,7 @@
 compilation:
   cloud_properties:
     availability_zone: zone_1
-    instance_type: c3.medium
+    instance_type: c3.large
   network: cf1
   reuse_compilation_vms: true
   workers: 6

--- a/templates/cf-infrastructure-aws.yml
+++ b/templates/cf-infrastructure-aws.yml
@@ -50,7 +50,7 @@ properties:
 
 compilation:
   cloud_properties:
-    instance_type: c1.medium
+    instance_type: c3.medium
     availability_zone: (( meta.zones.z1 ))
 
 
@@ -60,59 +60,59 @@ networks: (( merge ))
 resource_pools:
   - name: small_z1
     cloud_properties:
-      instance_type: m1.small
+      instance_type: m3.medium
       availability_zone: (( meta.zones.z1 ))
 
   - name: small_z2
     cloud_properties:
-      instance_type: m1.small
+      instance_type: m3.medium
       availability_zone: (( meta.zones.z2 ))
 
   - name: medium_z1
     cloud_properties:
-      instance_type: m1.medium
+      instance_type: m3.medium
       availability_zone: (( meta.zones.z1 ))
 
   - name: medium_z2
     cloud_properties:
-      instance_type: m1.medium
+      instance_type: m3.medium
       availability_zone: (( meta.zones.z2 ))
 
   - name: large_z1
     cloud_properties:
-      instance_type: m1.large
+      instance_type: m3.large
       availability_zone: (( meta.zones.z1 ))
 
   - name: large_z2
     cloud_properties:
-      instance_type: m1.large
+      instance_type: m3.large
       availability_zone: (( meta.zones.z2 ))
 
   - name: runner_z1
     cloud_properties:
-      instance_type: m1.large
+      instance_type: m3.large
       availability_zone: (( meta.zones.z1 ))
 
   - name: runner_z2
     cloud_properties:
-      instance_type: m1.large
+      instance_type: m3.large
       availability_zone: (( meta.zones.z2 ))
 
   - name: router_z1
     cloud_properties:
-      instance_type: m1.medium
+      instance_type: m3.medium
       availability_zone: (( meta.zones.z1 ))
       elbs: (( merge || ["cfrouter"] ))
 
   - name: router_z2
     cloud_properties:
-      instance_type: m1.medium
+      instance_type: m3.medium
       availability_zone: (( meta.zones.z2 ))
       elbs: (( merge || ["cfrouter"] ))
 
   - name: small_errand
     cloud_properties:
-      instance_type: m1.small
+      instance_type: m3.medium
       availability_zone: (( meta.zones.z1 ))
 
   - name: xlarge_errand

--- a/templates/cf-infrastructure-aws.yml
+++ b/templates/cf-infrastructure-aws.yml
@@ -50,7 +50,7 @@ properties:
 
 compilation:
   cloud_properties:
-    instance_type: c3.medium
+    instance_type: c3.large
     availability_zone: (( meta.zones.z1 ))
 
 


### PR DESCRIPTION
I updated the aws infrastructure yml file to have the latest generations of instance types.

This saves users money since the m1.X instance type and the c1.X instance types cost more money per hour than their current generation counterparts. 

The migration was as follows:
m1.small -> m3.medium (there is no m3.small offering)
m1.medium -> m3.medium
c1.medium -> c3.large (there is no c3.medium offering)

Updated unit tests also.
