### PR TITLE
Enable overwriting of property uaa.require_https

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml.erb
+++ b/spec/fixtures/aws/cf-manifest.yml.erb
@@ -1140,6 +1140,7 @@ properties:
     ldap: null
     login: null
     no_ssl: false
+    require_https: false
     restricted_ips_regex: 10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}
     scim:
       external_groups: null

--- a/spec/fixtures/openstack/cf-manifest.yml.erb
+++ b/spec/fixtures/openstack/cf-manifest.yml.erb
@@ -1117,6 +1117,7 @@ properties:
     ldap: null
     login: null
     no_ssl: false
+    require_https: false
     restricted_ips_regex: 10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}
     scim:
       external_groups: null

--- a/spec/fixtures/vsphere/cf-manifest.yml.erb
+++ b/spec/fixtures/vsphere/cf-manifest.yml.erb
@@ -1142,6 +1142,7 @@ properties:
     ldap: null
     login: null
     no_ssl: false
+    require_https: false
     restricted_ips_regex: 10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}
     scim:
       external_groups: null

--- a/spec/fixtures/warden/cf-manifest.yml.erb
+++ b/spec/fixtures/warden/cf-manifest.yml.erb
@@ -2943,6 +2943,7 @@ properties:
     ldap: null
     login: null
     no_ssl: true
+    require_https: false
     restricted_ips_regex: 10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}
     scim:
       external_groups: null

--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -228,6 +228,7 @@ properties:
     issuer: (( url ))
 
     no_ssl: false
+    require_https: false
 
     scim:
       userids_enabled: (( merge || true ))


### PR DESCRIPTION
The uaa job defines a property require_https, which could be
used to configure the uaa to accept only https requests (plaing
http requests are then redirected to https).

This patch adds the require_https property to cf-properties.yml,
so that it could be overwritten in a configuration stub file.
The default is set to 'false' to keep the current default
behaviour of the uaa job if the property is missing.