### PR TITLE
define separate fog aws key

### DIFF
--- a/templates/cf-infrastructure-aws.yml
+++ b/templates/cf-infrastructure-aws.yml
@@ -5,8 +5,8 @@ meta:
 
   fog_config:
     provider: AWS
-    aws_access_key_id: (( properties.template_only.aws.access_key_id ))
-    aws_secret_access_key: (( properties.template_only.aws.secret_access_key ))
+    aws_access_key_id: (( properties.fog_aws_key.aws_access_key_id ))
+    aws_secret_access_key: (( properties.fog_aws_key.aws_secret_access_key ))
     region: us-east-1
 
   stemcell:
@@ -17,6 +17,10 @@ meta:
 properties:
   <<: (( merge ))
   template_only: (( merge ))
+
+  fog_aws_key:
+    aws_access_key_id: (( properties.template_only.aws.access_key_id ))
+    aws_secret_access_key: (( properties.template_only.aws.secret_access_key ))
 
   logger_endpoint:
     port: 4443


### PR DESCRIPTION
To deploy cf on Tokyo region in AWS, we need two AWS keys. one is for AWS resource (e.g. VM, subnet..) . And we also need another key to access buildpack. So we defined a new property fog_aws_key for AWS key to access buildpack. 