### PR TITLE
Add security group for cf-mysql subnets.

### DIFF
--- a/bosh-lite/cf-stub-spiff.yml
+++ b/bosh-lite/cf-stub-spiff.yml
@@ -42,4 +42,8 @@ properties:
         rules:
         - protocol: all
           destination: (( merge || "10.244.0.34" ))
-    default_running_security_groups: ["public_networks", "dns", "services", "load_balancer"]
+      - name: cf_mysql
+        rules:
+        - protocol: all
+        destination: 10.244.7.0-10.244.9.255
+    default_running_security_groups: ["public_networks", "dns", "services", "load_balancer", "cf_mysql"]


### PR DESCRIPTION
As part of the effort to provide templates for multi-az support on mysql, we moved the deployment to new networks on bosh-lite. This requires new default running security groups.

[#87241160]