### PR TITLE
UAA-2.3.0 with NewRelic support

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -159,3 +159,11 @@ uaa/newrelic.jar:
   object_id: 2b9d1b59-bc86-4089-95ba-2c0374fe3737
   sha: a5070963fc84bea27acc1d492cb9e3143f0c4715
   size: 7064901
+uaa/openjdk-1.7.0_79.tar.gz:
+  object_id: 0942ce92-e7c2-4f4c-94d1-e50fac6eb905
+  sha: 2ca6e142325a3e054efbf5b72995cb9ce416d607
+  size: 36244117
+uaa/apache-tomcat-7.0.61.tar.gz:
+  object_id: fdad7b89-61f5-4cd1-a003-49c4d872412b
+  sha: 98ccbc95d029291e81bf818879ec8a0aa14465df
+  size: 8816567

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -159,11 +159,19 @@ uaa/newrelic.jar:
   object_id: 2b9d1b59-bc86-4089-95ba-2c0374fe3737
   sha: a5070963fc84bea27acc1d492cb9e3143f0c4715
   size: 7064901
-uaa/openjdk-1.7.0_79.tar.gz:
-  object_id: 0942ce92-e7c2-4f4c-94d1-e50fac6eb905
-  sha: 2ca6e142325a3e054efbf5b72995cb9ce416d607
-  size: 36244117
 uaa/apache-tomcat-7.0.61.tar.gz:
   object_id: fdad7b89-61f5-4cd1-a003-49c4d872412b
   sha: 98ccbc95d029291e81bf818879ec8a0aa14465df
   size: 8816567
+openjdk/openjdk-1.7.0_79.tar.gz:
+  object_id: b7c40a5c-6297-4158-b54a-23f89982f13a
+  sha: 2ca6e142325a3e054efbf5b72995cb9ce416d607
+  size: 36244117
+openjdk/openjdk-1.7.0-u40-unofficial-macosx-x86_64-bundle.tgz:
+  object_id: 6f065666-1889-4564-8dd9-8344b4a3e974
+  sha: ac7febc5bbff2dedf8add624a727a4c0ac6c3d10
+  size: 65991397
+openjdk/openjdk-1.7.0-u40-unofficial-linux-amd64.tgz:
+  object_id: 1c5d266f-9c90-4160-9fc5-b3b30f2c248a
+  sha: bb41c68e0dc26ad71635d4bff8da16246ded10f0
+  size: 42574624

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -155,3 +155,7 @@ consul/consul-template_0.9.0_linux_amd64.tar.gz:
   object_id: e83bcdcd-2f31-4b73-8cf8-516d54e8f59a
   sha: a44e441f9347abe64956e5bb30c4d4b0464d1f73
   size: 2460384
+uaa/newrelic.jar:
+  object_id: 2b9d1b59-bc86-4089-95ba-2c0374fe3737
+  sha: a5070963fc84bea27acc1d492cb9e3143f0c4715
+  size: 7064901

--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -11,6 +11,7 @@ templates:
 
   cf-registrar.config.yml.erb: config/cf-registrar/config.yml
   uaa.yml.erb: config/uaa.yml
+  newrelic.yml.erb: config/newrelic.yml
   varz.yml.erb: config/varz.yml
   log4j.properties.erb: config/log4j.properties
   varz.log4j.properties.erb: config/varz.log4j.properties
@@ -224,6 +225,14 @@ properties:
               - hostname3.example.com
     default:
       - uaa.service.consul
+  uaa.newrelic:
+    description: |
+      To enable newrelic monitoring, the sub element of this property will be placed in
+      a configuration file called newrelic.yml in the jobs config directory.
+      The syntax that must adhere to documentation in https://docs.newrelic.com/docs/agents/java-agent/configuration/java-agent-configuration-config-file
+      The JVM option -javaagent:/path/to/newrelic.jar will be added to Apache Tomcat's startup script
+      The enablement of the NewRelic agent in the UAA is triggered by the property uaa.newrelic.common.license_key
+      The property uaa.newrelic.common.license_key must be set!
   login.protocol:
     description: "Scheme to use for HTTP communication (http/https)"
   login.ldap.profile_type:

--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -29,7 +29,7 @@ packages:
 
 properties:
   uaa.admin.client_secret:
-    description:
+    description: "Secret of the admin client - a client named admin with uaa.admin as an authority"
   uaa.authentication.policy.lockoutAfterFailures:
     description: "Number of allowed failures before account is locked"
   uaa.authentication.policy.countFailuresWithinSeconds:

--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -379,3 +379,7 @@ properties:
     description: "The Location of the redirect header following a logout of the the UAA (/logout.do). Default value is back to login page (/login)"
   login.logout.redirect.parameter.disable:
     description: "When set to false, this allows an operator to leverage an open redirect on the UAA (/logout.do?redirect=google.com). Default value is true. No open redirect enabled"
+  login.logout.redirect.parameter.whitelist:
+    description: "A list of URLs. When this list is non null, including empty, and disable=false, 
+    logout redirects are allowed, but limited to the whitelist URLs. If a redirect parameter value is not white
+    listed, redirect will be to the default URL."

--- a/jobs/uaa/templates/login.yml.erb
+++ b/jobs/uaa/templates/login.yml.erb
@@ -76,7 +76,10 @@ logout:
   redirect:
     url: <%= (properties.login.logout.redirect.url) ? properties.login.logout.redirect.url : "/login" %>
     parameter:
-      disable: <%= (properties.login.logout.redirect.parameter && (!properties.login.logout.redirect.parameter.disable.nil?)) ? properties.login.logout.redirect.parameter.disable : "true" %> 
+      disable: <%= (properties.login.logout.redirect.parameter && (!properties.login.logout.redirect.parameter.disable.nil?)) ? properties.login.logout.redirect.parameter.disable : "true" %><% if (properties.login.logout.redirect.parameter && (!properties.login.logout.redirect.parameter.whitelist.nil?)) %>
+      whitelist: <% properties.login.logout.redirect.parameter.whitelist.each do |whitelistedurl| %>
+      - <%= whitelistedurl %><% end %>
+   <% end %>   
 <% end %>
 
 login:

--- a/jobs/uaa/templates/login.yml.erb
+++ b/jobs/uaa/templates/login.yml.erb
@@ -97,22 +97,29 @@ login:
   <% else %>
   serviceProviderCertificate: | 
     -----BEGIN CERTIFICATE-----
-    MIIC6TCCAlICCQDN85uMN+4K5jANBgkqhkiG9w0BAQsFADCBuDELMAkGA1UEBhMC
-    VVMxCzAJBgNVBAgMAkNBMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMR0wGwYDVQQK
-    DBRQaXZvdGFsIFNvZnR3YXJlIEluYzEeMBwGA1UECwwVQ2xvdWRmb3VuZHJ5IElk
-    ZW50aXR5MRswGQYDVQQDDBJ1YWEucnVuLnBpdm90YWwuaW8xKDAmBgkqhkiG9w0B
-    CQEWGXZjYXAtZGV2QGNsb3VkZm91bmRyeS5vcmcwHhcNMTUwMzAyMTQyMDQ4WhcN
-    MjUwMjI3MTQyMDQ4WjCBuDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMRYwFAYD
-    VQQHDA1TYW4gRnJhbmNpc2NvMR0wGwYDVQQKDBRQaXZvdGFsIFNvZnR3YXJlIElu
-    YzEeMBwGA1UECwwVQ2xvdWRmb3VuZHJ5IElkZW50aXR5MRswGQYDVQQDDBJ1YWEu
-    cnVuLnBpdm90YWwuaW8xKDAmBgkqhkiG9w0BCQEWGXZjYXAtZGV2QGNsb3VkZm91
-    bmRyeS5vcmcwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAN0u5J4BJUDgRv6I
-    h5/r7rZjSrFVLL7bl71CzBIaVk1BQPYfBC8gggGAWmYYxJV0Kz+2Vx0Z96OnXhJk
-    gG46Zo2KMDudEeSdXou+dSBNISDv4VpLKUGnVU4n/L0khbI+jX51aS80ub8vThca
-    bkdY5x4Ir8G3QCQvCGKgU2emfFe7AgMBAAEwDQYJKoZIhvcNAQELBQADgYEAXghg
-    PwMhO0+dASJ83e2Bu63pKO808BrVjD51sSEMb0qwFc5IV6RzK/mkJgO0fphhoqOm
-    ZLzGcSYwCmj0Vc0GO5NgnFVZg4N9CyYCpDMeQynumlrNhRgnZRzlqXtQgL2bQDiu
-    coxNL/KY05iVlE1bmq/fzNEmEi2zf3dQV8CNSYs=
+    MIIEJTCCA46gAwIBAgIJANIqfxWTfhpkMA0GCSqGSIb3DQEBBQUAMIG+MQswCQYD
+    VQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZyYW5j
+    aXNjbzEdMBsGA1UEChMUUGl2b3RhbCBTb2Z0d2FyZSBJbmMxJDAiBgNVBAsTG0Ns
+    b3VkIEZvdW5kcnkgSWRlbnRpdHkgVGVhbTEcMBoGA1UEAxMTaWRlbnRpdHkuY2Yt
+    YXBwLmNvbTEfMB0GCSqGSIb3DQEJARYQbWFyaXNzYUB0ZXN0Lm9yZzAeFw0xNTA1
+    MTQxNzE5MTBaFw0yNTA1MTExNzE5MTBaMIG+MQswCQYDVQQGEwJVUzETMBEGA1UE
+    CBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZyYW5jaXNjbzEdMBsGA1UEChMU
+    UGl2b3RhbCBTb2Z0d2FyZSBJbmMxJDAiBgNVBAsTG0Nsb3VkIEZvdW5kcnkgSWRl
+    bnRpdHkgVGVhbTEcMBoGA1UEAxMTaWRlbnRpdHkuY2YtYXBwLmNvbTEfMB0GCSqG
+    SIb3DQEJARYQbWFyaXNzYUB0ZXN0Lm9yZzCBnzANBgkqhkiG9w0BAQEFAAOBjQAw
+    gYkCgYEA30y2nX+kICXktl1yJhBzLGvtTuzJiLeOMWi++zdivifyRqX1dwJ5MgdO
+    sBWdNrASwe4ZKONiyLFRDsk7lAYq3f975chxSsrRu1BLetBZfPEmwBH7FCTdYtWk
+    lJbpz0vzQs/gSsMChT/UrN6zSJhPVHNizLxstedyxxVVts644U8CAwEAAaOCAScw
+    ggEjMB0GA1UdDgQWBBSvWY/TyHysYGxKvII95wD/CzE1AzCB8wYDVR0jBIHrMIHo
+    gBSvWY/TyHysYGxKvII95wD/CzE1A6GBxKSBwTCBvjELMAkGA1UEBhMCVVMxEzAR
+    BgNVBAgTCkNhbGlmb3JuaWExFjAUBgNVBAcTDVNhbiBGcmFuY2lzY28xHTAbBgNV
+    BAoTFFBpdm90YWwgU29mdHdhcmUgSW5jMSQwIgYDVQQLExtDbG91ZCBGb3VuZHJ5
+    IElkZW50aXR5IFRlYW0xHDAaBgNVBAMTE2lkZW50aXR5LmNmLWFwcC5jb20xHzAd
+    BgkqhkiG9w0BCQEWEG1hcmlzc2FAdGVzdC5vcmeCCQDSKn8Vk34aZDAMBgNVHRME
+    BTADAQH/MA0GCSqGSIb3DQEBBQUAA4GBAL5j1JCN5EoXMOOBSBUL8KeVZFQD3Nfy
+    YkYKBatFEKdBFlAKLBdG+5KzE7sTYesn7EzBISHXFz3DhdK2tg+IF1DeSFVmFl2n
+    iVxQ1sYjo4kCugHBsWo+MpFH9VBLFzsMlP3eIDuVKe8aPXFKYCGhctZEJdQTKlja
+    lshe50nayKrT
     -----END CERTIFICATE----
   <% end %>
   <% if !properties.login.saml.serviceProviderKey.nil? %>
@@ -121,25 +128,22 @@ login:
   <% else %>
   serviceProviderKey: | 
     -----BEGIN RSA PRIVATE KEY-----
-    Proc-Type: 4,ENCRYPTED
-    DEK-Info: DES-EDE3-CBC,BE03AC562D734AB1
-
-    mvMS20ddwCJ6A+ABJKWViGTgLpWUVA5ZqKYU6Q3N+le769s4uygcMOtvTcjgH46E
-    3gIDR+Qt+UO/Yv+EgIJnga+vLMayjg/pl2bR8p1lK7gUkAb7DwDviySSi18tAt0O
-    NTyJEzy6G+WnlSs+3tzRUCneaoFB1/LDdUSOzaSLRtU/r+Vt/9BYBQbZMalnSQRE
-    U17VhISbfj4MgNIfZU+7+ALfE0+Muno4WDk+IJXArAk7wckF6NO7M4EKHlLzrHI0
-    +PccNBKN/rAevYZrZOmGCw4jKu5JJDtt6SgQJIp/XGEZlv+KD2cWPBC4nj7nJHAz
-    ezt9SfnL8jQlClTwQyPHjwDPlL/WHQrBpxpFF83FnN8B02DWwXQE2oTC7RtijQVT
-    NKto/vSODK0RfaulLHNx6RvJF0YFWSSofTm0G5TLwWCCrVekK0N5zAYPeG9LgjlG
-    4xILPSE+Y6hYIVN2gXNZOVB8T5O+Jf1KQlmMnZ9A5o1gcUJq0rCBa6i2D2rveQGE
-    eLm3BgyMp5v0JsyuzDBuxVWSgJFt+KHz/mhdgdG8End3QBF2BBaHpLP0+5BqIZHX
-    NYCDBwWK/k40oxT8KLdFfkBU48Yndq7ARFdq3YzPU6FdSpgwZM5p8HYkl1THcskI
-    Ri7zVHxpm0tPZqqqgzr6HBvSiQhACT4dOXV5V8bEoL5tlyuZllq2MBayl9yd0+bq
-    6hVZXUYewtPyE2Wj2PDr2F7fGtYhKcrnQxH63w3OhIzgkxUTQ63h710QDJjOtYCm
-    /PCAsNBePrnjrHHxMxkMVCtTYSeBePk0vkUtFOE5hIc=
+    MIICXgIBAAKBgQDfTLadf6QgJeS2XXImEHMsa+1O7MmIt44xaL77N2K+J/JGpfV3
+    AnkyB06wFZ02sBLB7hko42LIsVEOyTuUBird/3vlyHFKytG7UEt60Fl88SbAEfsU
+    JN1i1aSUlunPS/NCz+BKwwKFP9Ss3rNImE9Uc2LMvGy153LHFVW2zrjhTwIDAQAB
+    AoGBAJDh21LRcJITRBQ3CUs9PR1DYZPl+tUkE7RnPBMPWpf6ny3LnDp9dllJeHqz
+    a3ACSgleDSEEeCGzOt6XHnrqjYCKa42Z+Opnjx/OOpjyX1NAaswRtnb039jwv4gb
+    RlwT49Y17UAQpISOo7JFadCBoMG0ix8xr4ScY+zCSoG5v0BhAkEA8llNsiWBJF5r
+    LWQ6uimfdU2y1IPlkcGAvjekYDkdkHiRie725Dn4qRiXyABeaqNm2bpnD620Okwr
+    sf7LY+BMdwJBAOvgt/ZGwJrMOe/cHhbujtjBK/1CumJ4n2r5V1zPBFfLNXiKnpJ6
+    J/sRwmjgg4u3Anu1ENF3YsxYabflBnvOP+kCQCQ8VBCp6OhOMcpErT8+j/gTGQUL
+    f5zOiPhoC2zTvWbnkCNGlqXDQTnPUop1+6gILI2rgFNozoTU9MeVaEXTuLsCQQDC
+    AGuNpReYucwVGYet+LuITyjs/krp3qfPhhByhtndk4cBA5H0i4ACodKyC6Zl7Tmf
+    oYaZoYWi6DzbQQUaIsKxAkEA2rXQjQFsfnSm+w/9067ChWg46p4lq5Na2NpcpFgH
+    waZKhM1W0oB8MX78M+0fG3xGUtywTx0D4N7pr1Tk2GTgNw==
     -----END RSA PRIVATE KEY-----
   <% end %>
-  serviceProviderKeyPassword: <%= properties.login.saml.serviceProviderKeyPassword ? properties.login.saml.serviceProviderKeyPassword : 'password' %>
+  serviceProviderKeyPassword: <%= properties.login.saml.serviceProviderKeyPassword ? properties.login.saml.serviceProviderKeyPassword : "\"\"" %>
   <% if !properties.login.self_service_links_enabled.nil? || !properties.login.signups_enabled.nil? %>
   selfServiceLinksEnabled: <%= properties.login.self_service_links_enabled.nil? ? properties.login.signups_enabled : properties.login.self_service_links_enabled %>
   <% end %>

--- a/jobs/uaa/templates/newrelic.yml.erb
+++ b/jobs/uaa/templates/newrelic.yml.erb
@@ -1,0 +1,3 @@
+<% if properties.uaa && properties.uaa.newrelic && properties.uaa.newrelic.common && properties.uaa.newrelic.common.license_key %>
+<%= require 'yaml'; YAML.dump(p('uaa.newrelic')) %>
+<% end %>

--- a/jobs/uaa/templates/uaa_ctl.erb
+++ b/jobs/uaa/templates/uaa_ctl.erb
@@ -50,6 +50,12 @@ fi
 <% end %>
 <% end %>
 
+NEWRELIC_OPTS=
+<% if properties.uaa && properties.uaa.newrelic &&  properties.uaa.newrelic.common && properties.uaa.newrelic.common.license_key %>
+NEWRELIC_OPTS="-javaagent:/var/vcap/data/uaa/tomcat/bin/newrelic.jar -Dnewrelic.config.file=$JOB_DIR/config/newrelic.yml"
+<% end %>
+export NEWRELIC_OPTS
+
 source /var/vcap/packages/common/utils.sh
 
 case $1 in
@@ -86,7 +92,7 @@ case $1 in
     cp -a /var/vcap/jobs/uaa/config/tomcat/* /var/vcap/data/uaa/tomcat/conf/
 
     export CLOUD_FOUNDRY_CONFIG_PATH=/var/vcap/jobs/uaa/config
-    export JAVA_OPTS="-DPID=$$ -Dsun.net.inetaddr.ttl=60 -Dnetworkaddress.cache.ttl=60 $HTTP_PROXY_JAVA_OPTIONS $UAA_OPTIONS"
+    export JAVA_OPTS="-DPID=$$ -Dsun.net.inetaddr.ttl=60 -Dnetworkaddress.cache.ttl=60 $HTTP_PROXY_JAVA_OPTIONS $UAA_OPTIONS $NEWRELIC_OPTS"
     export CATALINA_OPTS="<%= properties.uaa.catalina_opts %>"
 
     cd /var/vcap/data/uaa

--- a/packages/uaa/packaging
+++ b/packages/uaa/packaging
@@ -1,7 +1,7 @@
 set -e -x
 
 cd ${BOSH_INSTALL_TARGET}
-mkdir jdk && tar zxvf ${BOSH_COMPILE_TARGET}/uaa/openjdk-1.7.0_51.tar.gz -C jdk
+mkdir jdk && tar zxvf ${BOSH_COMPILE_TARGET}/uaa/openjdk-1.7.0_79.tar.gz -C jdk
 if [[ $? != 0 ]] ; then
   echo "Cannot unpack JDK"
   exit 1
@@ -9,13 +9,13 @@ fi
 
 cd ${BOSH_INSTALL_TARGET}
 
-tar zxvf ${BOSH_COMPILE_TARGET}/uaa/apache-tomcat-7.0.55.tar.gz
+tar zxvf ${BOSH_COMPILE_TARGET}/uaa/apache-tomcat-7.0.61.tar.gz
 if [[ $? != 0 ]] ; then
   echo "Cannot unpack Tomcat"
   exit 1
 fi
 
-mv apache-tomcat-7.0.55 tomcat
+mv apache-tomcat-7.0.61 tomcat
 
 cd tomcat
 rm -rf webapps/*

--- a/packages/uaa/packaging
+++ b/packages/uaa/packaging
@@ -1,7 +1,7 @@
 set -e -x
 
 cd ${BOSH_INSTALL_TARGET}
-mkdir jdk && tar zxvf ${BOSH_COMPILE_TARGET}/uaa/openjdk-1.7.0_79.tar.gz -C jdk
+mkdir jdk && tar zxvf ${BOSH_COMPILE_TARGET}/openjdk/openjdk-1.7.0_79.tar.gz -C jdk
 if [[ $? != 0 ]] ; then
   echo "Cannot unpack JDK"
   exit 1

--- a/packages/uaa/packaging
+++ b/packages/uaa/packaging
@@ -21,6 +21,7 @@ cd tomcat
 rm -rf webapps/*
 cp -a ${BOSH_COMPILE_TARGET}/uaa/cloudfoundry-identity-uaa.war webapps/ROOT.war
 cp -a ${BOSH_COMPILE_TARGET}/uaa/cloudfoundry-identity-varz-1.0.2.war webapps/varz.war
+cp -a ${BOSH_COMPILE_TARGET}/uaa/newrelic.jar bin/newrelic.jar
 
 cd ${BOSH_INSTALL_TARGET}
 cp -a ${BOSH_COMPILE_TARGET}/cf-registrar-bundle-for-identity vcap-common

--- a/packages/uaa/pre_packaging
+++ b/packages/uaa/pre_packaging
@@ -13,12 +13,12 @@ export PATH=$PATH:/bin:/usr/bin
 if [ `uname` = "Darwin" ]; then
   mkdir java
   cd java
-  tar zxvf ../uaa/openjdk-1.7.0-u40-unofficial-macosx-x86_64-bundle.tgz --exclude="._*"
+  tar zxvf ../openjdk/openjdk-1.7.0-u40-unofficial-macosx-x86_64-bundle.tgz --exclude="._*"
   export JAVA_HOME=${BUILD_DIR}/java/Contents/Home
 elif [ `uname` = "Linux" ]; then
   mkdir java
   cd java
-  tar zxvf ../uaa/openjdk-1.7.0-u40-unofficial-linux-amd64.tgz
+  tar zxvf ../openjdk/openjdk-1.7.0-u40-unofficial-linux-amd64.tgz
   export JAVA_HOME=${BUILD_DIR}/java
 else
   if [ ! -d $JAVA_HOME ]; then
@@ -39,6 +39,6 @@ cp uaa/build/libs/cloudfoundry-identity-uaa-*.war ${BUILD_DIR}/uaa/cloudfoundry-
 #clean build data
 ./gradlew clean
 rm -rf java
-rm -rf uaa/openjdk-1.7.0-u40-unofficial-linux-amd64.tgz
-rm -rf uaa/openjdk-1.7.0-u40-unofficial-macosx-x86_64-bundle.tgz
+rm -rf openjdk/openjdk-1.7.0-u40-unofficial-linux-amd64.tgz
+rm -rf openjdk/openjdk-1.7.0-u40-unofficial-macosx-x86_64-bundle.tgz
 ${BUILD_DIR}/uaa/.clean-cf-release-build

--- a/packages/uaa/spec
+++ b/packages/uaa/spec
@@ -4,4 +4,5 @@ dependencies:
 - ruby-2.1.6
 files:
 - uaa/**/*
+- openjdk/**/*
 - cf-registrar-bundle-for-identity/**/*

--- a/spec/fixtures/aws/cf-manifest.yml.erb
+++ b/spec/fixtures/aws/cf-manifest.yml.erb
@@ -1123,6 +1123,7 @@ properties:
       verification_key: vk
     ldap: null
     login: null
+    newrelic: null
     no_ssl: false
     restricted_ips_regex: 10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}
     scim:

--- a/spec/fixtures/openstack/cf-manifest.yml.erb
+++ b/spec/fixtures/openstack/cf-manifest.yml.erb
@@ -1123,6 +1123,7 @@ properties:
       verification_key: vk
     ldap: null
     login: null
+    newrelic: null
     no_ssl: false
     restricted_ips_regex: 10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}
     scim:

--- a/spec/fixtures/vsphere/cf-manifest.yml.erb
+++ b/spec/fixtures/vsphere/cf-manifest.yml.erb
@@ -1127,6 +1127,7 @@ properties:
       verification_key: vk
     ldap: null
     login: null
+    newrelic: null
     no_ssl: false
     restricted_ips_regex: 10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}
     scim:

--- a/spec/fixtures/warden/cf-manifest.yml.erb
+++ b/spec/fixtures/warden/cf-manifest.yml.erb
@@ -2943,7 +2943,7 @@ properties:
     ldap: null
     login: null
     newrelic:
-      common: &default_settings
+      production:
         license_key: '<yourlicensekeyhere>'
         agent_enabled: true
         app_name: UAA Identity Acceptance
@@ -2983,18 +2983,6 @@ properties:
           enabled: true
         browser_monitoring:
           auto_instrument: true
-      development:
-        <<: *default_settings
-        app_name: UAA Identity Acceptance (Development)
-      test:
-        <<: *default_settings
-        app_name: UAA Identity Acceptance (Test)
-      production:
-        <<: *default_settings
-      staging:
-        <<: *default_settings
-        app_name: UAA Identity Acceptance (Staging)
-
     no_ssl: true
     restricted_ips_regex: 10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}
     scim:
@@ -3006,6 +2994,11 @@ properties:
     url: https://uaa.10.244.0.34.xip.io
     user: null
     zones:
+      internal:
+        hostnames:
+          - host4
+          - host5.test.com
+
   uaadb:
     address: 10.244.0.30
     databases:

--- a/spec/fixtures/warden/cf-manifest.yml.erb
+++ b/spec/fixtures/warden/cf-manifest.yml.erb
@@ -2942,6 +2942,59 @@ properties:
 '
     ldap: null
     login: null
+    newrelic:
+      common: &default_settings
+        license_key: '<yourlicensekeyhere>'
+        agent_enabled: true
+        app_name: UAA Identity Acceptance
+        high_security: false
+        enable_auto_app_naming: false
+        enable_auto_transaction_naming: true
+        log_level: info
+        audit_mode: false
+        log_file_count: 1
+        log_limit_in_kbytes: 0
+        log_daily: false
+        log_file_name: newrelic_agent.log
+        #log_file_path:
+        ssl: true
+        max_stack_trace_lines: 30
+        attributes:
+          enabled: true
+        transaction_tracer:
+          enabled: true
+          transaction_threshold: apdex_f
+          record_sql: obfuscated
+          log_sql: false
+          stack_trace_threshold: 0.5
+          explain_enabled: true
+          explain_threshold: 0.5
+          top_n: 20
+        error_collector:
+          enabled: true
+          ignore_errors: akka.actor.ActorKilledException
+          ignore_status_codes: 404
+        analytics_events:
+          enabled: true
+          max_samples_stored: 2000
+        cross_application_tracer:
+          enabled: true
+        thread_profiler:
+          enabled: true
+        browser_monitoring:
+          auto_instrument: true
+      development:
+        <<: *default_settings
+        app_name: UAA Identity Acceptance (Development)
+      test:
+        <<: *default_settings
+        app_name: UAA Identity Acceptance (Test)
+      production:
+        <<: *default_settings
+      staging:
+        <<: *default_settings
+        app_name: UAA Identity Acceptance (Staging)
+
     no_ssl: true
     restricted_ips_regex: 10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}
     scim:

--- a/spec/fixtures/warden/cf-manifest.yml.erb
+++ b/spec/fixtures/warden/cf-manifest.yml.erb
@@ -2700,6 +2700,8 @@ properties:
         url: "/login?template=warden"
         parameter:
           disable: false
+          whitelist:
+            - https://testapp.10.244.0.34.xip.io/logout/success
     notifications:
       url: null
     protocol: http

--- a/spec/fixtures/warden/cf-stub.yml
+++ b/spec/fixtures/warden/cf-stub.yml
@@ -48,6 +48,8 @@ properties:
         url: "/login?template=warden"
         parameter:
           disable: false
+          whitelist:
+            - https://testapp.10.244.0.34.xip.io/logout/success
   uaa:
     clients:
       app-direct:

--- a/spec/fixtures/warden/cf-stub.yml
+++ b/spec/fixtures/warden/cf-stub.yml
@@ -70,7 +70,7 @@ properties:
         scope: openid,cloud_controller.read,cloud_controller.write,password.write,console.admin,console.support
         secret: console-secret
     newrelic:
-      common: &default_settings
+      production:
         license_key: '<yourlicensekeyhere>'
         agent_enabled: true
         app_name: UAA Identity Acceptance
@@ -110,17 +110,6 @@ properties:
           enabled: true
         browser_monitoring:
           auto_instrument: true
-      development:
-        <<: *default_settings
-        app_name: UAA Identity Acceptance (Development)
-      test:
-        <<: *default_settings
-        app_name: UAA Identity Acceptance (Test)
-      production:
-        <<: *default_settings
-      staging:
-        <<: *default_settings
-        app_name: UAA Identity Acceptance (Staging)
     zones:
       internal:
         hostnames:

--- a/spec/fixtures/warden/cf-stub.yml
+++ b/spec/fixtures/warden/cf-stub.yml
@@ -69,6 +69,63 @@ properties:
         refresh-token-validity: 1209600
         scope: openid,cloud_controller.read,cloud_controller.write,password.write,console.admin,console.support
         secret: console-secret
+    newrelic:
+      common: &default_settings
+        license_key: '<yourlicensekeyhere>'
+        agent_enabled: true
+        app_name: UAA Identity Acceptance
+        high_security: false
+        enable_auto_app_naming: false
+        enable_auto_transaction_naming: true
+        log_level: info
+        audit_mode: false
+        log_file_count: 1
+        log_limit_in_kbytes: 0
+        log_daily: false
+        log_file_name: newrelic_agent.log
+        #log_file_path:
+        ssl: true
+        max_stack_trace_lines: 30
+        attributes:
+          enabled: true
+        transaction_tracer:
+          enabled: true
+          transaction_threshold: apdex_f
+          record_sql: obfuscated
+          log_sql: false
+          stack_trace_threshold: 0.5
+          explain_enabled: true
+          explain_threshold: 0.5
+          top_n: 20
+        error_collector:
+          enabled: true
+          ignore_errors: akka.actor.ActorKilledException
+          ignore_status_codes: 404
+        analytics_events:
+          enabled: true
+          max_samples_stored: 2000
+        cross_application_tracer:
+          enabled: true
+        thread_profiler:
+          enabled: true
+        browser_monitoring:
+          auto_instrument: true
+      development:
+        <<: *default_settings
+        app_name: UAA Identity Acceptance (Development)
+      test:
+        <<: *default_settings
+        app_name: UAA Identity Acceptance (Test)
+      production:
+        <<: *default_settings
+      staging:
+        <<: *default_settings
+        app_name: UAA Identity Acceptance (Staging)
+    zones:
+      internal:
+        hostnames:
+          - host4
+          - host5.test.com
   router:
     enable_ssl: true
     ssl_cert: |

--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -263,6 +263,8 @@ properties:
 
     ldap: ~
 
+    newrelic: ~
+
     spring_profiles: ~
 
     user: ~


### PR DESCRIPTION
The uaa.zones.internal.hostnames property can be used for configuring a list of hostnames that are routed to the UAA. Any other hostnames get rejected by the UAA.