### PR TITLE
Be able to specify timeouts for acceptance tests without defaults in the spec.

### DIFF
--- a/jobs/acceptance-tests/spec
+++ b/jobs/acceptance-tests/spec
@@ -55,14 +55,10 @@ properties:
     default: false
     description: Services tests push their apps using diego if enabled
   acceptance_tests.default_timeout:
-    default: 30
     description: Default Timeout
   acceptance_tests.cf_push_timeout:
-    default: 120
     description: Timeout for cf push
   acceptance_tests.long_curl_timeout:
-    default: 120
     description: Timeout for long curls
   acceptance_tests.broker_start_timeout:
-    default: 300
     description: Timeout for broker starts

--- a/jobs/acceptance-tests/templates/config.json.erb
+++ b/jobs/acceptance-tests/templates/config.json.erb
@@ -1,4 +1,6 @@
 <%
+  require 'json'
+
   def discover_external_ip
     networks = spec.networks.marshal_dump
     _, network = networks.find do |_name, network_spec|
@@ -12,20 +14,23 @@
     end
     network.ip
   end
-  my_ip = discover_external_ip
+
+  at = properties.acceptance_tests
+  config = {
+    :api => at.api,
+    :apps_domain => Array(at.apps_domain).first,
+    :admin_user => at.admin_user,
+    :admin_password => at.admin_password,
+    :skip_ssl_validation => at.skip_ssl_validation,
+    :artifacts_directory => "/var/vcap/sys/log/acceptance_tests/",
+    :syslog_drain_port => 1234,
+    :syslog_ip_address => discover_external_ip,
+    :use_diego => at.use_diego
+  }
+  config[:default_timeout] = at.default_timeout if at.default_timeout
+  config[:cf_push_timeout] = at.default_timeout if at.cf_push_timeout
+  config[:long_curl_timeout] = at.default_timeout if at.long_curl_timeout
+  config[:broker_start_timeout] = at.default_timeout if at.broker_start_timeout
 %>
-{
-  "api"                 : "<%= properties.acceptance_tests.api %>",
-  "apps_domain"         : "<%= Array(properties.acceptance_tests.apps_domain).first %>",
-  "admin_user"          : "<%= properties.acceptance_tests.admin_user %>",
-  "admin_password"      : "<%= properties.acceptance_tests.admin_password %>",
-  "skip_ssl_validation" : <%= properties.acceptance_tests.skip_ssl_validation %>,
-  "artifacts_directory" : "/var/vcap/sys/log/acceptance_tests/",
-  "syslog_drain_port"   : 1234,
-  "syslog_ip_address"   : "<%= my_ip %>",
-  "use_diego"           : <%= properties.acceptance_tests.use_diego %>,
-  "default_timeout"     : <%= properties.acceptance_tests.default_timeout %>,
-  "cf_push_timeout"     : <%= properties.acceptance_tests.cf_push_timeout %>,
-  "long_curl_timeout"   : <%= properties.acceptance_tests.long_curl_timeout %>,
-  "broker_start_timeout": <%= properties.acceptance_tests.broker_start_timeout %>
-}
+
+<%= JSON.pretty_generate(config) %>


### PR DESCRIPTION
My previous PR (https://github.com/cloudfoundry/cf-release/pull/652) got rejected

"It looks like we're already configuring the default timeouts in the CATS codebase, and we would like for that to be the source of truth for defaults. Could you please remove the defaults from the spec file to prevent any overlap? We'll be happy to pull in the PR after that."
@zrob

It seems the similar changes ended up in develop anyways
https://github.com/cloudfoundry/cf-release/commit/b6c1f33771213ded1cf7c982f5f6fafb3d900197

Anyways, here is a new PR that addresses the issue that got raised.