### PR TITLE
Upgrading go buildpack to v1.3.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -95,10 +95,6 @@ consul/consul_0.5.0_linux_amd64.zip:
   object_id: 3e6c1e47-95a5-45ef-aeec-2cb4cc4c529a
   sha: 00e4c6e9ff2fb326d3b586fd86c3037f3b7e0974
   size: 4669655
-go-buildpack/go_buildpack-cached-v1.2.0.zip:
-  object_id: da609e02-aec5-4d54-93bc-86ca0b44eed7
-  sha: e58788c873ddbecd641532f32ce4d535b2a79f81
-  size: 663443569
 python-buildpack/python_buildpack-cached-v1.2.0.zip:
   object_id: 3e8561a1-7cdc-45c2-9eff-b8d49ebc4e88
   sha: 2ca4545ab99ac2a2e430f58fe1ec55fe6b96a7b3
@@ -143,3 +139,7 @@ staticfile-buildpack/staticfile_buildpack-cached-v1.0.0.zip:
   object_id: 631eb980-d1aa-44a5-86cc-e13b13f8c8b9
   sha: 34371ecb9973c03191ea35c7d52d6461186fe279
   size: 6449775
+go-buildpack/go_buildpack-cached-v1.3.1.zip:
+  object_id: 5e671c4a-4b81-41fe-a4a7-9bb6cabe933a
+  sha: 82d19816c39e0e77b25ce599117fa07b2e06efe8
+  size: 463782558

--- a/packages/buildpack_go/packaging
+++ b/packages/buildpack_go/packaging
@@ -1,3 +1,3 @@
 set -e -x
 
-cp go-buildpack/go_buildpack-cached-v1.2.0.zip ${BOSH_INSTALL_TARGET}
+cp go-buildpack/go_buildpack-cached-v1.3.1.zip ${BOSH_INSTALL_TARGET}

--- a/packages/buildpack_go/spec
+++ b/packages/buildpack_go/spec
@@ -1,4 +1,4 @@
 ---
 name: buildpack_go
 files:
-- go-buildpack/go_buildpack-cached-v1.2.0.zip
+- go-buildpack/go_buildpack-cached-v1.3.1.zip


### PR DESCRIPTION
Upgrading to latest stable version of go buildpack
 --Buildpacks Team