### PR TITLE
Add security group for cf-mysql subnets

### DIFF
--- a/bosh-lite/cf-stub-spiff.yml
+++ b/bosh-lite/cf-stub-spiff.yml
@@ -44,7 +44,11 @@ properties:
         rules:
         - protocol: all
           destination: (( merge || "10.244.0.34" ))
-    default_running_security_groups: ["public_networks", "dns", "services", "load_balancer"]
+      - name: cf_mysql
+        rules:
+        - protocol: all
+          destination: 10.244.7.0-10.244.9.255
+    default_running_security_groups: ["public_networks", "dns", "services", "load_balancer", "cf_mysql"]
 jobs:
 - instances: 1
   name: routing_api_z1


### PR DESCRIPTION
Updated to new networks used in multi-AZs