### PR TITLE
Fixing failed cc_ng and cc_ng_worker with NFS

### DIFF
--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -28,9 +28,9 @@ meta:
     release: (( meta.release.name ))
   - name: metron_agent
     release: (( meta.release.name ))
-  - name: nfs_mounter
-    release: (( meta.release.name ))
   - name: ca_truster
+    release: (( meta.release.name ))
+  - name: nfs_mounter
     release: (( meta.release.name ))
 
   api_worker_templates:
@@ -38,9 +38,9 @@ meta:
     release: (( meta.release.name ))
   - name: metron_agent
     release: (( meta.release.name ))
-  - name: nfs_mounter
-    release: (( meta.release.name ))
   - name: ca_truster
+    release: (( meta.release.name ))
+  - name: nfs_mounter
     release: (( meta.release.name ))
 
   clock_templates:


### PR DESCRIPTION
Trying to workaround failed start by changing the template order and placing nfs_moubnter last.

See http://cf-dev.70369.x6.nabble.com/cf-dev-api-and-api-worker-jobs-fail-to-bosh-update-but-monit-start-OK-td195.html
and https://www.pivotaltracker.com/n/projects/966314/stories/94152506