### PR TITLE
Add doppler_z* jobs and remove instances of loggregator_z*

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml.erb
+++ b/spec/fixtures/aws/cf-manifest.yml.erb
@@ -501,7 +501,7 @@ jobs:
     release: cf
   update:
     max_in_flight: 1
-- instances: 1
+- instances: 0
   name: loggregator_z1
   networks:
   - name: cf1
@@ -513,8 +513,32 @@ jobs:
   templates:
 <%= loggregator_templates %>
   update: {}
-- instances: 1
+- instances: 0
   name: loggregator_z2
+  networks:
+  - name: cf2
+  properties:
+<%= loggregator_z2_properties %>
+    networks:
+      apps: cf2
+  resource_pool: medium_z2
+  templates:
+<%= loggregator_templates %>
+  update: {}
+- instances: 1
+  name: doppler_z1
+  networks:
+  - name: cf1
+  properties:
+<%= loggregator_z1_properties %>
+    networks:
+      apps: cf1
+  resource_pool: medium_z1
+  templates:
+<%= loggregator_templates %>
+  update: {}
+- instances: 1
+  name: doppler_z2
   networks:
   - name: cf2
   properties:

--- a/spec/fixtures/openstack/cf-manifest.yml.erb
+++ b/spec/fixtures/openstack/cf-manifest.yml.erb
@@ -503,7 +503,7 @@ jobs:
     release: cf
   update:
     max_in_flight: 1
-- instances: 1
+- instances: 0
   name: loggregator_z1
   networks:
   - name: cf1
@@ -517,6 +517,30 @@ jobs:
   update: {}
 - instances: 0
   name: loggregator_z2
+  networks:
+  - name: cf2
+  properties:
+<%= loggregator_z2_properties %>
+    networks:
+      apps: cf2
+  resource_pool: medium_z2
+  templates:
+<%= loggregator_templates %>
+  update: {}
+- instances: 1
+  name: doppler_z1
+  networks:
+  - name: cf1
+  properties:
+<%= loggregator_z1_properties %>
+    networks:
+      apps: cf1
+  resource_pool: medium_z1
+  templates:
+<%= loggregator_templates %>
+  update: {}
+- instances: 0
+  name: doppler_z2
   networks:
   - name: cf2
   properties:

--- a/spec/fixtures/vsphere/cf-manifest.yml.erb
+++ b/spec/fixtures/vsphere/cf-manifest.yml.erb
@@ -504,7 +504,7 @@ jobs:
     release: cf
   update:
     max_in_flight: 1
-- instances: 1
+- instances: 0
   name: loggregator_z1
   networks:
   - name: cf1
@@ -516,8 +516,32 @@ jobs:
   templates:
 <%= loggregator_templates %>
   update: {}
-- instances: 1
+- instances: 0
   name: loggregator_z2
+  networks:
+  - name: cf2
+  properties:
+<%= loggregator_z2_properties %>
+    networks:
+      apps: cf2
+  resource_pool: medium_z2
+  templates:
+<%= loggregator_templates %>
+  update: {}
+- instances: 1
+  name: doppler_z1
+  networks:
+  - name: cf1
+  properties:
+<%= loggregator_z1_properties %>
+    networks:
+      apps: cf1
+  resource_pool: medium_z1
+  templates:
+<%= loggregator_templates %>
+  update: {}
+- instances: 1
+  name: doppler_z2
   networks:
   - name: cf2
   properties:

--- a/spec/fixtures/warden/cf-manifest.yml.erb
+++ b/spec/fixtures/warden/cf-manifest.yml.erb
@@ -549,7 +549,7 @@ jobs:
     release: cf
   update:
     max_in_flight: 1
-- instances: 1
+- instances: 0
   name: loggregator_z1
   networks:
   - name: cf1
@@ -563,6 +563,30 @@ jobs:
   update: {}
 - instances: 0
   name: loggregator_z2
+  networks:
+  - name: cf2
+  properties:
+<%= loggregator_z2_properties %>
+    networks:
+      apps: cf2
+  resource_pool: medium_z2
+  templates:
+<%= loggregator_templates %>
+  update: {}
+- instances: 1
+  name: doppler_z1
+  networks:
+  - name: cf1
+  properties:
+<%= loggregator_z1_properties %>
+    networks:
+      apps: cf1
+  resource_pool: medium_z1
+  templates:
+<%= loggregator_templates %>
+  update: {}
+- instances: 0
+  name: doppler_z2
   networks:
   - name: cf2
   properties:

--- a/templates/cf-infrastructure-aws.yml
+++ b/templates/cf-infrastructure-aws.yml
@@ -204,11 +204,21 @@ jobs:
         static_ips: (( static_ips(26) ))
 
   - name: loggregator_z1
-    instances: 1
+    instances: 0
     networks:
       - name: cf1
 
   - name: loggregator_z2
+    instances: 0
+    networks:
+      - name: cf2
+
+  - name: doppler_z1
+    instances: 1
+    networks:
+      - name: cf1
+
+  - name: doppler_z2
     instances: 1
     networks:
       - name: cf2

--- a/templates/cf-infrastructure-openstack.yml
+++ b/templates/cf-infrastructure-openstack.yml
@@ -174,6 +174,11 @@ jobs:
         static_ips: []
 
   - name: loggregator_z1
+    instances: 0
+    networks:
+      - name: cf1
+
+  - name: doppler_z1
     instances: 1
     networks:
       - name: cf1
@@ -229,6 +234,11 @@ jobs:
     instances: 0
     networks:
      - name: cf2
+
+  - name: doppler_z2
+    instances: 0
+    networks:
+      - name: cf1
 
   - name: loggregator_trafficcontroller_z2
     instances: 0

--- a/templates/cf-infrastructure-vsphere.yml
+++ b/templates/cf-infrastructure-vsphere.yml
@@ -143,11 +143,21 @@ jobs:
         static_ips: (( static_ips(16) ))
 
   - name: loggregator_z1
-    instances: 1
+    instances: 0
     networks:
       - name: cf1
 
   - name: loggregator_z2
+    instances: 0
+    networks:
+      - name: cf2
+
+  - name: doppler_z1
+    instances: 1
+    networks:
+      - name: cf1
+
+  - name: doppler_z2
     instances: 1
     networks:
       - name: cf2

--- a/templates/cf-infrastructure-warden.yml
+++ b/templates/cf-infrastructure-warden.yml
@@ -255,11 +255,21 @@ jobs:
       - name: cf2
 
   - name: loggregator_z1
-    instances: 1
+    instances: 0
     networks:
       - name: cf1
 
   - name: loggregator_z2
+    instances: 0
+    networks:
+      - name: cf2
+
+  - name: doppler_z1
+    instances: 1
+    networks:
+      - name: cf1
+
+  - name: doppler_z2
     instances: 0
     networks:
       - name: cf2

--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -488,7 +488,7 @@ jobs:
 
   - name: loggregator_z1
     templates: (( merge || lamb_meta.loggregator_templates ))
-    instances: 1
+    instances: 0
     resource_pool: medium_z1
     networks:
       - name: cf1
@@ -498,6 +498,28 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: loggregator_z2
+    templates: (( merge || lamb_meta.loggregator_templates ))
+    instances: 0
+    resource_pool: medium_z2
+    networks:
+      - name: cf2
+    properties:
+      <<: (( merge ))
+      networks: (( meta.networks.z2 ))
+    update: (( merge || empty_hash ))
+
+- name: doppler_z1
+    templates: (( merge || lamb_meta.loggregator_templates ))
+    instances: 1
+    resource_pool: medium_z1
+    networks:
+      - name: cf1
+    properties:
+      <<: (( merge ))
+      networks: (( meta.networks.z1 ))
+    update: (( merge || empty_hash ))
+
+  - name: doppler_z2
     templates: (( merge || lamb_meta.loggregator_templates ))
     instances: 1
     resource_pool: medium_z2

--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -508,7 +508,7 @@ jobs:
       networks: (( meta.networks.z2 ))
     update: (( merge || empty_hash ))
 
-- name: doppler_z1
+  - name: doppler_z1
     templates: (( merge || lamb_meta.loggregator_templates ))
     instances: 1
     resource_pool: medium_z1


### PR DESCRIPTION
ADDs doppler-named jobs to replace loggregator-named jobs. Deploying this commit with zero-downtime requires a two-phase deploy:
1. Add instances of each doppler job to match the number of instances of the corresponding loggregator job and deploy.
2. Remove all instances of loggregator and deploy.

The end result is jobs named doppler_z1 and doppler_z2, which run the component named doppler.

[#89420698]

Signed-off-by: Rohit Kumar <rokumar@pivotal.io>