### PR TITLE
Flexible UAA NewRelic Configuration

### DIFF
--- a/jobs/uaa/templates/newrelic.yml.erb
+++ b/jobs/uaa/templates/newrelic.yml.erb
@@ -1,3 +1,19 @@
-<% if properties.uaa && properties.uaa.newrelic && properties.uaa.newrelic.common && properties.uaa.newrelic.common.license_key %>
-<%= require 'yaml'; YAML.dump(p('uaa.newrelic')) %>
-<% end %>
+<%
+if properties.uaa && properties.uaa.newrelic 
+    newrelicenv = String.new("production")
+    if properties.uaa && properties.uaa.newrelic && properties.uaa.newrelic.environment
+        newrelicenv = p('uaa.newrelic.environment')
+    end
+
+    hasnewreliclic = false
+    if properties.uaa.newrelic.common && properties.uaa.newrelic.common.license_key
+        hasnewreliclic = true
+    elsif p('uaa.newrelic.'+newrelicenv+'.license_key').to_s.strip.length > 0
+        hasnewreliclic = true
+    end 
+
+    if hasnewreliclic %>
+<%= require 'yaml'; YAML.dump(p('uaa.newrelic').tap{|x| x.delete('environment')}) %><%
+    end
+end      
+%>

--- a/jobs/uaa/templates/uaa_ctl.erb
+++ b/jobs/uaa/templates/uaa_ctl.erb
@@ -51,9 +51,26 @@ fi
 <% end %>
 
 NEWRELIC_OPTS=
-<% if properties.uaa && properties.uaa.newrelic &&  properties.uaa.newrelic.common && properties.uaa.newrelic.common.license_key %>
-NEWRELIC_OPTS="-javaagent:/var/vcap/data/uaa/tomcat/bin/newrelic.jar -Dnewrelic.config.file=$JOB_DIR/config/newrelic.yml"
-<% end %>
+<%
+if properties.uaa && properties.uaa.newrelic 
+    newrelicenv = String.new("production")
+    if properties.uaa && properties.uaa.newrelic && properties.uaa.newrelic.environment
+        newrelicenv = p('uaa.newrelic.environment')
+    end
+
+    hasnewreliclic = false
+    if properties.uaa.newrelic.common && properties.uaa.newrelic.common.license_key
+        hasnewreliclic = true
+    elsif p('uaa.newrelic.'+newrelicenv+'.license_key').to_s.strip.length > 0
+        hasnewreliclic = true
+    end 
+
+    if hasnewreliclic %>
+<%= "NEWRELIC_OPTS=\"-javaagent:/var/vcap/data/uaa/tomcat/bin/newrelic.jar -Dnewrelic.config.file=$JOB_DIR/config/newrelic.yml -Dnewrelic.environment="+newrelicenv+"\"" %><%
+    end
+end
+%>
+
 export NEWRELIC_OPTS
 
 source /var/vcap/packages/common/utils.sh


### PR DESCRIPTION
Extract the newrelic.environment variable into a system environment, so that 

    properties:
      uaa:
        newrelic:
          environment

takes into effect. The following sample configurations have been tested
The following triggers UAA to enable the NewRelic agent

    properties.uaa.newrelic.common.license_key

or 

    properties.uaa.newrelic.(properties.uaa.newrelic.environment).license_key

The default value of properties.uaa.newrelic.environment is 'production'

Sample 1: test environment that inherits common properties

    properties:
      uaa:
        newrelic:
          environment: test
          common: &default_settings
            license_key: 'valid-license-here'
          test:
            <<: *default_settings
            app_name: FHANIK-New-Relic-UAA-Sample-1
            error_collector:
              ignore_errors: akka.actor.ActorKilledException

Sample 2 : staging environment

    properties:
      uaa:
        newrelic:
          environment: staging
          staging:
            license_key: 'valid-license-here'
            error_collector:
              ignore_errors: akka.actor.ActorKilledException
            app_name: FHANIK-New-Relic-UAA-Sample-2

Sample 3 : Staging environment that inherits common properties

    properties:
      uaa:
        newrelic:
          environment: staging
          common: &default_settings
            error_collector:
              ignore_errors: akka.actor.ActorKilledException
          staging:
            license_key: 'valid-license-here'
            <<: *default_settings
            app_name: FHANIK-New-Relic-UAA-Sample-3

Sample 4: Production environment - no need to specify properties.uaa.newrelic.environment

    properties:
      uaa:
        newrelic:
          production:
            license_key: 'valid-license-here'
            error_collector:
              ignore_errors: akka.actor.ActorKilledException
            app_name: FHANIK-New-Relic-UAA-Sample-4

Sample 5: Create a custom environment, this one called 'common'

    properties:
      uaa:
        newrelic:
          environment: common
          common:
            license_key: 'valid-license-here'
            app_name: FHANIK-New-Relic-UAA-Sample-5
            error_collector:
              ignore_errors: akka.actor.ActorKilledException

