### PR TITLE
Remove diego_docker property

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -349,9 +349,6 @@ properties:
   cc.users_can_select_backend:
     default: true
     description: "Allow non-admin users to switch their apps between DEA and Diego backends"
-  cc.diego_docker:
-    default: false
-    description: "Enable diego docker support"
   cc.default_to_diego_backend:
     default: false
     description: "Use Diego backend by default for new apps"

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -380,9 +380,6 @@ properties:
   cc.users_can_select_backend:
     default: true
     description: "Allow non-admin users to switch their apps between DEA and Diego backends"
-  cc.diego_docker:
-    default: false
-    description: "Enable diego docker support"
   cc.default_to_diego_backend:
     default: false
     description: "Use Diego backend by default for new apps"

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -347,9 +347,6 @@ properties:
   cc.users_can_select_backend:
     default: true
     description: "Allow non-admin users to switch their apps between DEA and Diego backends"
-  cc.diego_docker:
-    default: false
-    description: "Enable diego docker support"
   cc.default_to_diego_backend:
     default: false
     description: "Use Diego backend by default for new apps"

--- a/spec/fixtures/aws/cf-manifest.yml.erb
+++ b/spec/fixtures/aws/cf-manifest.yml.erb
@@ -748,7 +748,6 @@ properties:
     - dns
     default_to_diego_backend: false
     development_mode: false
-    diego_docker: false
     allow_app_ssh_access: true
     directories: null
     disable_custom_buildpacks: false

--- a/spec/fixtures/openstack/cf-manifest.yml.erb
+++ b/spec/fixtures/openstack/cf-manifest.yml.erb
@@ -740,7 +740,6 @@ properties:
     - dns
     default_to_diego_backend: false
     development_mode: false
-    diego_docker: false
     allow_app_ssh_access: true
     directories: null
     disable_custom_buildpacks: false

--- a/spec/fixtures/vsphere/cf-manifest.yml.erb
+++ b/spec/fixtures/vsphere/cf-manifest.yml.erb
@@ -747,7 +747,6 @@ properties:
     - dns
     default_to_diego_backend: false
     development_mode: false
-    diego_docker: false
     allow_app_ssh_access: true
     directories: null
     disable_custom_buildpacks: false

--- a/spec/fixtures/warden/cf-manifest.yml.erb
+++ b/spec/fixtures/warden/cf-manifest.yml.erb
@@ -2462,7 +2462,6 @@ properties:
     - dns
     default_to_diego_backend: false
     development_mode: false
-    diego_docker: false
     allow_app_ssh_access: true
     directories: null
     disable_custom_buildpacks: false

--- a/templates/cf-infrastructure-warden.yml
+++ b/templates/cf-infrastructure-warden.yml
@@ -62,7 +62,6 @@ properties:
     buildpacks:
       fog_connection: (( meta.fog_config ))
     diego: (( merge || false ))
-    diego_docker: (( merge || false ))
 
   uaa:
     catalina_opts: -Xmx192m -XX:MaxPermSize=128m

--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -69,7 +69,6 @@ properties:
     billing_event_writing_enabled: false
 
     users_can_select_backend: true
-    diego_docker: false
     default_to_diego_backend: false
     allow_app_ssh_access: true
     default_app_memory: 1024


### PR DESCRIPTION
[#95275686]

Removed in favor of `diego_docker` feature flag that ensures consistent behavior across multiple CC nodes.

Signed-off-by: Georgi Sabev <georgethebeatle@gmail.com>