### PR TITLE
Upgrading go buildpack to v1.4.0

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -111,10 +111,6 @@ php-buildpack/php_buildpack-cached-v3.2.2.zip:
   object_id: 4cbd86d2-a739-4a13-90f1-58f6097e718a
   sha: 3a6e7a88754029e6efbaa0d6905fca6086bb0b64
   size: 846464023
-go-buildpack/go_buildpack-cached-v1.3.1.zip:
-  object_id: 5e671c4a-4b81-41fe-a4a7-9bb6cabe933a
-  sha: 82d19816c39e0e77b25ce599117fa07b2e06efe8
-  size: 463782558
 consul/consul-template_0.9.0_linux_amd64.tar.gz:
   object_id: e83bcdcd-2f31-4b73-8cf8-516d54e8f59a
   sha: a44e441f9347abe64956e5bb30c4d4b0464d1f73
@@ -171,3 +167,7 @@ binary-buildpack/binary_buildpack-cached-v1.0.1.zip:
   object_id: ada385dd-f0b6-43c7-8429-0057766116cc
   sha: 3e62e3882495cf16686078e7209bf28d3f9d60f5
   size: 8487
+go-buildpack/go_buildpack-cached-v1.4.0.zip:
+  object_id: d405c4f8-f88d-41b7-8ca6-3a3e0e1fc3ef
+  sha: 37a05d1777d33aadcc7b80cb3823d9218b3aaea5
+  size: 463786756

--- a/packages/buildpack_go/packaging
+++ b/packages/buildpack_go/packaging
@@ -1,3 +1,3 @@
 set -e -x
 
-cp go-buildpack/go_buildpack-cached-v1.3.1.zip ${BOSH_INSTALL_TARGET}
+cp go-buildpack/go_buildpack-cached-v1.4.0.zip ${BOSH_INSTALL_TARGET}

--- a/packages/buildpack_go/spec
+++ b/packages/buildpack_go/spec
@@ -1,4 +1,4 @@
 ---
 name: buildpack_go
 files:
-- go-buildpack/go_buildpack-cached-v1.3.1.zip
+- go-buildpack/go_buildpack-cached-v1.4.0.zip


### PR DESCRIPTION
Upgrading to latest stable version of go buildpack
 --Buildpacks Team