### PR TITLE
Fix java removal in uaa pre_packaging script.

### DIFF
--- a/packages/uaa/pre_packaging
+++ b/packages/uaa/pre_packaging
@@ -38,6 +38,7 @@ cp uaa/build/libs/cloudfoundry-identity-uaa-*.war ${BUILD_DIR}/uaa/cloudfoundry-
 
 #clean build data
 ./gradlew clean
+cd ${BUILD_DIR}
 rm -rf java
 rm -rf openjdk/openjdk-1.7.0-u40-unofficial-linux-amd64.tgz
 rm -rf openjdk/openjdk-1.7.0-u40-unofficial-macosx-x86_64-bundle.tgz


### PR DESCRIPTION
Hi, all.

This is a simple fix that prevents putting unnecessary data to UAA package. 

This changes also cured me of the strange issue which happen when I run `bosh create release --with-tarball --force` command. When building UAA, I have following error output:
```
Building uaa...
  No artifact found for uaa
  Generating...
  Pre-packaging...
Cannot create tarball: tar: ./java/src.zip: File removed before we read it
tar: ./java/jre/lib/zi: File removed before we read it
tar: ./java/jre/lib/ext/libatk-wrapper.so: File removed before we read it
tar: ./java/jre/lib/ext/java-atk-wrapper.jar: File removed before we read it
tar: ./java/docs: File removed before we read it
```
After I added this changes the error was solved.