### PR TITLE
Preserve rootfs permissions

### DIFF
--- a/jobs/dea_next/spec
+++ b/jobs/dea_next/spec
@@ -116,7 +116,7 @@ properties:
   dea_next.stacks:
     default:
       - name: "cflinuxfs2"
-        package_path: "/var/vcap/packages/rootfs_cflinuxfs2"
+        package_path: "/var/vcap/packages/rootfs_cflinuxfs2/rootfs"
     description: "An array of stacks, specifying the name and package path."
   disk_quota_enabled:
     description: "disk quota must be disabled to use warden-inside-warden with the warden cpi"

--- a/jobs/dea_next/templates/warden.yml.erb
+++ b/jobs/dea_next/templates/warden.yml.erb
@@ -3,7 +3,7 @@ server:
   unix_domain_permissions: 0777
   unix_domain_path: /var/vcap/data/warden/warden.sock
   container_klass: Warden::Container::Linux
-  container_rootfs_path: /var/vcap/packages/rootfs_cflinuxfs2
+  container_rootfs_path: /var/vcap/packages/rootfs_cflinuxfs2/rootfs
   container_depot_path: /var/vcap/data/warden/depot
   container_rlimits:
     core: <%= p("dea_next.rlimit_core") %>

--- a/jobs/dea_next/templates/warden_ctl.erb
+++ b/jobs/dea_next/templates/warden_ctl.erb
@@ -22,6 +22,15 @@ case $1 in
     chown vcap:vcap /var/vcap/sys/cores
     echo /var/vcap/sys/cores/core-%e-%s-%p-%t > /proc/sys/kernel/core_pattern
 
+    # Setup rootfs
+    ROOTFS_PACKAGE=/var/vcap/packages/rootfs_cflinuxfs2/ 
+    ROOTFS_DIR=$ROOTFS_PACKAGE/rootfs 
+    if [ ! -d $ROOTFS_DIR ]; then
+      mkdir -p $ROOTFS_DIR
+      tar -pzxf $ROOTFS_PACKAGE/cflinuxfs2.tar.gz -C $ROOTFS_DIR
+    fi
+
+    # Set ulimits
     ulimit -c unlimited
 
     <% if p("dea_next.kernel_network_tuning_enabled") == true %>

--- a/packages/rootfs_cflinuxfs2/packaging
+++ b/packages/rootfs_cflinuxfs2/packaging
@@ -1,4 +1,4 @@
 set -e -x
 
-echo "Extracting rootfs"
-tar xzf rootfs/cflinuxfs2.tar.gz -C ${BOSH_INSTALL_TARGET}
+echo "Copying rootfs"
+cp rootfs/cflinuxfs2.tar.gz ${BOSH_INSTALL_TARGET}/cflinuxfs2.tar.gz


### PR DESCRIPTION
Move the extraction of the cflinuxfs2 rootfs into the dea_next job vm. This
will ensure that the ownership of /home/vcap dir in the rootfs is vcap:vcap.
The compilation & distribution steps do not preserve the ownership and that's
why we are moving the extraction of the rootfs to the warden_ctl script.

Signed-off-by: Svett Ralchev <sralchev@pivotal.io>