### PR TITLE
extract resource_pools property to separate file

### DIFF
--- a/generate_deployment_manifest
+++ b/generate_deployment_manifest
@@ -16,6 +16,7 @@ fi
 
 spiff merge \
   $templates/cf-deployment.yml \
+  $templates/cf-resource-pools.yml \
   $templates/cf-jobs.yml \
   $templates/cf-properties.yml \
   $templates/cf-lamb.yml \

--- a/spec/fixtures/aws/cf-manifest.yml.erb
+++ b/spec/fixtures/aws/cf-manifest.yml.erb
@@ -657,12 +657,6 @@ meta:
   releases:
   - name: cf
     version: latest
-  stemcell:
-    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: latest
-  default_env:
-    bosh:
-      password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 name: null
 networks:
 - name: cf1

--- a/spec/fixtures/openstack/cf-manifest.yml.erb
+++ b/spec/fixtures/openstack/cf-manifest.yml.erb
@@ -658,12 +658,6 @@ meta:
   releases:
   - name: cf
     version: latest
-  stemcell:
-    name: bosh-openstack-kvm-ubuntu-trusty-go_agent
-    version: latest
-  default_env:
-    bosh:
-      password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 name: null
 networks:
 - name: cf1

--- a/spec/fixtures/vsphere/cf-manifest.yml.erb
+++ b/spec/fixtures/vsphere/cf-manifest.yml.erb
@@ -660,12 +660,6 @@ meta:
   releases:
   - name: cf
     version: latest
-  stemcell:
-    name: bosh-vsphere-esxi-ubuntu-trusty-go_agent
-    version: latest
-  default_env:
-    bosh:
-      password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 name: null
 networks:
 - name: cf1

--- a/spec/fixtures/warden/cf-manifest.yml.erb
+++ b/spec/fixtures/warden/cf-manifest.yml.erb
@@ -704,12 +704,6 @@ meta:
   releases:
   - name: cf
     version: latest
-  stemcell:
-    name: bosh-warden-boshlite-ubuntu-trusty-go_agent
-    version: latest
-  default_env:
-    bosh:
-      password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 name: cf-warden
 networks:
 - name: cf1

--- a/templates/cf-deployment.yml
+++ b/templates/cf-deployment.yml
@@ -5,17 +5,9 @@ meta:
   # i.e. cf-tabasco
   environment: ~
 
-  default_env:
-    # Default vcap & root password on deployed VMs (ie c1oudc0w)
-    # Generated using mkpasswd -m sha-512
-    bosh:
-      password: (( merge || "$6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0" ))
-
   releases:
   - name: cf
     version: latest
-
-  stemcell: (( merge ))
 
 name: (( meta.environment ))
 
@@ -42,76 +34,4 @@ update:
   update_watch_time: 5000-600000
   serial: true
 
-resource_pools:
-  - name: small_z1
-    network: cf1
-    stemcell: (( meta.stemcell ))
-    cloud_properties: (( merge ))
-    env: (( merge || meta.default_env ))
-
-  - name: small_z2
-    network: cf2
-    stemcell: (( meta.stemcell ))
-    cloud_properties: (( merge ))
-    env: (( merge || meta.default_env ))
-
-  - name: medium_z1
-    network: cf1
-    stemcell: (( meta.stemcell ))
-    cloud_properties: (( merge ))
-    env: (( merge || meta.default_env ))
-
-  - name: medium_z2
-    network: cf2
-    stemcell: (( meta.stemcell ))
-    cloud_properties: (( merge ))
-    env: (( merge || meta.default_env ))
-
-  - name: large_z1
-    network: cf1
-    stemcell: (( meta.stemcell ))
-    cloud_properties: (( merge ))
-    env: (( merge || meta.default_env ))
-
-  - name: large_z2
-    network: cf2
-    stemcell: (( meta.stemcell ))
-    cloud_properties: (( merge ))
-    env: (( merge || meta.default_env ))
-
-  - name: runner_z1
-    network: cf1
-    stemcell: (( meta.stemcell ))
-    cloud_properties: (( merge ))
-    env: (( merge || meta.default_env ))
-
-  - name: runner_z2
-    network: cf2
-    stemcell: (( meta.stemcell ))
-    cloud_properties: (( merge ))
-    env: (( merge || meta.default_env ))
-
-  - name: router_z1
-    network: cf1
-    stemcell: (( meta.stemcell ))
-    cloud_properties: (( merge ))
-    env: (( merge || meta.default_env ))
-
-  - name: router_z2
-    network: cf2
-    stemcell: (( meta.stemcell ))
-    cloud_properties: (( merge ))
-    env: (( merge || meta.default_env ))
-
-  - name: small_errand
-    network: cf1
-    stemcell: (( meta.stemcell ))
-    cloud_properties: (( merge || resource_pools.small_z1.cloud_properties ))
-    env: (( merge || meta.default_env ))
-
-  - name: xlarge_errand
-    network: cf1
-    stemcell: (( meta.stemcell ))
-    cloud_properties: (( merge || resource_pools.large_z1.cloud_properties ))
-    env: (( merge || meta.default_env ))
-
+resource_pools: (( merge ))

--- a/templates/cf-deployment.yml
+++ b/templates/cf-deployment.yml
@@ -9,10 +9,6 @@ meta:
   - name: cf
     version: latest
 
-  default_env: (( merge ))
-
-  stemcell: (( merge ))
-
 name: (( meta.environment ))
 
 director_uuid: (( merge ))

--- a/templates/cf-deployment.yml
+++ b/templates/cf-deployment.yml
@@ -9,6 +9,10 @@ meta:
   - name: cf
     version: latest
 
+  default_env: (( merge ))
+
+  stemcell: (( merge ))
+
 name: (( meta.environment ))
 
 director_uuid: (( merge ))

--- a/templates/cf-resource-pools.yml
+++ b/templates/cf-resource-pools.yml
@@ -1,0 +1,87 @@
+meta:
+  default_env:
+    # Default vcap & root password on deployed VMs (ie c1oudc0w)
+    # Generated using mkpasswd -m sha-512
+    bosh:
+      password: (( merge || "$6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0" ))
+
+  stemcell: (( merge ))
+
+networks: (( merge ))
+
+jobs: (( merge ))
+
+properties: (( merge ))
+
+resource_pools:
+  - name: small_z1
+    network: cf1
+    stemcell: (( meta.stemcell ))
+    cloud_properties: (( merge ))
+    env: (( merge || meta.default_env ))
+
+  - name: small_z2
+    network: cf2
+    stemcell: (( meta.stemcell ))
+    cloud_properties: (( merge ))
+    env: (( merge || meta.default_env ))
+
+  - name: medium_z1
+    network: cf1
+    stemcell: (( meta.stemcell ))
+    cloud_properties: (( merge ))
+    env: (( merge || meta.default_env ))
+
+  - name: medium_z2
+    network: cf2
+    stemcell: (( meta.stemcell ))
+    cloud_properties: (( merge ))
+    env: (( merge || meta.default_env ))
+
+  - name: large_z1
+    network: cf1
+    stemcell: (( meta.stemcell ))
+    cloud_properties: (( merge ))
+    env: (( merge || meta.default_env ))
+
+  - name: large_z2
+    network: cf2
+    stemcell: (( meta.stemcell ))
+    cloud_properties: (( merge ))
+    env: (( merge || meta.default_env ))
+
+  - name: runner_z1
+    network: cf1
+    stemcell: (( meta.stemcell ))
+    cloud_properties: (( merge ))
+    env: (( merge || meta.default_env ))
+
+  - name: runner_z2
+    network: cf2
+    stemcell: (( meta.stemcell ))
+    cloud_properties: (( merge ))
+    env: (( merge || meta.default_env ))
+
+  - name: router_z1
+    network: cf1
+    stemcell: (( meta.stemcell ))
+    cloud_properties: (( merge ))
+    env: (( merge || meta.default_env ))
+
+  - name: router_z2
+    network: cf2
+    stemcell: (( meta.stemcell ))
+    cloud_properties: (( merge ))
+    env: (( merge || meta.default_env ))
+
+  - name: small_errand
+    network: cf1
+    stemcell: (( meta.stemcell ))
+    cloud_properties: (( merge || resource_pools.small_z1.cloud_properties ))
+    env: (( merge || meta.default_env ))
+
+  - name: xlarge_errand
+    network: cf1
+    stemcell: (( meta.stemcell ))
+    cloud_properties: (( merge || resource_pools.large_z1.cloud_properties ))
+    env: (( merge || meta.default_env ))

--- a/templates/cf-resource-pools.yml
+++ b/templates/cf-resource-pools.yml
@@ -7,12 +7,6 @@ meta:
 
   stemcell: (( merge ))
 
-networks: (( merge ))
-
-jobs: (( merge ))
-
-properties: (( merge ))
-
 resource_pools:
   - name: small_z1
     network: cf1


### PR DESCRIPTION
This allows to define custom resource_pools through additional spiff template files.
For example:

```yaml
meta:
  resource_pools:
    server_groups:
      etcd: (( merge ))
  stemcell: (( merge ))                                    

resource_pools:
  - <<: (( merge ))

  - name: etcd_z1
    cloud_properties:
      <<: (( merge ))
      instance_type: m1.medium
      scheduler_hints:
        group: (( meta.resource_pools.server_groups.etcd ))
    network: cf1
    stemcell: (( meta.stemcell ))
    env: (( merge || meta.default_env ))                   

jobs:
  - <<: (( merge ))

  - name: etcd_z1
    <<: (( merge ))
    resource_pool: etcd_z1
```
This way we can configure the openstack server-group (which is used for vm-anti-affinity) for each job separately.

Signed-off-by: Fabio Berchtold <fabio.berchtold@swisscom.com>