### PR TITLE
Checks if bundler version is correct in pre_packaging scripts.

### DIFF
--- a/packages/cloud_controller_ng/pre_packaging
+++ b/packages/cloud_controller_ng/pre_packaging
@@ -1,5 +1,10 @@
 set -e -x
 
+if [[ "`bundle --version`" != *"1.9"* ]]; then
+  echo "You should use bundler with version 1.9.x"
+  exit 2
+fi
+
 cd ${BUILD_DIR}/cloud_controller_ng
 BUNDLE_WITHOUT=development:test bundle package --all --no-install --path ./vendor/cache
 rm -rf ./vendor/cache/ruby

--- a/packages/collector/pre_packaging
+++ b/packages/collector/pre_packaging
@@ -1,5 +1,10 @@
 set -e -x
 
+if [[ "`bundle --version`" != *"1.9"* ]]; then
+  echo "You should use bundler with version 1.9.x"
+  exit 2
+fi
+
 cd ${BUILD_DIR}/collector
 BUNDLE_WITHOUT=development:test bundle package --all --no-install --path ./vendor/cache
 rm -rf ./vendor/cache/ruby

--- a/packages/dea_next/pre_packaging
+++ b/packages/dea_next/pre_packaging
@@ -1,5 +1,10 @@
 set -e -x
 
+if [[ "`bundle --version`" != *"1.9"* ]]; then
+  echo "You should use bundler with version 1.9.x"
+  exit 2
+fi
+
 cd ${BUILD_DIR}/dea_next
 BUNDLE_WITHOUT=development:test bundle package --all --no-install --path ./vendor/cache
 rm -rf ./vendor/cache/ruby

--- a/packages/nats/pre_packaging
+++ b/packages/nats/pre_packaging
@@ -1,5 +1,10 @@
 set -e -x
 
+if [[ "`bundle --version`" != *"1.9"* ]]; then
+  echo "You should use bundler with version 1.9.x"
+  exit 2
+fi
+
 cd ${BUILD_DIR}/nats
 BUNDLE_WITHOUT=development:test bundle package --all --no-install --path ./vendor/cache
 rm -rf ./vendor/cache/ruby


### PR DESCRIPTION
Hey, all.

I've noticed that `.gem` files that was packaged by bundler with the latest version not always can be found by the earlier version of bundler. To avoid such problems in I added checks in `pre_packaging` script of my release and it helped several people.

For the same purpose I created this PR https://github.com/cloudfoundry-incubator/bosh-openstack-cpi-release/pull/6.