### PR TITLE
Fix 3.19 kernel issue with SYN's being silently dropped when tcp_tw_r…

### DIFF
--- a/jobs/dea_next/templates/dea_ctl.erb
+++ b/jobs/dea_next/templates/dea_ctl.erb
@@ -46,7 +46,7 @@ case $1 in
     # incorrectly states the default as enabled. It can be changed to 1 (enabled) in many cases. Known to cause some
     # issues with hoststated (load balancing and fail over) if enabled, should be used with caution.
 
-    echo 1 > /proc/sys/net/ipv4/tcp_tw_recycle
+    echo 0 > /proc/sys/net/ipv4/tcp_tw_recycle
 
     # TCP_TW_REUSE
     # This allows reusing sockets in TIME_WAIT state for new connections when it is safe from protocol viewpoint.

--- a/jobs/gorouter/templates/gorouter_ctl.erb
+++ b/jobs/gorouter/templates/gorouter_ctl.erb
@@ -44,7 +44,7 @@ case $1 in
         # incorrectly states the default as enabled. It can be changed to 1 (enabled) in many cases. Known to cause some
         # issues with hoststated (load balancing and fail over) if enabled, should be used with caution.
 
-        echo 1 > /proc/sys/net/ipv4/tcp_tw_recycle
+        echo 0 > /proc/sys/net/ipv4/tcp_tw_recycle
 
         # TCP_TW_REUSE
         # This allows reusing sockets in TIME_WAIT state for new connections when it is safe from protocol viewpoint.


### PR DESCRIPTION
http://serverfault.com/questions/342741/what-are-the-ramifications-of-setting-tcp-tw-recycle-reuse-to-1

When you enable tcp_tw_recycle, the kernel becomes much more aggressive, and will make assumptions on the timestamps used by remote hosts. It will track the last timestamp used by each remote host having a connection in TIME_WAIT state), and allow to re-use a socket if the timestamp has correctly increased. However, if the timestamp used by the host changes (i.e. warps back in time), the SYN packet will be silently dropped, and the connection won't establish (you will see an error similar to "connect timeout"). If you want to dive into kernel code, the definition of tcp_timewait_state_process might be a good starting point.