### PR TITLE
CATs are now a bit more Diego compatible

### DIFF
--- a/jobs/acceptance-tests/spec
+++ b/jobs/acceptance-tests/spec
@@ -67,6 +67,9 @@ properties:
     description: Flag for using HTTP when making api and application requests rather than the default HTTPS
   acceptance_tests.skip_regex:
     description: Regex for tests that should be skipped
+  acceptance_tests.skip_diego_unsupported_tests:
+    default: false
+    description: Skip tests that are known to not be supported by Diego. Set to true if your deployment defaults to Diego as its runtime.
   acceptance_tests.default_timeout:
     description: Default Timeout
   acceptance_tests.cf_push_timeout:

--- a/jobs/acceptance-tests/templates/run.erb
+++ b/jobs/acceptance-tests/templates/run.erb
@@ -47,6 +47,7 @@ skipPackages+=<%= properties.acceptance_tests.include_routing ? "" : "routing," 
 
 <% skips = [] %>
 <% skips.push("SSO") unless properties.acceptance_tests.include_sso %>
+<% skips.push("NO_DIEGO_SUPPORT") if properties.acceptance_tests.skip_diego_unsupported_tests %>
 <% if_p("acceptance_tests.skip_regex") { skips.push properties.acceptance_tests.skip_regex } %>
 skips=<%= skips.empty? ? "" : %Q[-skip="#{skips.join("|")}"] %>
 


### PR DESCRIPTION
see also https://github.com/cloudfoundry/cf-acceptance-tests/pull/63

Mainly this bumps the submodule and adds a property to the errand to skip known-Diego-unsupported tests when running in Diego-default mode.