### PR TITLE
Support for customizing login prompt.

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -304,6 +304,12 @@ properties:
     description:
   login.notifications.url:
     description: "The url for the notifications service (configure to use Notifications Service instead of SMTP server)"
+  login.prompt.username.text:
+    description: "The text used to prompt for a username during login"
+    default: Email
+  login.prompt.password.text:
+    description: "The text used to prompt for a password during login"
+    default: Password
   login.smtp:
     description: "SMTP server configuration, for password reset emails etc."
   login.smtp.host:

--- a/jobs/uaa/templates/login.yml.erb
+++ b/jobs/uaa/templates/login.yml.erb
@@ -90,6 +90,11 @@ login:
   <% if !properties.login.invitations_enabled.nil? %>
   invitationsEnabled: <%= properties.login.invitations_enabled %>
   <% end %>
+  prompt:
+    username:
+      text: <%= properties.login.prompt.username.text %>
+    password:
+      text: <%= properties.login.prompt.password.text %>
 <% if properties.login.saml %>
   <% if !properties.login.saml.serviceProviderCertificate.nil? %>
   serviceProviderCertificate: |


### PR DESCRIPTION
cf-release PR for https://github.com/cloudfoundry/uaa/pull/169

Allows for customizing the username and password login prompt shown in the Web and CLI.  Defaults remain Email and Password.