### PR TITLE
Improve manifest generation scripts

### DIFF
--- a/bosh-lite/cf-stub-spiff.yml
+++ b/bosh-lite/cf-stub-spiff.yml
@@ -1,6 +1,5 @@
 ---
 name: cf-warden
-director_uuid: PLACEHOLDER-DIRECTOR-UUID
 releases:
   - name: cf
     version: latest

--- a/bosh-lite/make_manifest
+++ b/bosh-lite/make_manifest
@@ -5,37 +5,35 @@ export BOSH_USE_BUNDLER=true
 BOSH_RELEASES_DIR=${BOSH_RELEASES_DIR:-~/workspace}
 CF_RELEASE_DIR=${CF_RELEASE_DIR:-$BOSH_RELEASES_DIR/cf-release}
 
-if [[ ! -d $CF_RELEASE_DIR ]]; then
-  echo "Cannot find cf-release at $CF_RELEASE_DIR; override with \$CF_RELEASE_DIR variable"
+if [[ ! -d "${CF_RELEASE_DIR}" ]]; then
+  echo "Cannot find cf-release at '${CF_RELEASE_DIR}'; override with \$CF_RELEASE_DIR variable"
   exit 1
 fi
 
 BOSH_STATUS=$(bosh status)
 EXPECTED_DIRECTOR_NAME="Bosh Lite Director"
-DIRECTOR_UUID=$(echo "$BOSH_STATUS" | grep UUID | awk '{print $2}')
 
 if [[ "$(echo "$BOSH_STATUS" | grep Name)" != *"$EXPECTED_DIRECTOR_NAME"* ]]; then
   echo "Can only target $EXPECTED_DIRECTOR_NAME. Please use 'bosh target' before running this script."
   exit 1
 fi
 
-cd $CF_RELEASE_DIR
-mkdir -p bosh-lite/tmp
-mkdir -p bosh-lite/manifests
-cp bosh-lite/cf-stub-spiff.yml bosh-lite/tmp/cf-stub-with-uuid.yml
+mkdir -p "${CF_RELEASE_DIR}/bosh-lite/manifests"
 
+DIRECTOR_UUID=$(echo "$BOSH_STATUS" | grep UUID | awk '{print $2}')
 echo $DIRECTOR_UUID
-perl -pi -e "s/PLACEHOLDER-DIRECTOR-UUID/$DIRECTOR_UUID/g" bosh-lite/tmp/cf-stub-with-uuid.yml
 
-if [[ -f $BOSH_RELEASES_DIR/diego-release/stubs-for-cf-release/enable_diego_ssh_in_cc.yml  ]]; then
-  diego_stub="$BOSH_RELEASES_DIR/diego-release/stubs-for-cf-release/enable_diego_ssh_in_cc.yml"
+if [[ -f "${BOSH_RELEASES_DIR}/diego-release/stubs-for-cf-release/enable_diego_ssh_in_cc.yml" ]]; then
+  diego_stub="${BOSH_RELEASES_DIR}/diego-release/stubs-for-cf-release/enable_diego_ssh_in_cc.yml"
 fi
 
-$CF_RELEASE_DIR/scripts/generate_deployment_manifest \
-                                              warden \
-                                              bosh-lite/tmp/cf-stub-with-uuid.yml \
-                                              templates/cf-minimal-dev.yml \
-                                              $diego_stub \
-                                              $* > bosh-lite/manifests/cf-manifest.yml
+"${CF_RELEASE_DIR}/scripts/generate_deployment_manifest" \
+  warden \
+  "${CF_RELEASE_DIR}/bosh-lite/cf-stub-spiff.yml" \
+  <(echo "director_uuid: ${DIRECTOR_UUID}") \
+  "${CF_RELEASE_DIR}/templates/cf-minimal-dev.yml" \
+  "${diego_stub}" \
+  "$@" \
+  > "${CF_RELEASE_DIR}/bosh-lite/manifests/cf-manifest.yml"
 
-bosh deployment bosh-lite/manifests/cf-manifest.yml
+bosh deployment "${CF_RELEASE_DIR}/bosh-lite/manifests/cf-manifest.yml"

--- a/generate_deployment_manifest
+++ b/generate_deployment_manifest
@@ -1,6 +1,6 @@
 #!/bin/sh
 
->&2 echo "WARNING: This file is deprecated and will be removed. Please use ./scripts/generate_deployment_manifest instead."
+>&2 echo "WARNING: The './generate_deployment_manifest' file is deprecated and will be removed. Please use './scripts/generate_deployment_manifest' instead."
 
 templates=$(dirname $0)/templates
 

--- a/scripts/generate_deployment_manifest
+++ b/scripts/generate_deployment_manifest
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-root_dir=$(cd $(dirname $0)/.. && pwd)
+root_dir=$(cd "$(dirname "$0")/.." && pwd)
 
-templates=$root_dir/templates
+templates="${root_dir}/templates"
 
 infrastructure=$1
 
@@ -17,10 +17,10 @@ if [ "$infrastructure" != "aws" ] && \
 fi
 
 spiff merge \
-  $templates/cf-deployment.yml \
-  $templates/cf-resource-pools.yml \
-  $templates/cf-jobs.yml \
-  $templates/cf-properties.yml \
-  $templates/cf-lamb.yml \
-  $templates/cf-infrastructure-${infrastructure}.yml \
+  "${templates}/cf-deployment.yml" \
+  "${templates}/cf-resource-pools.yml" \
+  "${templates}/cf-jobs.yml" \
+  "${templates}/cf-properties.yml" \
+  "${templates}/cf-lamb.yml" \
+  "${templates}/cf-infrastructure-${infrastructure}.yml" \
   "$@"


### PR DESCRIPTION
bosh-lite/make_manifest:
* remove perl dependency
* avoid making temp dir and temp stub
* avoid changing working directory
* tolerate whitespace in paths
* fix whitespace and unusual indentation
* improve variable cohesion

bosh-lite/cf-stub-spiff.yml
* add explicit spiff 'merge' directive for director_uuid

scripts/generate_deployment_manifest:
* tolerate whitespace in paths

generate_deployment_manifest:
* deprecation notice refers to deprecated file