### PR TITLE
Change UAA timestamp logging to be rfc3339 compatible

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -258,6 +258,9 @@ properties:
   uaa.logging_level:
     description: Set UAA logging level.  (e.g. TRACE, DEBUG, INFO)
     default: DEBUG
+  uaa.logging_use_rfc3339:
+    description: Sets the time format for log messages to be rfc3339 compatible. 
+    default: false
   login.protocol:
     description: "Scheme to use for HTTP communication (http/https)"
   login.ldap.profile_type:

--- a/jobs/uaa/templates/log4j.properties.erb
+++ b/jobs/uaa/templates/log4j.properties.erb
@@ -3,7 +3,7 @@ log4j.rootCategory=INFO, FILE, SYSLOG
 PID=????
 LOG_PATH=/var/vcap/sys/log/uaa
 LOG_FILE=${LOG_PATH}/uaa.log
-LOG_PATTERN=[%d{yyyy-MM-dd HH:mm:ss.SSS}] uaa%X{context} - ${PID} [%t] .... %5p --- %c{1}: %m%n
+LOG_PATTERN=[%d{<%= (properties.uaa.logging_use_rfc3339) ? "yyyy-MM-dd'T'HH:mm:ss.SSSXXX" : "yyyy-MM-dd HH:mm:ss.SSS" %>}] uaa%X{context} - ${PID} [%t] .... %5p --- %c{1}: %m%n
 
 log4j.appender.FILE=org.apache.log4j.FileAppender
 log4j.appender.FILE.File=${LOG_FILE}

--- a/jobs/uaa/templates/varz.log4j.properties.erb
+++ b/jobs/uaa/templates/varz.log4j.properties.erb
@@ -3,7 +3,7 @@ log4j.rootCategory=INFO, FILE, SYSLOG
 PID=????
 LOG_PATH=/var/vcap/sys/log/uaa
 LOG_FILE=${LOG_PATH}/varz.log
-LOG_PATTERN=[%d{yyyy-MM-dd HH:mm:ss.SSS}] uaa%X{context} - ${PID} [%t] .... %5p --- %c{1}: %m%n
+LOG_PATTERN=[%d{<%= (properties.uaa.logging_use_rfc3339) ? "yyyy-MM-dd'T'HH:mm:ss.SSSXXX" : "yyyy-MM-dd HH:mm:ss.SSS" %>}] uaa%X{context} - ${PID} [%t] .... %5p --- %c{1}: %m%n
 
 log4j.appender.FILE=org.apache.log4j.RollingFileAppender
 log4j.appender.FILE.File=${LOG_FILE}


### PR DESCRIPTION
This will add timezone information and improve timestamp detection on log servers like Splunk.