### PR TITLE
Update to nginx 1.8

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -55,10 +55,6 @@ golang/go1.3.1.linux-amd64.tar.gz:
   object_id: b4778c9a-1994-4dda-b7a2-97ae93e1b835
   sha: 3af011cc19b21c7180f2604fd85fbc4ddde97143
   size: 51930765
-nginx/nginx-1.6.2.tar.gz:
-  object_id: 041b7bdb-b770-4c6c-b797-565b7b1a423d
-  sha: 1a5458bc15acf90eea16353a1dd17285cf97ec35
-  size: 804164
 golang/go1.4.2.linux-amd64.tar.gz:
   object_id: bfaf73b1-de68-4c94-9a02-555245b2eb8d
   sha: 5020af94b52b65cc9b6f11d50a67e4bae07b0aff

--- a/packages/nginx/packaging
+++ b/packages/nginx/packaging
@@ -15,10 +15,10 @@ pushd nginx-upload-module-2.2
 popd
 
 echo "Extracting nginx..."
-tar xzvf nginx/nginx-1.6.2.tar.gz
+tar xzvf nginx/nginx-1.8.0.tar.gz
 
 echo "Building nginx..."
-pushd nginx-1.6.2
+pushd nginx-1.8.0
   ./configure \
     --prefix=${BOSH_INSTALL_TARGET} \
     --with-pcre=../pcre-8.37 \

--- a/packages/nginx/spec
+++ b/packages/nginx/spec
@@ -2,7 +2,7 @@
 name: nginx
 files:
 - nginx/headers-more-v0.25.tgz
-- nginx/nginx-1.6.2.tar.gz
+- nginx/nginx-1.8.0.tar.gz
 - nginx/pcre-8.37.tar.gz
 - nginx/nginx-upload-module-2.2.tar.gz
 - nginx/upload_module_put_support.patch


### PR DESCRIPTION
The latest stable version of nginx is v1.8 and includes some features we're looking to build on.

The nginx blob needs to be added and uploaded before merging:

$ wget http://nginx.org/download/nginx-1.8.0.tar.gz
$ bosh add blob ./nginx-1.8.0.tar.gz nginx
$ bosh upload blobs