### PR TITLE
Fix description of staging_upload_user and staging_upload_password

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -186,10 +186,10 @@ properties:
 
   cc.staging_upload_user:
     default: ""
-    description: "S3 Access key for staging droplets on AWS installs; Blobstore user for other IaaSs"
+    description: "User name used to access internal endpoints of Cloud Controller to upload files when staging"
   cc.staging_upload_password:
     default: ""
-    description: "S3 Secure Access Key for staging droplets on AWS installs; Blobstore password for other IaaSs"
+    description: "User's password used to access internal endpoints of Cloud Controller to upload files when staging"
 
   cc.quota_definitions:
     description: "Hash of default quota definitions. Overriden by custom quota definitions."

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -220,10 +220,10 @@ properties:
 
   cc.staging_upload_user:
     default: ""
-    description: "S3 Access key for staging droplets on AWS installs; Blobstore user for other IaaSs"
+    description: "User name used to access internal endpoints of Cloud Controller to upload files when staging"
   cc.staging_upload_password:
     default: ""
-    description: "S3 Secure Access Key for staging droplets on AWS installs; Blobstore password for other IaaSs"
+    description: "User's password used to access internal endpoints of Cloud Controller to upload files when staging"
 
   cc.quota_definitions:
     description: "Hash of default quota definitions. Overriden by custom quota definitions."

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -186,10 +186,10 @@ properties:
 
   cc.staging_upload_user:
     default: ""
-    description: "S3 Access key for staging droplets on AWS installs; Blobstore user for other IaaSs"
+    description: "User name used to access internal endpoints of Cloud Controller to upload files when staging"
   cc.staging_upload_password:
     default: ""
-    description: "S3 Secure Access Key for staging droplets on AWS installs; Blobstore password for other IaaSs"
+    description: "User's password used to access internal endpoints of Cloud Controller to upload files when staging"
 
   cc.quota_definitions:
     description: "Hash of default quota definitions. Overriden by custom quota definitions."


### PR DESCRIPTION
These properties should be credential for Cloud Controller's upload endpoint (not S3 or other IaaSs credential).

I took the description from the following article:
http://docs.cloudfoundry.org/deploying/cf-stub-openstack.html

> Replace the staging_upload_user: username with the account user name used to upload files to the Cloud Controller. 
> Replace the staging_upload_password: password with the password of the account used to upload files to the Cloud Controller. 