### PR TITLE
Add support for specifying an existing user in CATs.

### DIFF
--- a/jobs/acceptance-tests/spec
+++ b/jobs/acceptance-tests/spec
@@ -78,3 +78,7 @@ properties:
     description: Timeout for long curls
   acceptance_tests.broker_start_timeout:
     description: Timeout for broker starts
+  acceptance_tests.existing_user:
+    description: "The username of an existing user. If set, the acceptance-tests will push apps and perform other actions as this user, otherwise its default behaviour is to create a temporary user for such actions."
+  acceptance_tests.existing_user_password:
+    description: "The password of the existing user. Only required if the existing user property is also being set."

--- a/jobs/acceptance-tests/templates/config.json.erb
+++ b/jobs/acceptance-tests/templates/config.json.erb
@@ -27,7 +27,11 @@
     :use_diego => properties.acceptance_tests.use_diego,
     :system_domain => properties.acceptance_tests.system_domain,
     :client_secret => properties.acceptance_tests.client_secret,
-    :use_http => properties.acceptance_tests.use_http
+    :use_http => properties.acceptance_tests.use_http,
+    :existing_user => properties.acceptance_tests.existing_user,
+    :existing_user_password => properties.acceptance_tests.existing_user_password,
+    :use_existing_user => !properties.acceptance_tests.existing_user.nil?,
+    :keep_user_at_suite_end => !properties.acceptance_tests.existing_user.nil?
   }
   config[:default_timeout] = properties.acceptance_tests.default_timeout if properties.acceptance_tests.default_timeout
   config[:cf_push_timeout] = properties.acceptance_tests.default_timeout if properties.acceptance_tests.cf_push_timeout


### PR DESCRIPTION
In our deployments we use LDAP.  Exposing the existing user attribute allows us to run the CATs with an existing LDAP test account.