### PR TITLE
Add enable_routing_api property to cc spec file and cf-jobs template.

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -370,6 +370,10 @@ properties:
     description: "Port for doppler_logging_endpoint listed at /v2/info"
     default: 443
 
+  router.enable_routing_api:
+    description: "Whether to expose the routing_api endpoint listed at /v2/info"
+    default: true
+
   cc.db_encryption_key:
     default: ""
     description: "key for encrypting sensitive values in the CC database"

--- a/spec/fixtures/aws/cf-manifest.yml.erb
+++ b/spec/fixtures/aws/cf-manifest.yml.erb
@@ -991,6 +991,7 @@ properties:
       rotate: 5
       size: 3M
     enable_ssl: true
+    enable_routing_api: true
     extra_headers_to_log: null
     ssl_cert: |
       -----BEGIN CERTIFICATE-----

--- a/spec/fixtures/openstack/cf-manifest.yml.erb
+++ b/spec/fixtures/openstack/cf-manifest.yml.erb
@@ -983,6 +983,7 @@ properties:
       rotate: 5
       size: 3M
     enable_ssl: true
+    enable_routing_api: true
     extra_headers_to_log: null
     ssl_cert: |
       -----BEGIN CERTIFICATE-----

--- a/spec/fixtures/vsphere/cf-manifest.yml.erb
+++ b/spec/fixtures/vsphere/cf-manifest.yml.erb
@@ -998,6 +998,7 @@ properties:
       rotate: 5
       size: 3M
     enable_ssl: true
+    enable_routing_api: true
     extra_headers_to_log: null
     ssl_cert: |
       -----BEGIN CERTIFICATE-----

--- a/spec/fixtures/warden/cf-manifest.yml.erb
+++ b/spec/fixtures/warden/cf-manifest.yml.erb
@@ -2877,6 +2877,7 @@ properties:
       rotate: 5
       size: 3M
     enable_ssl: true
+    enable_routing_api: true
     extra_headers_to_log: null
     ssl_cert: |
       -----BEGIN CERTIFICATE-----

--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -694,6 +694,7 @@ properties:
 
   router:
     enable_ssl: (( merge || nil ))
+    enable_routing_api: (( merge || true ))
     ssl_cert: (( merge || nil ))
     ssl_key: (( merge || nil ))
     cipher_suites: (( merge || nil ))


### PR DESCRIPTION
This PR is to add router.enable_routing_api property in CC spec file to enable conditionally exposing routing api endpoint url in /v2/info.

Tracker: [#100974596]

Regards,
@atulkc and @fordaz 