### PR TITLE
Update MySQL client in cf-release

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -17,7 +17,7 @@ packages:
   - nginx
   - nginx_newrelic_plugin
   - libpq
-  - mysqlclient
+  - mysqlclient-5.5
   - ruby-2.1.7
 
 properties:

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -28,7 +28,7 @@ packages:
   - nginx
   - nginx_newrelic_plugin
   - libpq
-  - mysqlclient
+  - mysqlclient-5.5
   - ruby-2.1.7
   - buildpack_java
   - buildpack_java_offline

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -18,7 +18,7 @@ packages:
   - nginx
   - nginx_newrelic_plugin
   - libpq
-  - mysqlclient
+  - mysqlclient-5.5
   - ruby-2.1.7
 
 properties:

--- a/packages/cloud_controller_ng/packaging
+++ b/packages/cloud_controller_ng/packaging
@@ -5,9 +5,9 @@ cp -a * ${BOSH_INSTALL_TARGET}
 cd ${BOSH_INSTALL_TARGET}/cloud_controller_ng
 
 bundle_cmd=/var/vcap/packages/ruby-2.1.7/bin/bundle
-mysqlclient_dir=/var/vcap/packages/mysqlclient
+mysqlclient_dir=/var/vcap/packages/mysqlclient-5.5
 libpq_dir=/var/vcap/packages/libpq
 
-$bundle_cmd config build.mysql2 --with-mysql-dir=$mysqlclient_dir --with-mysql-include=$mysqlclient_dir/include/mysql
+$bundle_cmd config build.mysql2 --with-mysql-config=$mysqlclient_dir/bin/mysql_config
 $bundle_cmd config build.pg --with-pg-lib=$libpq_dir/lib --with-pg-include=$libpq_dir/include
 $bundle_cmd install --local --deployment --without development test

--- a/packages/cloud_controller_ng/spec
+++ b/packages/cloud_controller_ng/spec
@@ -2,8 +2,9 @@
 name: cloud_controller_ng
 dependencies:
 - libpq
-- mysqlclient
+- mysqlclient-5.5
 - ruby-2.1.7
+
 files:
 - cloud_controller_ng/{.ruby-version,Rakefile,Gemfile,Gemfile.lock}
 - cloud_controller_ng/{db,lib,bin,app}/**/*

--- a/packages/mysqlclient-5.5/packaging
+++ b/packages/mysqlclient-5.5/packaging
@@ -1,0 +1,8 @@
+set -e -x
+
+cd mysqlclient-5.5
+tar zxvf libmysqlclient-dev_5.5.44.tar.gz
+
+for x in bin include lib; do
+  cp -a ${x} ${BOSH_INSTALL_TARGET}
+done

--- a/packages/mysqlclient-5.5/spec
+++ b/packages/mysqlclient-5.5/spec
@@ -1,0 +1,4 @@
+---
+name: mysqlclient-5.5
+files:
+- mysqlclient-5.5/libmysqlclient-dev_5.5.44.tar.gz


### PR DESCRIPTION
As part of the Ruby 2.2.3 upgrade of CC, we need to update the MySQL client used by CC. The current version of the `mysql2` gem does not work with Ruby 2.2.3. Newer versions of the `mysql2` gem need an updated `mysql-client` library. 

This PR creates a new `mysqlclient-5.5` package (next to the existing `mysqlclient`). The package itself can be found in the [tracker](https://www.pivotaltracker.com/file_attachments/51072542/download?inline=true).

The [update to Ruby 2.2.3](https://www.pivotaltracker.com/story/show/101225348) depends on this PR to be merged.

We verified that both CC unit tests and CATs are still green with MySQL and PostgreSQL:

* `mysql2` 0.3.13 (current version) + mysql-client-5.5
* `mysql2` 0.3.20 (will be the version for Ruby 2.2.3) + mysql-client-5.5

Story for the mysql client update: [#103481978](https://www.pivotaltracker.com/story/show/103481978)