### PR TITLE
Change commit_with_shortlog to not use git alias

### DIFF
--- a/scripts/commit_with_shortlog
+++ b/scripts/commit_with_shortlog
@@ -1,4 +1,4 @@
 #!/bin/bash
 script_dir=$(dirname $0)
 
-$script_dir/staged_shortlog | git ci -F -
+$script_dir/staged_shortlog | git commit -F -


### PR DESCRIPTION
Allow ./scripts/commit_with_shortlog to be Concourse pipeline friendly

We updated our Routing CI pipeline to auto-bump, however the docker image we use does not have the standard aliases (i.e. from sprout wrapped machines).
Its not a major issue and can be worked around it by creating the git alias in concourse build script  but I thought others teams may encounter if they use ./commit_with_shortlog

Mark - CF Routing Team