### PR TITLE
Do not require use of static_ips or subnets in spiff templates

### DIFF
--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -12,11 +12,13 @@ meta:
 
   consul_servers: (( merge || jobs.consul_z1.networks.cf1.static_ips jobs.consul_z2.networks.cf2.static_ips ))
 
+  nfs_client_ranges:
+    - (( .networks.cf1.subnets.[0].range || nil ))
+    - (( .networks.cf2.subnets.[0].range || nil ))
+
   nfs_server:
-    address: (( jobs.nfs_z1.networks.cf1.static_ips.[0] || nil ))
-    allow_from_entries:
-      - (( .networks.cf1.subnets.[0].range || nil ))
-      - (( .networks.cf2.subnets.[0].range || nil ))
+    address: (( merge || jobs.nfs_z1.networks.cf1.static_ips.[0] || nil ))
+    allow_from_entries: (( merge || meta.nfs_client_ranges ))
     share: ~
 
   api_templates:

--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -593,7 +593,7 @@ properties:
     client_cert:
     client_key:
     cluster:
-    machines: (( jobs.etcd_z1.networks.cf1.static_ips jobs.etcd_z2.networks.cf2.static_ips ))
+    machines: (( merge || jobs.etcd_z1.networks.cf1.static_ips jobs.etcd_z2.networks.cf2.static_ips ))
     peer_require_ssl:
     require_ssl:
     server_cert:

--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -137,7 +137,7 @@ jobs:
     resource_pool: small_z1
     networks:
       - name: cf1
-        static_ips: (( merge ))
+        static_ips: (( merge || nil ))
     update:
       serial: true
       max_in_flight: 1
@@ -155,7 +155,7 @@ jobs:
     resource_pool: small_z2
     networks:
       - name: cf2
-        static_ips: (( merge ))
+        static_ips: (( merge || nil ))
     update:
       serial: true
       max_in_flight: 1
@@ -193,7 +193,7 @@ jobs:
     resource_pool: medium_z1
     networks:
       - name: cf1
-        static_ips: (( merge ))
+        static_ips: (( merge || nil ))
     properties:
       metron_agent:
         zone: z1
@@ -205,7 +205,7 @@ jobs:
     resource_pool: medium_z2
     networks:
       - name: cf2
-        static_ips: (( merge ))
+        static_ips: (( merge || nil ))
     properties:
       metron_agent:
         zone: z2
@@ -218,7 +218,7 @@ jobs:
     resource_pool: medium_z1
     networks:
       - name: cf1
-        static_ips: (( merge ))
+        static_ips: (( merge || nil ))
     properties:
       metron_agent:
         zone: z1
@@ -232,7 +232,7 @@ jobs:
     resource_pool: medium_z2
     networks:
       - name: cf2
-        static_ips: (( merge ))
+        static_ips: (( merge || nil ))
     properties:
       metron_agent:
         zone: z2
@@ -498,7 +498,7 @@ jobs:
     resource_pool: router_z1
     networks:
       - name: cf1
-        static_ips: (( merge ))
+        static_ips: (( merge || nil ))
     properties:
       consul:
         agent:
@@ -514,7 +514,7 @@ jobs:
     resource_pool: router_z2
     networks:
       - name: cf2
-        static_ips: (( merge ))
+        static_ips: (( merge || nil ))
     properties:
       consul:
         agent:

--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -181,8 +181,8 @@ jobs:
         ssl_ciphers: ~
       router:
         servers:
-          z1: (( jobs.router_z1.networks.cf1.static_ips ))
-          z2: (( jobs.router_z2.networks.cf2.static_ips ))
+          z1: (( merge || jobs.router_z1.networks.cf1.static_ips ))
+          z2: (( merge || jobs.router_z2.networks.cf2.static_ips ))
       metron_agent:
         zone: z1
     update: (( merge || empty_hash ))

--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -4,13 +4,13 @@ networks: (( merge ))
 
 lamb_meta: (( merge ))
 
-consul_servers: (( jobs.consul_z1.networks.cf1.static_ips jobs.consul_z2.networks.cf2.static_ips ))
-
 meta:
   environment: ~
 
   release:
     name: cf
+
+  consul_servers: (( merge || jobs.consul_z1.networks.cf1.static_ips jobs.consul_z2.networks.cf2.static_ips ))
 
   nfs_server:
     address: (( jobs.nfs_z1.networks.cf1.static_ips.[0] || nil ))
@@ -550,7 +550,7 @@ properties:
     agent:
       log_level: (( merge || nil ))
       servers:
-        lan: (( consul_servers ))
+        lan: (( meta.consul_servers ))
     ca_cert:
     agent_cert:
     agent_key:

--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -580,9 +580,9 @@ properties:
   nats:
     user: (( merge ))
     password: (( merge ))
-    address: (( jobs.nats_z1.networks.cf1.static_ips.[0] ))
+    address: (( merge || jobs.nats_z1.networks.cf1.static_ips.[0] ))
     port: 4222
-    machines: (( jobs.nats_z1.networks.cf1.static_ips jobs.nats_z2.networks.cf2.static_ips ))
+    machines: (( merge || jobs.nats_z1.networks.cf1.static_ips jobs.nats_z2.networks.cf2.static_ips ))
     debug: false
     trace: false
     monitor_port: 0


### PR DESCRIPTION
Currently the `templates/cf-jobs.yml` template requires that the network subnets and the `static_jps` for several jobs (nats, etcd, nfs, consul, etc.) are defined.

But using alternative CPIs, like the new [Google Compute BOSH CPI](https://github.com/frodenas/bosh-google-cpi/) static IPs and subnets these values are not currently supported. 

With this PR it is possible to create a new `templates/infrastructure_gce.yml` where no static IPs are defined  (we will summit an example soon). In the stub files we can then overwrite the required values (nats, etcd, consul and NFS) to use BOSH DNS names (or other alternative service discovery).

This PR does not change the previous behaviour if the static IPs are defined and the new optional values not.  For example, for warden:

```
git checkout master
./scripts/generate_deployment_manifest warden \
    <(echo -e "---\ndirector_uuid: UUID") \
    ./templates/cf-minimal-dev.yml > \
        /tmp/warden_orig.yml

git checkout cf_jobs_without_static_ips_dependencies_latest
./scripts/generate_deployment_manifest warden \
    <(echo -e "---\ndirector_uuid: UUID") \
    ./templates/cf-minimal-dev.yml > \
        /tmp/warden_new.yml

diff /tmp/warden_orig.yml /tmp/warden_new.yml
```
