### PR TITLE
Allow override default network for router jobs

### DIFF
--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -494,9 +494,10 @@ jobs:
     templates: (( merge || meta.router_templates ))
     instances: 1
     resource_pool: router_z1
-    networks:
+    default_networks:
       - name: cf1
-        static_ips: (( merge ))
+        static_ips: ~
+    networks: (( merge || default_networks ))
     properties:
       consul:
         agent:
@@ -510,9 +511,10 @@ jobs:
     templates: (( merge || meta.router_templates ))
     instances: 1
     resource_pool: router_z2
-    networks:
+    default_networks:
       - name: cf2
-        static_ips: (( merge ))
+        static_ips: ~
+    networks: (( merge || default_networks ))
     properties:
       consul:
         agent:

--- a/templates/cf-resource-pools.yml
+++ b/templates/cf-resource-pools.yml
@@ -57,13 +57,13 @@ resource_pools:
     env: (( merge || meta.default_env ))
 
   - name: router_z1
-    network: cf1
+    network: (( merge || "cf1" ))
     stemcell: (( meta.stemcell ))
     cloud_properties: (( merge ))
     env: (( merge || meta.default_env ))
 
   - name: router_z2
-    network: cf2
+    network: (( merge || "cf2" ))
     stemcell: (( meta.stemcell ))
     cloud_properties: (( merge ))
     env: (( merge || meta.default_env ))


### PR DESCRIPTION
This PR allows override the network default name and configuration (`cf1` or `cf2`) for the `router_z1` and `router_z2` jobs and their corresponding resource pools.

This feature is required in the case that a different network is needed to configure the routers' loadbalancer. For instance,  in the case of the [BOSH Google CPI](https://github.com/frodenas/bosh-google-cpi), the automatic loadbalancer registering requires the definition of alternate networks with a custom `cloud_properties.target_pool` entry.

The implementation is similar to the `ha_proxy_z1`, where a new yaml node `default_network` is defined in each job, and included if the networks are not defined in the stubs. 

This PR is related to #790, as it enables deploy Cloud Foundry using the official templates from this repository on Google Compute Engine.