### PR TITLE
Configure https as default in templates

### DIFF
--- a/jobs/uaa/templates/login.yml.erb
+++ b/jobs/uaa/templates/login.yml.erb
@@ -21,9 +21,8 @@ logging:
   end
 %>
 
-<% protocol = (properties.login && properties.login.protocol) ? properties.login.protocol : "http" %>
+<% protocol = (properties.login && properties.login.protocol) ? properties.login.protocol : "https" %>
 <% if !properties.login || !properties.login.uaa_base
-  # Fix this to https when SSL certs are working in dev and staging
   uaa_base = "#{protocol}://uaa.#{properties.domain}"
 else
   uaa_base = properties.login.uaa_base

--- a/jobs/uaa/templates/uaa.yml.erb
+++ b/jobs/uaa/templates/uaa.yml.erb
@@ -1,7 +1,7 @@
 ---
 <% uaa_db = properties.uaadb.databases.find { |db| db.tag == "uaa" } %>
 <% uaa_role = properties.uaadb.roles.find { |role| role.tag == "admin" } %>
-<% protocol = (properties.login && properties.login.protocol) ? properties.login.protocol : "http" %>
+<% protocol = (properties.login && properties.login.protocol) ? properties.login.protocol : "https" %>
 
 <%
   # The login secret is defined in one of two properties

--- a/spec/fixtures/aws/cf-manifest.yml.erb
+++ b/spec/fixtures/aws/cf-manifest.yml.erb
@@ -719,7 +719,7 @@ properties:
         region: us-east-1
     external_host: api
     external_port: 9022
-    external_protocol: http
+    external_protocol: https
     install_buildpacks:
     - name: staticfile_buildpack
       package: buildpack_staticfile

--- a/spec/fixtures/openstack/cf-manifest.yml.erb
+++ b/spec/fixtures/openstack/cf-manifest.yml.erb
@@ -705,7 +705,7 @@ properties:
       fog_connection: null
     external_host: api
     external_port: 9022
-    external_protocol: http
+    external_protocol: https
     install_buildpacks:
     - name: staticfile_buildpack
       package: buildpack_staticfile

--- a/spec/fixtures/vsphere/cf-manifest.yml.erb
+++ b/spec/fixtures/vsphere/cf-manifest.yml.erb
@@ -716,7 +716,7 @@ properties:
       fog_connection: null
     external_host: api
     external_port: 9022
-    external_protocol: http
+    external_protocol: https
     install_buildpacks:
     - name: staticfile_buildpack
       package: buildpack_staticfile
@@ -954,7 +954,7 @@ properties:
           disable: false
     notifications:
       url: null
-    protocol: http
+    protocol: https
     restricted_ips_regex: ~
     saml: null
     self_service_links_enabled: null
@@ -1086,7 +1086,7 @@ properties:
         authorities: oauth.login,scim.write,clients.read,notifications.write,critical_notifications.write,emails.write,scim.userids,password.write
         authorized-grant-types: authorization_code,client_credentials,refresh_token
         override: true
-        redirect-uri: http://login.0.0.0.3.xip.io
+        redirect-uri: https://login.0.0.0.3.xip.io
         scope: openid,oauth.approvals
         secret: login_client_secret
       notifications:

--- a/spec/fixtures/warden/cf-manifest.yml.erb
+++ b/spec/fixtures/warden/cf-manifest.yml.erb
@@ -2566,7 +2566,7 @@ properties:
     users_can_select_backend: true
   ha_proxy: null
   hm9000:
-    url: http://hm9000.bosh-lite.com
+    url: https://hm9000.bosh-lite.com
   ccdb:
     address: 10.244.0.30
     databases:
@@ -2815,7 +2815,7 @@ properties:
             - https://testapp.bosh-lite.com/logout/success
     notifications:
       url: null
-    protocol: http
+    protocol: https
     restricted_ips_regex: ~
     saml: null
     self_service_links_enabled: null
@@ -2993,7 +2993,7 @@ properties:
         authorities: oauth.login,scim.write,clients.read,notifications.write,critical_notifications.write,emails.write,scim.userids,password.write
         authorized-grant-types: authorization_code,client_credentials,refresh_token
         override: true
-        redirect-uri: http://login.bosh-lite.com
+        redirect-uri: https://login.bosh-lite.com
         scope: openid,oauth.approvals
         secret: login-secret
       notifications:
@@ -3103,7 +3103,7 @@ properties:
           enabled: true
         browser_monitoring:
           auto_instrument: true
-    no_ssl: true
+    no_ssl: false
     port: 8080
     require_https: ~
     restricted_ips_regex: 10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}

--- a/spec/fixtures/warden/cf-stub.yml
+++ b/spec/fixtures/warden/cf-stub.yml
@@ -11,7 +11,7 @@ properties:
     shared_secret: PLACEHOLDER-LOGGREGATOR-SECRET
 
   hm9000:
-    url: http://hm9000.bosh-lite.com
+    url: https://hm9000.bosh-lite.com
   cc:
     external_protocol: https
     security_group_definitions:

--- a/templates/cf-infrastructure-vsphere.yml
+++ b/templates/cf-infrastructure-vsphere.yml
@@ -247,5 +247,5 @@ properties:
     catalina_opts: -Xmx768m -XX:MaxPermSize=256m
 
   login:
-    protocol: http
+    protocol: https
 

--- a/templates/cf-infrastructure-warden.yml
+++ b/templates/cf-infrastructure-warden.yml
@@ -133,10 +133,10 @@ properties:
     scim:
       users:
       - admin|admin|scim.write,scim.read,openid,cloud_controller.admin,clients.read,clients.write,doppler.firehose
-    no_ssl: true
+    no_ssl: false
 
   login:
-    protocol: http
+    protocol: https
     links:
       home: (( "https://console." domain ))
     uaa_certificate: |

--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -177,7 +177,7 @@ properties:
         alert_if_above_mb: ~
         restart_if_consistently_above_mb: ~
         restart_if_above_mb: ~
-    external_protocol: "http"
+    external_protocol: "https"
 
   hm9000:
     url: (( "https://hm9000." domain ))


### PR DESCRIPTION
Prefer ssh where possible for defaults. Without this, we have defaults which advertise a mix of secure and insecure endpoints to cli which can result in credential leaks when interacting with the UAA.