### PR TITLE
Update CC to use Ruby 2.2.3

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -18,7 +18,7 @@ packages:
   - nginx_newrelic_plugin
   - libpq
   - mysqlclient-5.5
-  - ruby-2.1.7
+  - ruby-2.2.3
 
 properties:
   ssl.skip_cert_verify:

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -29,7 +29,7 @@ packages:
   - nginx_newrelic_plugin
   - libpq
   - mysqlclient-5.5
-  - ruby-2.1.7
+  - ruby-2.2.3
   - buildpack_java
   - buildpack_java_offline
   - buildpack_ruby

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -19,7 +19,7 @@ packages:
   - nginx_newrelic_plugin
   - libpq
   - mysqlclient-5.5
-  - ruby-2.1.7
+  - ruby-2.2.3
 
 properties:
   ssl.skip_cert_verify:

--- a/packages/cloud_controller_ng/packaging
+++ b/packages/cloud_controller_ng/packaging
@@ -4,7 +4,7 @@ cp -a * ${BOSH_INSTALL_TARGET}
 
 cd ${BOSH_INSTALL_TARGET}/cloud_controller_ng
 
-bundle_cmd=/var/vcap/packages/ruby-2.1.7/bin/bundle
+bundle_cmd=/var/vcap/packages/ruby-2.2.3/bin/bundle
 mysqlclient_dir=/var/vcap/packages/mysqlclient-5.5
 libpq_dir=/var/vcap/packages/libpq
 

--- a/packages/cloud_controller_ng/spec
+++ b/packages/cloud_controller_ng/spec
@@ -3,7 +3,7 @@ name: cloud_controller_ng
 dependencies:
 - libpq
 - mysqlclient-5.5
-- ruby-2.1.7
+- ruby-2.2.3
 
 files:
 - cloud_controller_ng/{.ruby-version,Rakefile,Gemfile,Gemfile.lock}

--- a/packages/ruby-2.2.3/README.md
+++ b/packages/ruby-2.2.3/README.md
@@ -1,0 +1,11 @@
+ruby-package
+============
+This repo is used for ruby packaging in BOSH deployments.
+
+The files can be downloaded from the following locations:
+
+| Filename | Download URL |
+| -------- | ------------ |
+| ruby-2.2.3.tar.gz | [ruby-lang.org](http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.gz) |
+| rubygems-2.4.8.tgz | [rubygems.org](http://production.cf.rubygems.org/rubygems/rubygems-2.4.8.tgz) |
+| bundler-1.10.6.gem | [rubygems.org](https://rubygems.org/downloads/bundler-1.10.6.gem) |

--- a/packages/ruby-2.2.3/packaging
+++ b/packages/ruby-2.2.3/packaging
@@ -1,0 +1,31 @@
+# abort script on any command that exits with a non zero value
+set -e
+
+# We grab the latest versions that are in the directory
+RUBY_VERSION=`ls -r ruby-2.2.3/ruby-* | sed 's/ruby-2.2.3\/ruby-\(.*\)\.tar\.gz/\1/' | head -1`
+RUBYGEMS_VERSION=`ls -r ruby-2.2.3/rubygems-* | sed 's/ruby-2.2.3\/rubygems-\(.*\)\.tgz/\1/' | head -1`
+BUNDLER_VERSION=`ls -r ruby-2.2.3/bundler-* | sed 's/ruby-2.2.3\/bundler-\(.*\)\.gem/\1/' | head -1`
+
+tar xzf ruby-2.2.3/ruby-${RUBY_VERSION}.tar.gz
+(
+  set -e
+  cd ruby-${RUBY_VERSION}
+  LDFLAGS="-Wl,-rpath -Wl,${BOSH_INSTALL_TARGET}" ./configure --prefix=${BOSH_INSTALL_TARGET} --disable-install-doc --with-opt-dir=${BOSH_INSTALL_TARGET}
+  make
+  make install
+)
+
+tar zxvf ruby-2.2.3/rubygems-${RUBYGEMS_VERSION}.tgz
+(
+  set -e
+  cd rubygems-${RUBYGEMS_VERSION}
+
+  ${BOSH_INSTALL_TARGET}/bin/ruby setup.rb
+
+  if [[ $? != 0 ]] ; then
+    echo "Cannot install rubygems"
+    exit 1
+  fi
+)
+
+${BOSH_INSTALL_TARGET}/bin/gem install ruby-2.2.3/bundler-${BUNDLER_VERSION}.gem --no-ri --no-rdoc

--- a/packages/ruby-2.2.3/spec
+++ b/packages/ruby-2.2.3/spec
@@ -1,0 +1,6 @@
+---
+name: ruby-2.2.3
+files:
+- ruby-2.2.3/ruby-2.2.3.tar.gz
+- ruby-2.2.3/rubygems-2.4.8.tgz
+- ruby-2.2.3/bundler-1.10.6.gem


### PR DESCRIPTION
* Create Ruby 2.2.3 package (see links to blobs below)
* Update CloudController jobs to use Ruby 2.2.3

Tracker story [#101225348](https://www.pivotaltracker.com/story/show/101225348)

Attention: This change needs to be included in cf-release together with the [CloudController PR](https://github.com/cloudfoundry/cloud_controller_ng/pull/438), which relies on ruby-2.2.3.

Blobs:

* [bundler-1.10.6.gem](https://www.pivotaltracker.com/file_attachments/51328536/download?inline=true)
* [ruby-2.2.3.tar.gz](https://www.pivotaltracker.com/file_attachments/51328750/download?inline=true)
* ~~[rubygems-2.4.6.tgz](https://www.pivotaltracker.com/file_attachments/51328546/download?inline=true)~~
* [rubygems-2.4.8.tgz](https://www.pivotaltracker.com/file_attachments/51358104/download?inline=true)
