### PR TITLE
Bump the open files for DEA and Warden

### DIFF
--- a/jobs/dea_next/templates/dea_ctl.erb
+++ b/jobs/dea_next/templates/dea_ctl.erb
@@ -30,6 +30,7 @@ case $1 in
     echo /var/vcap/sys/cores/core-%e-%s-%p-%t > /proc/sys/kernel/core_pattern
 
     ulimit -c unlimited
+    ulimit -n 4096
 
     <% if p("dea_next.kernel_network_tuning_enabled") == true %>
     # TCP_FIN_TIMEOUT

--- a/jobs/dea_next/templates/warden_ctl.erb
+++ b/jobs/dea_next/templates/warden_ctl.erb
@@ -32,6 +32,7 @@ case $1 in
 
     # Set ulimits
     ulimit -c unlimited
+    ulimit -n 4096
 
     <% if p("dea_next.kernel_network_tuning_enabled") == true %>
     # Use default local port range (higher ports are used for pooling)


### PR DESCRIPTION
Connections are closed when no longer used which means that there will be
a minimum of 5 * 256 connections on either side in the worst case.