### PR TITLE
Update default AWS instance types

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml.erb
+++ b/spec/fixtures/aws/cf-manifest.yml.erb
@@ -1145,7 +1145,7 @@ releases:
 resource_pools:
 - cloud_properties:
     availability_zone: zone_1
-    instance_type: c3.large
+    instance_type: t2.small
     ephemeral_disk:
       size: 10_240
       type: gp2
@@ -1159,7 +1159,7 @@ resource_pools:
       password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 - cloud_properties:
     availability_zone: zone_2
-    instance_type: c3.large
+    instance_type: t2.small
     ephemeral_disk:
       size: 10_240
       type: gp2
@@ -1173,7 +1173,7 @@ resource_pools:
       password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 - cloud_properties:
     availability_zone: zone_1
-    instance_type: c3.large
+    instance_type: t2.medium
     ephemeral_disk:
       size: 10_240
       type: gp2
@@ -1187,7 +1187,7 @@ resource_pools:
       password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 - cloud_properties:
     availability_zone: zone_2
-    instance_type: c3.large
+    instance_type: t2.medium
     ephemeral_disk:
       size: 10_240
       type: gp2
@@ -1201,7 +1201,7 @@ resource_pools:
       password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 - cloud_properties:
     availability_zone: zone_1
-    instance_type: m3.large
+    instance_type: t2.large
     ephemeral_disk:
       size: 65_536
       type: gp2
@@ -1215,7 +1215,7 @@ resource_pools:
       password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 - cloud_properties:
     availability_zone: zone_2
-    instance_type: m3.large
+    instance_type: t2.large
     ephemeral_disk:
       size: 65_536
       type: gp2
@@ -1229,7 +1229,7 @@ resource_pools:
       password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 - cloud_properties:
     availability_zone: zone_1
-    instance_type: m3.large
+    instance_type: r3.large
     ephemeral_disk:
       size: 102_400
       type: gp2
@@ -1243,7 +1243,7 @@ resource_pools:
       password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 - cloud_properties:
     availability_zone: zone_2
-    instance_type: m3.large
+    instance_type: r3.large
     ephemeral_disk:
       size: 102_400
       type: gp2
@@ -1259,7 +1259,7 @@ resource_pools:
     availability_zone: zone_1
     elbs:
     - cfrouter
-    instance_type: c3.large
+    instance_type: t2.medium
     ephemeral_disk:
       size: 10_240
       type: gp2
@@ -1275,7 +1275,7 @@ resource_pools:
     availability_zone: zone_2
     elbs:
     - cfrouter
-    instance_type: c3.large
+    instance_type: t2.medium
     ephemeral_disk:
       size: 10_240
       type: gp2
@@ -1289,7 +1289,7 @@ resource_pools:
       password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 - cloud_properties:
     availability_zone: zone_1
-    instance_type: c3.large
+    instance_type: t2.medium
     ephemeral_disk:
       size: 10_240
       type: gp2
@@ -1303,7 +1303,7 @@ resource_pools:
       password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
 - cloud_properties:
     availability_zone: zone_1
-    instance_type: c3.xlarge
+    instance_type: c4.xlarge
   name: xlarge_errand
   network: cf1
   stemcell:

--- a/templates/cf-infrastructure-aws.yml
+++ b/templates/cf-infrastructure-aws.yml
@@ -57,7 +57,7 @@ networks: (( merge ))
 resource_pools:
   - name: small_z1
     cloud_properties:
-      instance_type: c3.large
+      instance_type: t2.small
       ephemeral_disk:
         size: 10_240
         type: gp2
@@ -65,7 +65,7 @@ resource_pools:
 
   - name: small_z2
     cloud_properties:
-      instance_type: c3.large
+      instance_type: t2.small
       ephemeral_disk:
         size: 10_240
         type: gp2
@@ -73,7 +73,7 @@ resource_pools:
 
   - name: medium_z1
     cloud_properties:
-      instance_type: c3.large
+      instance_type: t2.medium
       ephemeral_disk:
         size: 10_240
         type: gp2
@@ -81,7 +81,7 @@ resource_pools:
 
   - name: medium_z2
     cloud_properties:
-      instance_type: c3.large
+      instance_type: t2.medium
       ephemeral_disk:
         size: 10_240
         type: gp2
@@ -89,7 +89,7 @@ resource_pools:
 
   - name: large_z1
     cloud_properties:
-      instance_type: m3.large
+      instance_type: t2.large
       ephemeral_disk:
         size: 65_536
         type: gp2
@@ -97,7 +97,7 @@ resource_pools:
 
   - name: large_z2
     cloud_properties:
-      instance_type: m3.large
+      instance_type: t2.large
       ephemeral_disk:
         size: 65_536
         type: gp2
@@ -105,7 +105,7 @@ resource_pools:
 
   - name: runner_z1
     cloud_properties:
-      instance_type: m3.large
+      instance_type: r3.large
       ephemeral_disk:
         size: 102_400
         type: gp2
@@ -113,7 +113,7 @@ resource_pools:
 
   - name: runner_z2
     cloud_properties:
-      instance_type: m3.large
+      instance_type: r3.large
       ephemeral_disk:
         size: 102_400
         type: gp2
@@ -121,7 +121,7 @@ resource_pools:
 
   - name: router_z1
     cloud_properties:
-      instance_type: c3.large
+      instance_type: t2.medium
       ephemeral_disk:
         size: 10_240
         type: gp2
@@ -130,7 +130,7 @@ resource_pools:
 
   - name: router_z2
     cloud_properties:
-      instance_type: c3.large
+      instance_type: t2.medium
       ephemeral_disk:
         size: 10_240
         type: gp2
@@ -139,7 +139,7 @@ resource_pools:
 
   - name: small_errand
     cloud_properties:
-      instance_type: c3.large
+      instance_type: t2.medium
       ephemeral_disk:
         size: 10_240
         type: gp2
@@ -147,7 +147,7 @@ resource_pools:
 
   - name: xlarge_errand
     cloud_properties:
-      instance_type: c3.xlarge
+      instance_type: c4.xlarge
       availability_zone: (( meta.zones.z1 ))
 
 # set up static IPs


### PR DESCRIPTION
Use more appropriate AWS instance types. Jobs of the CF are well suited for AWS T2 bursty instance type. Runners use r3 instance with sustained performance and more memory capacity for apps. This update also decreases running cost for default AWS deployment.

```
small:  c3.large -> t2.small
medium: c3.large -> t2.medium
large:  m3.large -> t2.large
runner: m3.large -> r3.large
router: c3.large -> t2.medium
compilation:  c3.large -> t2.medium
small errand: c3.large -> t2.medium
large errand: c3.xlarge -> c4.xlarge
```

T2 medium instance receives 1 hour 100% CPU load burst upon creation, making it also suitable for compilation and errands.