### PR TITLE
Modify DEA configuration for higher performance

### DIFF
--- a/jobs/dea_next/templates/dea_ctl.erb
+++ b/jobs/dea_next/templates/dea_ctl.erb
@@ -53,6 +53,12 @@ case $1 in
     # Default value is 0 (disabled). It is generally a safer alternative to tcp_tw_recycle
 
     echo 1 > /proc/sys/net/ipv4/tcp_tw_reuse
+
+    # NF_CONNTRACK_MAX
+    # Default value is 65536. We set it to a larger number in the purpose for higher performance.
+    # We do not need to worry about DDOS attack because there are other components(gorouter,etc) in front of DEA will handle it.
+
+    echo 262144 > /proc/sys/net/netfilter/nf_conntrack_max
     <% end %>
 
     exec /var/vcap/packages/ruby-2.1.7/bin/ruby /var/vcap/packages/dea_next/bin/dea \


### PR DESCRIPTION
- nf_conntrack_max is set to 65536 by default, we found linux kernel
  drop tcp handshake request with the message "nf_conntrack: table
  full, dropping packet" by using command "dmesg"
- in order to support higher performance, we set nf_conntrack_max
  to a larger number

Signed-off-by: Yun Lv <lvyun@huawei.com>