### PR TITLE
Cleanup UAA job spec and templates

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -314,10 +314,10 @@ properties:
     description: "Array of the router IPs acting as the first group of HTTP/TCP backends. These will be added to the proxy_ips_regex as exact matches. When using spiff, these will be router_z1 and router_z2 static IPs from cf-jobs.yml"
     default: []
   login.brand:
-    description: "The brand to use for the reset password emails, available values are oss and pivotal"
+    description: "The branding style to use with the web interface, account confirmation, and password reset emails."
     default: oss
   login.asset_base_url:
-    description: "Base url for static assets, allows custom styling of the login server.  Use '/resources/pivotal' for Pivotal style."
+    description: "Base url for static assets, allows custom styling of the login server."
   login.uaa_certificate:
     description: "Certificate to import if the UAA is using self-signed certificates"
   login.catalina_opts:
@@ -344,21 +344,10 @@ properties:
     description: "SMTP server password"
   login.links:
     description: "A hash of home/passwd/signup URLS (see commented examples below)"
-  login.links.home:
-    description: URL for primary console/dashboard for users
-    default: https://console.run.pivotal.io
   login.links.passwd:
     description: URL for requesting password reset
-    default: https://console.run.pivotal.io/password_resets/new
   login.links.signup:
     description: URL for requesting to signup/register for an account
-    default: https://console.run.pivotal.io/register
-  login.links.network:
-    description: URL for Pivotal Network
-    default: https://network.gopivotal.com/login
-  login.links.signup-network:
-    description: URL for requesting to signup/register for an account at Pivotal Network
-    default: https://network.gopivotal.com/registrations/new
   login.tiles:
     description: "A list of links to other services to show on the landing page after logging in and/or signing up, depending on whether login-link and/or signup-link is specified."
   login.port:
@@ -366,6 +355,9 @@ properties:
     description:
   login.uaa_base:
     description: "Location of the UAA."
+  login.self_service_links_enabled:
+    description: "Enable self-service account creation and password resets links."
+    default: false
   login.signups_enabled:
     description: "Enable account creation flow in the login server. Enabled by default."
   login.invitations_enabled:

--- a/spec/fixtures/aws/cf-manifest.yml.erb
+++ b/spec/fixtures/aws/cf-manifest.yml.erb
@@ -955,11 +955,8 @@ properties:
     catalina_opts: ~
     invitations_enabled: null
     links:
-      home: https://console.example.com
-      network: null
       passwd: https://console.example.com/password_resets/new
       signup: https://console.example.com/register
-      signup-network: null
     logout: null
     notifications:
       url: null

--- a/spec/fixtures/openstack/cf-manifest.yml.erb
+++ b/spec/fixtures/openstack/cf-manifest.yml.erb
@@ -946,11 +946,8 @@ properties:
     catalina_opts: null
     invitations_enabled: null
     links:
-      home: https://console.example.com
-      network: null
       passwd: https://console.example.com/password_resets/new
       signup: https://console.example.com/register
-      signup-network: null
     logout:
       redirect:
         url: "/login?template=openstack"

--- a/spec/fixtures/vsphere/cf-manifest.yml.erb
+++ b/spec/fixtures/vsphere/cf-manifest.yml.erb
@@ -961,11 +961,8 @@ properties:
     catalina_opts: null
     invitations_enabled: null
     links:
-      home: https://console.0.0.0.3.xip.io
-      network: null
       passwd: https://console.0.0.0.3.xip.io/password_resets/new
       signup: https://console.0.0.0.3.xip.io/register
-      signup-network: null
     logout:
       redirect:
         parameter:

--- a/spec/fixtures/warden/cf-manifest.yml.erb
+++ b/spec/fixtures/warden/cf-manifest.yml.erb
@@ -2816,11 +2816,8 @@ properties:
     catalina_opts: null
     invitations_enabled: null
     links:
-      home: https://console.bosh-lite.com
-      network: null
       passwd: https://console.bosh-lite.com/password_resets/new
       signup: https://console.bosh-lite.com/register
-      signup-network: null
     logout:
       redirect:
         url: "/login?template=warden"

--- a/templates/cf-infrastructure-warden.yml
+++ b/templates/cf-infrastructure-warden.yml
@@ -116,9 +116,6 @@ properties:
       users:
       - admin|admin|scim.write,scim.read,openid,cloud_controller.admin,clients.read,clients.write,doppler.firehose,routing.router_groups.read
 
-  login:
-    links:
-      home: (( "https://console." domain ))
   router:
     status:
       user: router

--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -211,11 +211,8 @@ properties:
       password: ~
 
     links:
-      home: (( "https://console." domain ))
       passwd: (( "https://console." domain "/password_resets/new" ))
       signup: (( "https://console." domain "/register" ))
-      network: ~
-      signup-network: ~
 
     logout: ~
 


### PR DESCRIPTION
This removes default references to run.pivotal.io in the UAA specs and enables consumers to disable the signup and password reset links from the default login page on the UAA.

The `links.home`, `links.network`, and `links.signup-network` do not appear to be used in the UAA so they were removed entirely. If they are used, the Pivotal Network related links should likely be extracted and separated from the open source release.