### PR TITLE
possibility to add custom SCIM groups to UAA automatically

### DIFF
--- a/jobs/uaa/spec
+++ b/jobs/uaa/spec
@@ -107,6 +107,8 @@ properties:
     description:
   uaa.scim.external_groups:
     description: "A list of external group mappings. Pipe delimited. A value may look as '- internal.read|cn=developers,ou=scopes,dc=test,dc=com'"
+  uaa.scim.groups:
+    description: Comma separated list of groups that should be added to the UAA db, but not assigned to a user by default.
   domain:
     description: "The domain name for this CloudFoundry deploy"
   env.http_proxy:

--- a/jobs/uaa/templates/uaa.yml.erb
+++ b/jobs/uaa/templates/uaa.yml.erb
@@ -167,8 +167,8 @@ scim:
     - <%= group %><% end %>
 <% end %>
 
-<% if properties.uaa.scim && properties.uaa.scim.groups then %>
-  groups: <%= properties.uaa.scim.groups %>
+<% if_p('uaa.scim.groups') do |groups| %>
+  groups: <%= groups %>
 <% end %>
 
 <% if properties.uaa && properties.uaa.zones && properties.uaa.zones.internal &&  properties.uaa.zones.internal.hostnames then %>

--- a/jobs/uaa/templates/uaa.yml.erb
+++ b/jobs/uaa/templates/uaa.yml.erb
@@ -167,6 +167,10 @@ scim:
     - <%= group %><% end %>
 <% end %>
 
+<% if properties.uaa.scim && properties.uaa.scim.groups then %>
+  groups: <%= properties.uaa.scim.groups %>
+<% end %>
+
 <% if properties.uaa && properties.uaa.zones && properties.uaa.zones.internal &&  properties.uaa.zones.internal.hostnames then %>
 zones:
   internal:

--- a/spec/fixtures/aws/cf-manifest.yml.erb
+++ b/spec/fixtures/aws/cf-manifest.yml.erb
@@ -1131,6 +1131,7 @@ properties:
       userids_enabled: true
       users:
       - admin|fakepassword|scim.write,scim.read,openid,cloud_controller.admin,doppler.firehose
+      groups: additionalgroup1,additionalgroup2
     spring_profiles: null
     url: https://uaa.example.com
     user: null

--- a/spec/fixtures/aws/cf-stub.yml
+++ b/spec/fixtures/aws/cf-stub.yml
@@ -142,6 +142,7 @@ properties:
     scim:
       users:
       - admin|fakepassword|scim.write,scim.read,openid,cloud_controller.admin,doppler.firehose
+      groups: additionalgroup1,additionalgroup2
   loggregator_endpoint:
     shared_secret: secret
   uaadb:

--- a/spec/fixtures/openstack/cf-manifest.yml.erb
+++ b/spec/fixtures/openstack/cf-manifest.yml.erb
@@ -1129,6 +1129,7 @@ properties:
       userids_enabled: true
       users:
       - admin|fakepassword|scim.write,scim.read,openid,cloud_controller.admin,doppler.firehose
+      groups: additionalgroup1,additionalgroup2
     spring_profiles: null
     url: https://uaa.example.com
     user: null

--- a/spec/fixtures/openstack/cf-stub.yml
+++ b/spec/fixtures/openstack/cf-stub.yml
@@ -144,6 +144,7 @@ properties:
     scim:
       users:
       - admin|fakepassword|scim.write,scim.read,openid,cloud_controller.admin,doppler.firehose
+      groups: additionalgroup1,additionalgroup2
   uaadb:
     roles:
     - name: uaaadmin

--- a/spec/fixtures/vsphere/cf-manifest.yml.erb
+++ b/spec/fixtures/vsphere/cf-manifest.yml.erb
@@ -1138,6 +1138,7 @@ properties:
       userids_enabled: true
       users:
       - admin|fakepassword|scim.write,scim.read,openid,cloud_controller.admin,doppler.firehose
+      groups: additionalgroup1,additionalgroup2
     spring_profiles: null
     url: https://uaa.0.0.0.3.xip.io
     user: null

--- a/spec/fixtures/vsphere/cf-stub.yml
+++ b/spec/fixtures/vsphere/cf-stub.yml
@@ -129,6 +129,7 @@ properties:
     scim:
       users:
       - admin|fakepassword|scim.write,scim.read,openid,cloud_controller.admin,doppler.firehose
+      groups: additionalgroup1,additionalgroup2
 
 # code_snippet cf-stub-vsphere end
 # The previous line helps maintain current documentation at http://docs.cloudfoundry.org.

--- a/spec/fixtures/warden/cf-manifest.yml.erb
+++ b/spec/fixtures/warden/cf-manifest.yml.erb
@@ -3105,6 +3105,7 @@ properties:
       userids_enabled: true
       users:
       - admin|admin|scim.write,scim.read,openid,cloud_controller.admin,clients.read,clients.write,doppler.firehose,routing.router_groups.read
+      groups: additionalgroup1,additionalgroup2
     spring_profiles: null
     url: https://uaa.bosh-lite.com
     user: null

--- a/spec/fixtures/warden/cf-stub.yml
+++ b/spec/fixtures/warden/cf-stub.yml
@@ -68,6 +68,8 @@ properties:
         refresh-token-validity: 1209600
         scope: openid,cloud_controller.read,cloud_controller.write,password.write,console.admin,console.support
         secret: console-secret
+    scim:
+      groups: additionalgroup1,additionalgroup2
     newrelic:
       production:
         license_key: '<yourlicensekeyhere>'

--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -235,6 +235,7 @@ properties:
       userids_enabled: (( merge || true ))
       users: (( merge ))
       external_groups: ~
+      groups: ~
 
     jwt:
       signing_key: (( merge ))


### PR DESCRIPTION
We'd like to add certain SCIM groups to the UAA automatically (without the manual task of creating it with `uaac`). 

The cf-release UAA job allows specifying `authorities` - groups that are automatically created in the UAA db, but also always assigned to every user by default. We'd like to specify a set of SCIM groups in the config, that are automatically added to the UAA db, but not assigned to every user by default.

I saw the UAA config already allows specifying such groups in its [config](https://github.com/cloudfoundry/uaa/blob/bbea63986bbf2de9c42f231668e344a4a321184c/uaa/src/main/webapp/WEB-INF/spring/scim-endpoints.xml#L275), but it's not yet possible in the cf-release templates.

This PR adds the possibility to specify these groups as job properties.