### PR TITLE
Allow additional configuration of etcd

### DIFF
--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -641,6 +641,7 @@ properties:
     prof_port: 0
 
   etcd:
+    <<: (( merge ))
     machines: (( merge || jobs.etcd_z1.networks.cf1.static_ips jobs.etcd_z2.networks.cf2.static_ips ))
     require_ssl: false
     peer_require_ssl: false


### PR DESCRIPTION
We want to use the `election_timeout_in_milliseconds` parameter for etcd, but the templates don't support this yet. This change should allow use of any config parameters.