### PR TITLE
Clean up info properties in CC-related job specs

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -25,21 +25,6 @@ properties:
     description: "specifies that the job is allowed to skip ssl cert verification"
     default: false
 
-  name:
-    default: "vcap"
-    description:
-  build:
-    default: "2222"
-    description:
-  version:
-    default: "2"
-    description:
-  support_address:
-    default: "http://support.cloudfoundry.com"
-    description:
-  description:
-    default: "Cloud Foundry sponsored by Pivotal"
-    description:
   domain:
     description: "domain where cloud_controller will listen (api.domain) often the same as the system domain"
   system_domain:
@@ -62,6 +47,26 @@ properties:
   request_timeout_in_seconds:
     description: "Timeout for requests in seconds."
     default: 900
+
+
+  name:
+    description: "'name' attribute in the /info and /v2/info endpoints"
+    default: ""
+  build:
+    description: "'build' attribute in the /info and /v2/info endpoints"
+    default: ""
+  version:
+    description: "'version' attribute in the /info and /v2/info endpoints"
+    default: ""
+  support_address:
+    description: "'support' attribute in the /info and /v2/info endpoints"
+    default: ""
+  description:
+    description: "'description' attribute in the /info and /v2/info endpoints"
+    default: ""
+
+  cc.info.custom:
+    description: "Custom attribute keys and values for /v2/info endpoint"
 
   cc.external_port:
     description: "External Cloud Controller port"
@@ -103,16 +108,6 @@ properties:
   cc.pending_packages.expiration_in_seconds:
     description: "How long packages can remain in pending state before being cleaned up"
     default: 1200
-  cc.info.name:
-    description: "name attribute in the /info endpoint"
-  cc.info.build:
-    description: "build attribute in the /info endpoint"
-  cc.info.version:
-    description: "version attribute in the /info endpoint"
-  cc.info.description:
-    description: "free form description for attribute in the /info endpoint"
-  cc.info.custom:
-    description: "Custom values for /v2/info endpoint"
 
   cc.external_protocol:
     default: "https"

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -45,21 +45,6 @@ properties:
     description: "specifies that the job is allowed to skip ssl cert verification"
     default: false
 
-  name:
-    default: "vcap"
-    description:
-  build:
-    default: "2222"
-    description:
-  version:
-    default: "2"
-    description:
-  support_address:
-    default:
-    description:
-  description:
-    default: "Cloud Foundry sponsored by Pivotal"
-    description:
   domain:
     description: "domain where cloud_controller will listen (api.domain) often the same as the system domain"
   system_domain:
@@ -98,6 +83,26 @@ properties:
     description: "Timeout for requests in seconds."
     default: 900
 
+
+  name:
+    description: "'name' attribute in the /info and /v2/info endpoints"
+    default: ""
+  build:
+    description: "'build' attribute in the /info and /v2/info endpoints"
+    default: ""
+  version:
+    description: "'version' attribute in the /info and /v2/info endpoints"
+    default: ""
+  support_address:
+    description: "'support' attribute in the /info and /v2/info endpoints"
+    default: ""
+  description:
+    description: "'description' attribute in the /info and /v2/info endpoints"
+    default: ""
+
+  cc.info.custom:
+    description: "Custom attribute keys and values for /v2/info endpoint"
+
   cc.external_port:
     description: "External Cloud Controller port"
     default: 9022
@@ -132,16 +137,6 @@ properties:
   cc.failed_jobs.cutoff_age_in_days:
     description: "How old a failed job should stay in cloud controller database before being cleaned up"
     default: 31
-  cc.info.name:
-    description: "name attribute in the /info endpoint"
-  cc.info.build:
-    description: "build attribute in the /info endpoint"
-  cc.info.version:
-    description: "version attribute in the /info endpoint"
-  cc.info.description:
-    description: "free form description for attribute in the /info endpoint"
-  cc.info.custom:
-    description: "Custom values for /v2/info endpoint"
 
   cc.directories.tmpdir:
     default: "/var/vcap/data/cloud_controller_ng/tmp"
@@ -287,7 +282,7 @@ properties:
     description: "Directory (bucket) used store droplets.  It does not have be pre-created."
     default: "cc-droplets"
   cc.droplets.max_staged_droplets_stored:
-    description: "Number of recent, staged droplets stored per app (not including current droplet)" 
+    description: "Number of recent, staged droplets stored per app (not including current droplet)"
     default: 5
   cc.droplets.fog_connection:
     description: "Fog connection hash"

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -26,21 +26,6 @@ properties:
     description: "specifies that the job is allowed to skip ssl cert verification"
     default: false
 
-  name:
-    default: "vcap"
-    description:
-  build:
-    default: "2222"
-    description:
-  version:
-    default: "2"
-    description:
-  support_address:
-    default: "http://support.cloudfoundry.com"
-    description:
-  description:
-    default: "Cloud Foundry sponsored by Pivotal"
-    description:
   domain:
     description: "domain where cloud_controller will listen (api.domain) often the same as the system domain"
   system_domain:
@@ -68,6 +53,25 @@ properties:
   request_timeout_in_seconds:
     description: "Timeout for requests in seconds."
     default: 900
+
+  name:
+    description: "'name' attribute in the /info and /v2/info endpoints"
+    default: ""
+  build:
+    description: "'build' attribute in the /info and /v2/info endpoints"
+    default: ""
+  version:
+    description: "'version' attribute in the /info and /v2/info endpoints"
+    default: ""
+  support_address:
+    description: "'support' attribute in the /info and /v2/info endpoints"
+    default: ""
+  description:
+    description: "'description' attribute in the /info and /v2/info endpoints"
+    default: ""
+
+  cc.info.custom:
+    description: "Custom attribute keys and values for /v2/info endpoint"
 
   cc.external_port:
     description: "External Cloud Controller port"
@@ -103,16 +107,6 @@ properties:
   cc.failed_jobs.cutoff_age_in_days:
     description: "How old a failed job should stay in cloud controller database before being cleaned up"
     default: 31
-  cc.info.name:
-    description: "name attribute in the /info endpoint"
-  cc.info.build:
-    description: "build attribute in the /info endpoint"
-  cc.info.version:
-    description: "version attribute in the /info endpoint"
-  cc.info.description:
-    description: "free form description for attribute in the /info endpoint"
-  cc.info.custom:
-    description: "Custom values for /v2/info endpoint"
 
   cc.external_protocol:
     default: "https"


### PR DESCRIPTION
- Remove unused cc.info properties (except for cc.info.custom)
- Improve descriptions of info properties
- Remove odd defaults in some info properties (build 2222?)
- Remove Pivotal-specific default for description property