### PR TITLE
Expose hm9000.sender_message_limit to bosh

### DIFF
--- a/jobs/hm9000/spec
+++ b/jobs/hm9000/spec
@@ -57,3 +57,6 @@ properties:
   hm9000.fetcher_network_timeout_in_seconds:
     description: "Each API call to the CC must succeed within this timeout."
     default: 30
+  hm9000.sender_message_limit:
+    description: "The maximum number of messages the sender should send per invocation."
+    default: 60

--- a/jobs/hm9000/templates/hm9000.json.erb
+++ b/jobs/hm9000/templates/hm9000.json.erb
@@ -26,6 +26,7 @@
     "skip_cert_verify": <%= p("ssl.skip_cert_verify") %>,
     "desired_state_batch_size": <%= p("hm9000.desired_state_batch_size") %>,
     "fetcher_network_timeout_in_seconds": <%= p("hm9000.fetcher_network_timeout_in_seconds") %>,
+    "sender_message_limit": <%= p("hm9000.sender_message_limit") %>,
 
     "store_schema_version": 4,
     "store_urls": [<%= p("etcd.machines").map{|addr| "\"http://#{addr}:4001\""}.join(",")%>],


### PR DESCRIPTION
Large deployments can handle more than 60 concurrent messages.