### PR TITLE
Update generate_deployment_manifest

### DIFF
--- a/scripts/generate_deployment_manifest
+++ b/scripts/generate_deployment_manifest
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-set -euf -o pipefail
+set -ef -o pipefail
 
-CF_DEPLOYMENT_TRACE=${CF_DEPLOYMENT_TRACE:-}
-if [ ! -z "${CF_DEPLOYMENT_TRACE}" ]; then
+if [ -n "${CF_DEPLOYMENT_TRACE}" ]; then
   set -x
 fi
+
+set -u
 
 root_dir=$(cd "$(dirname "$0")/.." && pwd)
 


### PR DESCRIPTION
set -u after CF_DEPLOYMENT_TRACE check, as GoCD agents are failing on
line 5 with "unbound variable".

Also, `! -z` -> `-n`. http://tldp.org/LDP/abs/html/comparison-ops.html