### PR TITLE
fix test timeout config bug

### DIFF
--- a/jobs/acceptance-tests/templates/config.json.erb
+++ b/jobs/acceptance-tests/templates/config.json.erb
@@ -34,9 +34,9 @@
     :keep_user_at_suite_end => !properties.acceptance_tests.existing_user.nil?
   }
   config[:default_timeout] = properties.acceptance_tests.default_timeout if properties.acceptance_tests.default_timeout
-  config[:cf_push_timeout] = properties.acceptance_tests.default_timeout if properties.acceptance_tests.cf_push_timeout
-  config[:long_curl_timeout] = properties.acceptance_tests.default_timeout if properties.acceptance_tests.long_curl_timeout
-  config[:broker_start_timeout] = properties.acceptance_tests.default_timeout if properties.acceptance_tests.broker_start_timeout
+  config[:cf_push_timeout] = properties.acceptance_tests.cf_push_timeout if properties.acceptance_tests.cf_push_timeout
+  config[:long_curl_timeout] = properties.acceptance_tests.long_curl_timeout if properties.acceptance_tests.long_curl_timeout
+  config[:broker_start_timeout] = properties.acceptance_tests.broker_start_timeout if properties.acceptance_tests.broker_start_timeout
 
   config[:staticfile_buildpack_name] = properties.acceptance_tests.staticfile_buildpack_name if properties.acceptance_tests.staticfile_buildpack_name
   config[:java_buildpack_name] = properties.acceptance_tests.java_buildpack_name if properties.acceptance_tests.java_buildpack_name


### PR DESCRIPTION
Currently, the documented `cf_push_timeout`, `long_curl_timeout`, and `broker_start_timeout` options for the acceptance tests are ignored, and the default timeout is used instead. Looks like a copy-paste error.