### PR TITLE
Changed default port from 17001 to 18001

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -36,7 +36,7 @@ properties:
     default: -1
   router.debug_addr:
     description: "Address at which to serve debug info"
-    default: "0.0.0.0:17001"
+    default: "0.0.0.0:18001"
   router.secure_cookies:
     description: "Set secure flag on http cookies"
     default: false


### PR DESCRIPTION
17001 interferes with hardcoded value in `hm9000_analyzer`:
https://github.com/axelaris/cf-release/blob/master/jobs/hm9000/templates/hm9000_analyzer_ctl#L25