### PR TITLE
Add route registrars

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml.erb
+++ b/spec/fixtures/aws/cf-manifest.yml.erb
@@ -123,6 +123,8 @@ jobs:
   properties:
     metron_agent:
       zone: z1
+    route_registrar:
+      routes: null
   resource_pool: medium_z1
   templates:
   - name: etcd
@@ -175,6 +177,8 @@ jobs:
   properties:
     metron_agent:
       zone: z1
+    route_registrar:
+      routes: null
   persistent_disk: 102400
   resource_pool: medium_z1
   templates:
@@ -596,6 +600,8 @@ jobs:
           gorouter: {}
     metron_agent:
       zone: z1
+    route_registrar:
+      routes: null
   resource_pool: router_z1
   templates:
   - name: gorouter

--- a/spec/fixtures/openstack/cf-manifest.yml.erb
+++ b/spec/fixtures/openstack/cf-manifest.yml.erb
@@ -124,6 +124,8 @@ jobs:
   properties:
     metron_agent:
       zone: z1
+    route_registrar:
+      routes: null
   resource_pool: medium_z1
   templates:
   - name: etcd
@@ -176,6 +178,8 @@ jobs:
   properties:
     metron_agent:
       zone: z1
+    route_registrar:
+      routes: null
   persistent_disk: 102400
   resource_pool: medium_z1
   templates:
@@ -596,6 +600,8 @@ jobs:
           gorouter: {}
     metron_agent:
       zone: z1
+    route_registrar:
+      routes: null
   resource_pool: router_z1
   templates:
   - name: gorouter

--- a/spec/fixtures/vsphere/cf-manifest.yml.erb
+++ b/spec/fixtures/vsphere/cf-manifest.yml.erb
@@ -126,6 +126,8 @@ jobs:
   properties:
     metron_agent:
       zone: z1
+    route_registrar:
+      routes: null
   resource_pool: medium_z1
   templates:
   - name: etcd
@@ -179,6 +181,8 @@ jobs:
   properties:
     metron_agent:
       zone: z1
+    route_registrar:
+      routes: null
   persistent_disk: 102400
   resource_pool: medium_z1
   templates:
@@ -602,6 +606,8 @@ jobs:
           gorouter: {}
     metron_agent:
       zone: z1
+    route_registrar:
+      routes: null
   resource_pool: router_z1
   templates:
   - name: gorouter

--- a/spec/fixtures/warden/cf-manifest.yml.erb
+++ b/spec/fixtures/warden/cf-manifest.yml.erb
@@ -165,6 +165,8 @@ jobs:
   properties:
     metron_agent:
       zone: z1
+    route_registrar:
+      routes: null
   resource_pool: medium_z1
   templates:
   - name: etcd
@@ -216,6 +218,8 @@ jobs:
   properties:
     metron_agent:
       zone: z1
+    route_registrar:
+      routes: null
   persistent_disk: 102400
   resource_pool: medium_z1
   templates:
@@ -641,6 +645,8 @@ jobs:
           gorouter: {}
     metron_agent:
       zone: z1
+    route_registrar:
+      routes: null
   resource_pool: router_z1
   templates:
   - name: gorouter

--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -75,6 +75,8 @@ meta:
   - name: metron_agent
     release: (( meta.release.name ))
 
+  etcd_routes: null
+
   etcd_templates:
   - name: etcd
     release: (( meta.release.name ))
@@ -115,6 +117,8 @@ meta:
   - name: metron_agent
     release: (( meta.release.name ))
 
+  nfs_routes: null
+
   nfs_templates:
   - name: debian_nfs_server
     release: (( meta.release.name ))
@@ -126,6 +130,8 @@ meta:
     release: (( meta.release.name ))
   - name: metron_agent
     release: (( meta.release.name ))
+
+  router_routes: null
 
   router_templates:
   - name: gorouter
@@ -254,6 +260,8 @@ jobs:
     properties:
       metron_agent:
         zone: z1
+      route_registrar:
+        routes: (( merge || meta.etcd_routes ))
     update:
       max_in_flight: 1
 
@@ -293,6 +301,8 @@ jobs:
     properties:
       metron_agent:
         zone: z1
+      route_registrar:
+        routes: (( merge || meta.nfs_routes ))
     update: (( merge || empty_hash ))
 
   - name: postgres_z1
@@ -557,6 +567,8 @@ jobs:
             gorouter: {}
       metron_agent:
         zone: z1
+      route_registrar:
+        routes: (( merge || meta.router_routes ))
     update: (( merge || empty_hash ))
 
   - name: router_z2


### PR DESCRIPTION
This PR is like https://github.com/cloudfoundry/cf-release/pull/833 and https://github.com/cloudfoundry/cf-release/pull/834 and mainly related to moving CF components between their jobs.
Here I'm adding route_registrar's properties to jobs `etcd_z1`, `nfs_z1` and `route_z1` to make it possible to move `route_registrar` template there.

Unit tests also have been fixed.
I'm hope you will like this PR. 
Thanks.