### PR TITLE
bosh configuration for dea bandwidth limits

### DIFF
--- a/jobs/dea_next/spec
+++ b/jobs/dea_next/spec
@@ -89,6 +89,14 @@ properties:
   dea_next.instance_disk_inode_limit:
     description: Limit on inodes for an instance container
     default: 200000
+  dea_next.staging_bandwidth_limit.rate:
+    description: "Network bandwidth limit for staging tasks in bytes per second"
+  dea_next.staging_bandwidth_limit.burst:
+    description: "Network bandwidth burst limit for staging tasks in bytes"
+  dea_next.instance_bandwidth_limit.rate:
+    description: "Network bandwidth limit for running instances in bytes per second"
+  dea_next.instance_bandwidth_limit.burst:
+    description: "Network bandwidth burst limit for running instances in bytes"
   dea_next.directory_server_protocol:
     description: 'The protocol to use when communicating with the directory server ("http" or "https")'
     default: 'https'

--- a/jobs/dea_next/templates/dea.yml.erb
+++ b/jobs/dea_next/templates/dea.yml.erb
@@ -59,12 +59,22 @@ staging:
   disk_limit_mb: <%= p("dea_next.staging_disk_limit_mb") %>
   cpu_limit_shares: <%= p("dea_next.staging_cpu_limit_shares") %>
   disk_inode_limit: <%= p("dea_next.staging_disk_inode_limit") %>
+<% if_p("dea_next.staging_bandwidth_limit.rate", "dea_next.staging_bandwidth_limit.burst") do |rate, burst| %>
+  bandwidth_limit:
+    rate: <%= rate %>
+    burst: <%= burst %>
+<% end %>
 
 instance:
   memory_to_cpu_share_ratio: <%= p("dea_next.instance_memory_to_cpu_share_ratio") %>
   min_cpu_share_limit: <%= p("dea_next.instance_min_cpu_share_limit") %>
   max_cpu_share_limit: <%= p("dea_next.instance_max_cpu_share_limit") %>
   disk_inode_limit: <%= p("dea_next.instance_disk_inode_limit") %>
+<% if_p("dea_next.instance_bandwidth_limit.rate", "dea_next.instance_bandwidth_limit.burst") do |rate, burst| %>
+  bandwidth_limit:
+    rate: <%= rate %>
+    burst: <%= burst %>
+<% end %>
 
 stacks: <%= p("dea_next.stacks", []).to_yaml.gsub("---", "") %>
 


### PR DESCRIPTION
Allow configuration of bandwidth limits in the DEA. This is associated with cloudfoundry/dea_ng/pull/177 and cloudfoundry/warden/pull/105.

```
  dea_next:
    ...
    instance_disk_inode_limit: 200000
    instance_bandwidth_limit:
      rate: 2000000
      burst: 8000000
    ...
    staging_memory_limit_mb: 1024
    staging_bandwidth_limit:
      rate: 2000000
      burst: 8000000
    ...
```