### PR TITLE
Squashed commit to add 3 variables (port, status/port and debug_addr)

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml.erb
+++ b/spec/fixtures/aws/cf-manifest.yml.erb
@@ -1025,13 +1025,16 @@ properties:
     ssl_key: null
     ssl_skip_validation: null
     requested_route_registration_interval_in_seconds: null
+    port: null
     status:
       password: ROUTER_PASSWORD
       user: ROUTER_USER
+      port: null
     secure_cookies: null
     route_service_timeout: null
     route_services_secret: null
     route_services_secret_decrypt_only: null
+    debug_addr: null
   smoke_tests: null
   ssl:
     skip_cert_verify: false

--- a/spec/fixtures/openstack/cf-manifest.yml.erb
+++ b/spec/fixtures/openstack/cf-manifest.yml.erb
@@ -1047,13 +1047,16 @@ properties:
     cipher_suites: TLS_RSA_WITH_RC4_128_SHA:TLS_RSA_WITH_AES_128_CBC_SHA
     ssl_skip_validation: null
     requested_route_registration_interval_in_seconds: null
+    port: null
     status:
       password: router_password
       user: router_user
+      port: null
     secure_cookies: null
     route_service_timeout: null
     route_services_secret: null
     route_services_secret_decrypt_only: null
+    debug_addr: null
   smoke_tests: null
   ssl:
     skip_cert_verify: false

--- a/spec/fixtures/vsphere/cf-manifest.yml.erb
+++ b/spec/fixtures/vsphere/cf-manifest.yml.erb
@@ -1064,13 +1064,16 @@ properties:
     cipher_suites: TLS_RSA_WITH_RC4_128_SHA:TLS_RSA_WITH_AES_128_CBC_SHA
     ssl_skip_validation: null
     requested_route_registration_interval_in_seconds: null
+    port: null
     status:
       password: router_password
       user: router_user
+      port: null
     secure_cookies: null
     route_service_timeout: null
     route_services_secret: null
     route_services_secret_decrypt_only: null
+    debug_addr: null
   smoke_tests: null
   ssl:
     skip_cert_verify: false

--- a/spec/fixtures/warden/cf-manifest.yml.erb
+++ b/spec/fixtures/warden/cf-manifest.yml.erb
@@ -2921,13 +2921,16 @@ properties:
     cipher_suites: TLS_RSA_WITH_RC4_128_SHA:TLS_RSA_WITH_AES_128_CBC_SHA
     ssl_skip_validation: true
     requested_route_registration_interval_in_seconds: null
+    port: null
     status:
       password: router
       user: router
+      port: null
     secure_cookies: null
     route_service_timeout: null
     route_services_secret: emc1Bu39coo4mcz+iaecPAL2wCeo4VB1+6s099ZYu/M=
     route_services_secret_decrypt_only: null
+    debug_addr: null
   smoke_tests:
     api: api.bosh-lite.com
     apps_domain: bosh-lite.com

--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -708,15 +708,18 @@ properties:
     cipher_suites: (( merge || nil ))
     requested_route_registration_interval_in_seconds: (( merge || nil ))
     ssl_skip_validation: (( merge || nil ))
+    port: (( merge || nil ))
     status:
       user: (( merge ))
       password: (( merge ))
+      port: (( merge || nil ))
     secure_cookies: (( merge || nil ))
     route_services_secret: (( merge || nil ))
     route_services_secret_decrypt_only: (( merge || nil ))
     route_service_timeout: (( merge || nil ))
     logrotate: (( merge || nil ))
     extra_headers_to_log: (( merge || nil ))
+    debug_addr: (( merge || nil ))
 
   syslog_daemon_config: ~
 


### PR DESCRIPTION
to router properties with fixing appropriate fixtures.
This PR is replacement for https://github.com/cloudfoundry/cf-release/pull/833 and https://github.com/cloudfoundry/cf-release/pull/834 with following enhancements:
- It was forked from Development branch
- All commits are squashed together
