### PR TITLE
Add cloud_controller_ng_console script to ease debugging of cloud controller

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -11,6 +11,7 @@ templates:
   mime.types: config/mime.types
   cloud_controller_api.yml.erb: config/cloud_controller_ng.yml
   cloud_controller_api_ctl.erb: bin/cloud_controller_ng_ctl
+  cloud_controller_api_console.erb: bin/cloud_controller_ng_console
   cloud_controller_api_worker_ctl.erb: bin/cloud_controller_worker_ctl
   cloud_controller_api_migration_ctl.erb: bin/cloud_controller_migration_ctl
   handle_local_blobstore.sh.erb: bin/handle_local_blobstore.sh

--- a/jobs/cloud_controller_ng/templates/cloud_controller_api_console.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_api_console.erb
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# You can use this script to run irb console of cloud controller for debug purposes
+
+export CC_JOB_DIR=/var/vcap/jobs/cloud_controller_ng
+source $CC_JOB_DIR/bin/ruby_version.sh
+
+CC_PACKAGE_DIR=/var/vcap/packages/cloud_controller_ng
+
+RUN_DIR=/var/vcap/sys/run/cloud_controller_ng
+LOG_DIR=/var/vcap/sys/log/cloud_controller_ng
+PIDFILE=$RUN_DIR/cloud_controller_ng.pid
+
+export CONFIG_DIR=$CC_JOB_DIR/config
+export CLOUD_CONTROLLER_NG_CONFIG=$CONFIG_DIR/cloud_controller_ng.yml
+export BUNDLE_GEMFILE=$CC_PACKAGE_DIR/cloud_controller_ng/Gemfile
+export HOME=/home/vcap # rake needs it to be set to run tasks
+export TMPDIR=/var/vcap/data/cloud_controller_ng/tmp
+
+<% if properties.env %>
+<% if properties.env.http_proxy %>
+export HTTP_PROXY='<%= properties.env.http_proxy %>'
+export http_proxy='<%= properties.env.http_proxy %>'
+<% end %>
+<% if properties.env.https_proxy %>
+export HTTPS_PROXY='<%= properties.env.https_proxy %>'
+export https_proxy='<%= properties.env.https_proxy %>'
+<% end %>
+<% if properties.env.no_proxy %>
+export NO_PROXY='<%= properties.env.no_proxy %>'
+export no_proxy='<%= properties.env.no_proxy %>'
+<% end %>
+<% end %>
+
+export C_INCLUDE_PATH=/var/vcap/packages/libpq/include:$C_INCLUDE_PATH
+export LIBRARY_PATH=/var/vcap/packages/libpq/lib:$LIBRARY_PATH
+export LANG=en_US.UTF-8
+
+$CC_PACKAGE_DIR/cloud_controller_ng/bin/console $CLOUD_CONTROLLER_NG_CONFIG


### PR DESCRIPTION
Hey, all.

Sometimes to debug problems related to CC I need to put a special script to run CC IRB console for debugging purposes.

I think someone might find it useful.