### PR TITLE
Error when BOSH_RELEASES_DIR doesn't exist

### DIFF
--- a/scripts/generate-bosh-lite-dev-manifest
+++ b/scripts/generate-bosh-lite-dev-manifest
@@ -3,6 +3,11 @@
 export BOSH_USE_BUNDLER=true
 
 BOSH_RELEASES_DIR=${BOSH_RELEASES_DIR:-~/workspace}
+if [[ ! -d "${BOSH_RELEASES_DIR}" ]]; then
+  echo "Connot find bosh-releases-dir at '{$BOSH_RELEASES_DIR}'; override with \$BOSH_RELEASES_DIR variable"
+  exit 1
+fi
+
 SCRIPT_DIR=$(dirname $0)
 CF_RELEASE_DIR=${CF_RELEASE_DIR:-$SCRIPT_DIR/..}
 


### PR DESCRIPTION
Previously filed bug asking BOSH_RELEASES_DIR environment variable to be
required instead of silently using ~/workspace. Requiring the
environment variable might be a bit heavy handed from a UX standpoint,
how about we error if the BOSH_RELEASES_DIR doesn't exist? This
preserves same behavior when user clones to ~/workspace, but exits 1 if
the directory doesn't exist, e.g. in a concourse pipeline.