### PR TITLE
Fix CLA URLs in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@ If you want to make changes to the `cf-release` itself, read on.
 Follow these steps to make a contribution to any of our open source repositories:
 
 1. Ensure that you have completed our CLA Agreement for
-  [individuals](http://www.cloudfoundry.org/individualcontribution.pdf) or
-  [corporations](http://www.cloudfoundry.org/corpcontribution.pdf).
+  [individuals](https://www.cloudfoundry.org/pdfs/CFF_Corporate_CLA.pdf) or
+  [corporations](https://www.cloudfoundry.org/pdfs/CFF_Individual_CLA.pdf).
 
 1. Set your name and email (these should match the information on your submitted CLA)
   ```


### PR DESCRIPTION
It appears that the PDF documents have moved.

I'm not sure if there's a `[ci skip]` type of commit message annotation for Concourse, if there is and it should be used I can update this commit.