### PR TITLE
Add license files to final packages.

### DIFF
--- a/packages/cloud_controller_ng/spec
+++ b/packages/cloud_controller_ng/spec
@@ -15,3 +15,5 @@ files:
 - cloud_controller_ng/config/boot.rb
 - cloud_controller_ng/config/environment.rb
 - cloud_controller_ng/config/routes.rb
+- cloud_controller_ng/LICENSE
+- cloud_controller_ng/NOTICE

--- a/packages/dea_next/spec
+++ b/packages/dea_next/spec
@@ -6,6 +6,8 @@ dependencies:
 files:
 - dea_next/Gemfile
 - dea_next/Gemfile.lock
+- dea_next/LICENSE
+- dea_next/NOTICE
 - dea_next/{bin,lib,vendor}/**/*
 - dea_next/go/{bin,src,vendor}/**/*
 - dea_next/buildpacks/{bin,lib}/**/*

--- a/packages/gnatsd/spec
+++ b/packages/gnatsd/spec
@@ -3,3 +3,4 @@ dependencies:
   - golang1.4
 files:
   - gnatsd/**/*.go
+  - gnatsd/LICENSE

--- a/packages/gorouter/spec
+++ b/packages/gorouter/spec
@@ -5,3 +5,5 @@ dependencies:
 files:
 - github.com/cloudfoundry/gorouter/**/*.{go,golden,proto,c,h,}
 - github.com/cloudfoundry/gorouter/**/Makefile
+- github.com/cloudfoundry/gorouter/LICENSE
+- github.com/cloudfoundry/gorouter/NOTICE

--- a/packages/warden/pre_packaging
+++ b/packages/warden/pre_packaging
@@ -9,6 +9,7 @@ mv warden tmp_warden
 mv tmp_warden/warden .
 mv tmp_warden/warden-client .
 mv tmp_warden/warden-protocol .
+mv tmp_warden/LICENSE tmp_warden/NOTICE .
 rmdir tmp_warden
 
 cd warden

--- a/packages/warden/spec
+++ b/packages/warden/spec
@@ -3,6 +3,8 @@ name: warden
 dependencies:
 - ruby-2.1.7
 files:
+- warden/LICENSE
+- warden/NOTICE
 - warden/warden/{bin,config,lib,root,src}/**/*
 - warden/warden/Gemfile
 - warden/warden/Gemfile.lock


### PR DESCRIPTION
The idea here is to deliver a bosh.io tarball with the licenses inside each
package.tgz file distributed. The tarball ships with source code not simple
binaries and therefore should probably be shipped with licenses alongside.

- CF Slack participants told me to go ahead and open these PRs.
- This work is semi-dependent on other bits in other submodules but I was
  instructed not to commit submodule pointers and instead do separate
  PRs and such the submodules/repos: uaa, loggregator, etcd-release,
  statsd-injector should also be merged/updated.

https://github.com/cloudfoundry-incubator/etcd-release/pull/8
https://github.com/cloudfoundry/statsd-injector/pull/1
https://github.com/cloudfoundry/uaa/pull/256
https://github.com/cloudfoundry/loggregator/pull/100
