### PR TITLE
Graceful drain

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -40,6 +40,13 @@ properties:
   router.secure_cookies:
     description: "Set secure flag on http cookies"
     default: false
+  router.drain_wait:
+    description: |
+      Delay in seconds after drain begins before server stops listening.
+      During this time the server will respond with 503 Service Unavailable to
+      requests having header User-Agent: HTTP-Monitor/1.1. This accommodates
+      requests in transit sent while health check responded ok.
+    default: 0
   router.enable_ssl:
     description: "Enable ssl termination on the router"
     default: false

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -55,6 +55,7 @@ routing_api:
   auth_disabled: <%= p("routing-api.auth_disabled") %>
 <% end %>
 
+drain_wait: <%= p("router.drain_wait") %>
 endpoint_timeout: <%= p("request_timeout_in_seconds") %>
 
 start_response_delay_interval_in_seconds: <%= p("router.requested_route_registration_interval_in_seconds") %>


### PR DESCRIPTION
Enabling bits for cloudfoundry/gorouter#109

Expose drain_wait with a default value of 0 seconds (i.e. maintain the current behavior: do not wait before stopping the listener)