### PR TITLE
Check for spiff installation

### DIFF
--- a/scripts/generate_deployment_manifest
+++ b/scripts/generate_deployment_manifest
@@ -8,6 +8,12 @@ fi
 
 set -u
 
+# Check for spiff installation
+which spiff > /dev/null 2>&1 || {
+  echo "Aborted. Please install spiff by following https://github.com/cloudfoundry-incubator/spiff#installation" 1>&2
+  exit 1
+}
+
 root_dir=$(cd "$(dirname "$0")/.." && pwd)
 
 templates="${root_dir}/templates"


### PR DESCRIPTION
Spiff command is used in the generate_deployment_manifest
script, but its installation was not checked.
Now the script checks if spiff is installed and if it's not
installed, it exits with a friendly message guiding to
the installation doc.