### PR TITLE
Updated shebang lines

### DIFF
--- a/git_hooks/pre-commit
+++ b/git_hooks/pre-commit
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/usr/bin/env bash
 ./scripts/test

--- a/jobs/debian_nfs_server/templates/rpc_mountd_ctl
+++ b/jobs/debian_nfs_server/templates/rpc_mountd_ctl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RUN_DIR=/var/vcap/sys/run
 PIDFILE=$RUN_DIR/rpc_mountd.pid

--- a/jobs/debian_nfs_server/templates/rpc_nfsd_ctl
+++ b/jobs/debian_nfs_server/templates/rpc_nfsd_ctl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source /var/vcap/packages/common/utils.sh
 

--- a/jobs/gorouter/templates/drain
+++ b/jobs/gorouter/templates/drain
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # vim: set ft=sh
 
 set -e -x

--- a/jobs/haproxy/templates/consul_template_ctl
+++ b/jobs/haproxy/templates/consul_template_ctl
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 PATH=/var/vcap/packages/haproxy/bin:$PATH
 RUN_DIR=/var/vcap/sys/run/consul_template

--- a/jobs/haproxy/templates/haproxy_ctl
+++ b/jobs/haproxy/templates/haproxy_ctl
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 PATH=/var/vcap/packages/haproxy/bin:$PATH
 LOG_DIR=/var/vcap/sys/log/haproxy

--- a/jobs/hm9000/templates/hm9000_analyzer_ctl
+++ b/jobs/hm9000/templates/hm9000_analyzer_ctl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RUN_DIR=/var/vcap/sys/run/hm9000
 LOG_DIR=/var/vcap/sys/log/hm9000

--- a/jobs/hm9000/templates/hm9000_api_server_ctl
+++ b/jobs/hm9000/templates/hm9000_api_server_ctl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RUN_DIR=/var/vcap/sys/run/hm9000
 LOG_DIR=/var/vcap/sys/log/hm9000

--- a/jobs/hm9000/templates/hm9000_evacuator_ctl
+++ b/jobs/hm9000/templates/hm9000_evacuator_ctl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RUN_DIR=/var/vcap/sys/run/hm9000
 LOG_DIR=/var/vcap/sys/log/hm9000

--- a/jobs/hm9000/templates/hm9000_fetcher_ctl
+++ b/jobs/hm9000/templates/hm9000_fetcher_ctl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RUN_DIR=/var/vcap/sys/run/hm9000
 LOG_DIR=/var/vcap/sys/log/hm9000

--- a/jobs/hm9000/templates/hm9000_listener_ctl
+++ b/jobs/hm9000/templates/hm9000_listener_ctl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RUN_DIR=/var/vcap/sys/run/hm9000
 LOG_DIR=/var/vcap/sys/log/hm9000

--- a/jobs/hm9000/templates/hm9000_metrics_server_ctl
+++ b/jobs/hm9000/templates/hm9000_metrics_server_ctl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RUN_DIR=/var/vcap/sys/run/hm9000
 LOG_DIR=/var/vcap/sys/log/hm9000

--- a/jobs/hm9000/templates/hm9000_sender_ctl
+++ b/jobs/hm9000/templates/hm9000_sender_ctl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RUN_DIR=/var/vcap/sys/run/hm9000
 LOG_DIR=/var/vcap/sys/log/hm9000

--- a/jobs/hm9000/templates/hm9000_shredder_ctl
+++ b/jobs/hm9000/templates/hm9000_shredder_ctl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RUN_DIR=/var/vcap/sys/run/hm9000
 LOG_DIR=/var/vcap/sys/log/hm9000

--- a/scripts/commit_with_shortlog
+++ b/scripts/commit_with_shortlog
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 script_dir=$(dirname $0)
 
 $script_dir/staged_shortlog | git ci -F -

--- a/scripts/generate-bosh-lite-dev-manifest
+++ b/scripts/generate-bosh-lite-dev-manifest
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export BOSH_USE_BUNDLER=true
 
 SCRIPT_DIR=$(dirname $0)
-CF_RELEASE_DIR=${CF_RELEASE_DIR:-$SCRIPT_DIR/..}
+CF_RELEASE_DIR="${CF_RELEASE_DIR:-$SCRIPT_DIR/..}"
 
-if [[ ! -d "${CF_RELEASE_DIR}" ]]; then
+if [ ! -d "${CF_RELEASE_DIR}" ]; then
   echo "Cannot find cf-release at '${CF_RELEASE_DIR}'; override with \$CF_RELEASE_DIR variable"
   exit 1
 fi

--- a/scripts/generate-consul-certs
+++ b/scripts/generate-consul-certs
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e -x
 

--- a/scripts/generate-etcd-certs
+++ b/scripts/generate-etcd-certs
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e -x
 

--- a/scripts/generate_deployment_manifest
+++ b/scripts/generate_deployment_manifest
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ef -o pipefail
 

--- a/scripts/pull-blobs-from-uaa-release
+++ b/scripts/pull-blobs-from-uaa-release
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash -eu
 
 CF_RELEASE_DIR="${CF_RELEASE_DIR:-"$(cd $(dirname $0)/.. && pwd)"}"
 UAA_RELEASE_DIR="${UAA_RELEASE_DIR:-"$(cd "${CF_RELEASE_DIR}"/../uaa-release && pwd)"}"

--- a/scripts/setup-git-hooks
+++ b/scripts/setup-git-hooks
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 pushd $(dirname $0) > /dev/null
   SCRIPT_DIR=$(pwd)

--- a/scripts/test
+++ b/scripts/test
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 pushd $(dirname $0) > /dev/null
   SCRIPT_DIR=$(pwd)

--- a/scripts/update
+++ b/scripts/update
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 submodule_warning='Uncommitted submodules changes will be clobbered'


### PR DESCRIPTION
`generate-bosh-lite-dev-manifest` wouldn't run for me, changing the shebang line worked. So I wrote this little snippet to change all the shebangs to `#!/usr/bin/env bash`:
```
find -type f ! -name "*.*" -exec sed -i '1{/^#!\/[^ ]*\/\(ba\|\)sh\( *\)/s||#!/usr/bin/env bash\2|}' {} \;
```

Recommend doing similar throughout your repositories.