### PR TITLE
Allow customization of uaa.client property

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -1208,6 +1208,7 @@ properties:
     catalina_opts: -Xmx768m -XX:MaxPermSize=256m
     cc:
       client_secret: CC_CLIENT_SECRET
+    client: null
     clients:
       cc_routing:
         authorities: routing.router_groups.read

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -1190,6 +1190,7 @@ properties:
     catalina_opts: -Xmx768m -XX:MaxPermSize=256m
     cc:
       client_secret: CC_CLIENT_SECRET
+    client: null
     clients:
       cc_routing:
         authorities: routing.router_groups.read

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -1214,6 +1214,7 @@ properties:
     catalina_opts: -Xmx768m -XX:MaxPermSize=256m
     cc:
       client_secret: CC_CLIENT_SECRET
+    client: null
     clients:
       cc_routing:
         authorities: routing.router_groups.read

--- a/spec/fixtures/warden/cf-manifest.yml
+++ b/spec/fixtures/warden/cf-manifest.yml
@@ -3100,6 +3100,7 @@ properties:
     catalina_opts: -Xmx192m -XX:MaxPermSize=128m
     cc:
       client_secret: cc-secret
+    client: null
     clients:
       app-direct:
         access-token-validity: 1209600

--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -302,6 +302,7 @@ properties:
     spring_profiles: ~
 
     user: ~
+    client: ~
     clients:
       <<: (( merge || nil ))
       login:


### PR DESCRIPTION
uaa's spec also has a `client` property that we need to customize in what we merge in:
https://github.com/cloudfoundry/uaa-release/blob/develop/jobs/uaa/spec#L229