### PR TITLE
HCF-516: Make the name of the CCNG hostname configurable

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -67,6 +67,9 @@ properties:
   cc.external_port:
     description: "External Cloud Controller port"
     default: 9022
+  cc.internal_service_hostname:
+    description: "Internal hostname used to resolve the address of the Cloud Controller"
+    default: "cloud-controller-ng.service.cf.internal"
 
   cc.jobs.global.timeout_in_seconds:
     description: "The longest any job can take before it is cancelled unless overriden per job"

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -105,6 +105,9 @@ properties:
   cc.external_port:
     description: "External Cloud Controller port"
     default: 9022
+  cc.internal_service_hostname:
+    description: "Internal hostname used to resolve the address of the Cloud Controller"
+    default: "cloud-controller-ng.service.cf.internal"
 
   cc.jobs.global.timeout_in_seconds:
     description: "The longest any job can take before it is cancelled unless overriden per job"

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -73,6 +73,9 @@ properties:
   cc.external_port:
     description: "External Cloud Controller port"
     default: 9022
+  cc.internal_service_hostname:
+    description: "Internal hostname used to resolve the address of the Cloud Controller"
+    default: "cloud-controller-ng.service.cf.internal"
 
   cc.jobs.global.timeout_in_seconds:
     description: "The longest any job can take before it is cancelled unless overriden per job"


### PR DESCRIPTION
This allows HCF to not depend on consul to do DNS resolution. Also it's the
only hardwired hostname in cf. Works with ccng PR https://github.com/cloudfoundry/cloud_controller_ng/pull/544