### PR TITLE
Set deployment name to cf

### DIFF
--- a/templates/cf-infrastructure-warden.yml
+++ b/templates/cf-infrastructure-warden.yml
@@ -1,5 +1,5 @@
 meta:
-  environment: cf-warden
+  environment: cf
 
   stemcell: (( merge || .meta.default_stemcell ))
 


### PR DESCRIPTION
The deployment name for cloud foundry should be cf by default and not include the infrastructure name.
Other cf-infrastructure-* stubs also do not include the name of their infrastructure into the deployment name.
