### PR TITLE
Allow specifying a reserved set of private domains

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -490,3 +490,6 @@ properties:
     description: "The file descriptors made available to each app instance"
     default: 16384
 
+  cc.reserved_private_domains:
+    description: "File location of a list of reserved private domains (for file format, see https://publicsuffix.org/)"
+    default: ~

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -609,3 +609,7 @@ properties:
   router.route_services_secret:
     description: "Support for route services is disabled when no value is configured."
     default: ""
+
+  cc.reserved_private_domains:
+    description: "File location of a list of reserved private domains (for file format, see https://publicsuffix.org/)"
+    default: ~

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -506,3 +506,7 @@ properties:
   cc.broker_client_max_async_poll_duration_minutes:
     default: 10080
     description: "The max duration the CC will fetch service instance state from a service broker. Default is 1 week"
+
+  cc.reserved_private_domains:
+    description: "File location of a list of reserved private domains (for file format, see https://publicsuffix.org/)"
+    default: ~

--- a/templates/cf-properties.yml
+++ b/templates/cf-properties.yml
@@ -241,6 +241,8 @@ properties:
       username: ((  properties.blobstore.admin_users.[0].username || nil ))
       password: ((  properties.blobstore.admin_users.[0].password || nil ))
 
+    reserved_private_domains: ~
+
   hm9000:
     url: (( "https://hm9000." domain ))
     port: 5155


### PR DESCRIPTION
This goes with
https://github.com/cloudfoundry/cloud_controller_ng/pull/554

The corresponding CC changes will need to be included.