### PR TITLE
ectd-release advertise url suffix

### DIFF
--- a/example_manifests/minimal-aws.yml
+++ b/example_manifests/minimal-aws.yml
@@ -497,6 +497,7 @@ properties:
     machines: [10.0.16.104]
     peer_require_ssl: false
     require_ssl: false
+    advertise_urls_dns_suffix: etcd.service.cf.internal
   hm9000:
     url: https://hm9000.REPLACE_WITH_SYSTEM_DOMAIN
     port: 5155

--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -1221,6 +1221,7 @@ properties:
     - 10.10.80.19
     peer_require_ssl: false
     require_ssl: false
+    advertise_urls_dns_suffix: etcd.service.cf.internal
   etcd_metrics_server:
     nats:
       machines:

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -1232,6 +1232,7 @@ properties:
     - 10.10.0.133
     peer_require_ssl: false
     require_ssl: false
+    advertise_urls_dns_suffix: etcd.service.cf.internal
   etcd_metrics_server:
     nats:
       machines:

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -1235,6 +1235,7 @@ properties:
     - 10.85.10.243
     peer_require_ssl: false
     require_ssl: false
+    advertise_urls_dns_suffix: etcd.service.cf.internal
   etcd_metrics_server:
     nats:
       machines:

--- a/spec/fixtures/warden/cf-manifest.yml
+++ b/spec/fixtures/warden/cf-manifest.yml
@@ -3100,6 +3100,7 @@ properties:
     - 10.244.0.42
     peer_require_ssl: false
     require_ssl: false
+    advertise_urls_dns_suffix: etcd.service.cf.internal
   etcd_metrics_server:
     nats:
       machines:

--- a/templates/cf-jobs.yml
+++ b/templates/cf-jobs.yml
@@ -794,6 +794,7 @@ properties:
     machines: (( merge || jobs.etcd_z1.networks.cf1.static_ips jobs.etcd_z2.networks.cf2.static_ips ))
     require_ssl: false
     peer_require_ssl: false
+    advertise_urls_dns_suffix: (( merge || "etcd.service.cf.internal" ))
 
   etcd_metrics_server:
     nats:


### PR DESCRIPTION
See cloudfoundry-incubator/etcd-release#9 for details. This really only applies after `etcd-release` has been bumped, but there should be no issues doing things out of order.

I'm assuming it's still desired to eventually remove the default value from `etcd-release`.  Will adjust `diego-release` after this lands.