### PR TITLE
Skip writing `somaxconn` when running in containers

### DIFF
--- a/jobs/gorouter/templates/gorouter_ctl.erb
+++ b/jobs/gorouter/templates/gorouter_ctl.erb
@@ -27,7 +27,7 @@ case $1 in
         # This setting determines the time that must elapse before TCP/IP can release a closed connection and reuse
         # its resources. During this TIME_WAIT state, reopening the connection to the client costs less than establishing
         # a new connection. By reducing the value of this entry, TCP/IP can release closed connections faster, making more
-        # resources available for new connections. Addjust this in the presense of many connections sitting in the
+        # resources available for new connections. Adjust this in the presence of many connections sitting in the
         # TIME_WAIT state:
 
         echo 5 > /proc/sys/net/ipv4/tcp_fin_timeout

--- a/jobs/gorouter/templates/gorouter_ctl.erb
+++ b/jobs/gorouter/templates/gorouter_ctl.erb
@@ -44,10 +44,11 @@ case $1 in
         # Default value is 0 (disabled). It is generally a safer alternative to tcp_tw_recycle
 
         echo 1 > /proc/sys/net/ipv4/tcp_tw_reuse
-    fi
 
-    # Allow a few more queued connections than are allowed by default
-    echo 1024 > /proc/sys/net/core/somaxconn
+        # Allow a few more queued connections than are allowed by default
+
+        echo 1024 > /proc/sys/net/core/somaxconn
+    fi
 
     # Allowed number of open file descriptors
     ulimit -n 100000

--- a/src/common/utils.sh
+++ b/src/common/utils.sh
@@ -84,5 +84,5 @@ kill_and_wait() {
 }
 
 running_in_container() {
-  grep -q '/instance' /proc/self/cgroup
+  grep -q -E '/instance|/docker/' /proc/self/cgroup
 }


### PR DESCRIPTION
`/proc/sys/net/core/somaxconn` isn't writeable in some container configurations, add a config value so it can be disabled.

Modify running_in_containers() so it detects Docker containers.

See https://github.com/cloudfoundry-incubator/diego-release/pull/146 for more details about the format of `/proc/self/cgroup`