### PR TITLE
Added backed parameter to smoketest

### DIFF
--- a/jobs/smoke-tests/spec
+++ b/jobs/smoke-tests/spec
@@ -49,3 +49,6 @@ properties:
   smoke_tests.enable_windows_tests:
     default: false
     description: Toggles a portion of the suite that exercises Windows platform support
+  smoke_tests.backend:
+    default: ''
+    description: Defines the backend to be used. ('dea', 'diego', '' (default))

--- a/jobs/smoke-tests/templates/config.json.erb
+++ b/jobs/smoke-tests/templates/config.json.erb
@@ -32,5 +32,6 @@
   "skip_ssl_validation"  : <%= properties.smoke_tests.skip_ssl_validation %>,
   "syslog_drain_port"    : 514,
   "syslog_ip_address"    : "<%= discover_external_ip %>",
-  "enable_windows_tests" : <%= properties.smoke_tests.enable_windows_tests %>
+  "enable_windows_tests" : <%= properties.smoke_tests.enable_windows_tests %>,
+  "backend"              : "<%= properties.smoke_tests.backend %>"
 }


### PR DESCRIPTION
This PR is dependent on https://github.com/cloudfoundry/cf-smoke-tests/pull/14. It will allow to specify if the smoketest is running on diego, dea or the default setting in the deployment.