### PR TITLE
Add setting for cc.core_file_pattern

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -926,6 +926,7 @@ properties:
         ca_cert: null
     bulk_api_password: BULK_API_PASSWORD
     client_max_body_size: 15M
+    core_file_pattern: "/var/vcap/sys/cores/core-%e-%s-%p-%t"
     dea_use_https: false
     db_encryption_key: CCDB_ENCRYPTION_KEY
     db_logging_level: debug2

--- a/spec/fixtures/bosh-lite/cf-manifest.yml
+++ b/spec/fixtures/bosh-lite/cf-manifest.yml
@@ -2754,6 +2754,7 @@ properties:
           -----END CERTIFICATE-----
     bulk_api_password: bulk-password
     client_max_body_size: 15M
+    core_file_pattern: "/var/vcap/sys/cores/core-%e-%s-%p-%t"
     db_encryption_key: db-encryption-key
     db_logging_level: debug2
     dea_use_https: true

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -936,6 +936,7 @@ properties:
         ca_cert: BLOBSTORE_CA_CERT
     bulk_api_password: BULK_API_PASSWORD
     client_max_body_size: 15M
+    core_file_pattern: "/var/vcap/sys/cores/core-%e-%s-%p-%t"
     db_encryption_key: DB_ENCRYPTION_KEY
     db_logging_level: debug2
     dea_use_https: false

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -934,6 +934,7 @@ properties:
         ca_cert: BLOBSTORE_CA_CERT
     bulk_api_password: BULK_API_PASSWORD
     client_max_body_size: 15M
+    core_file_pattern: "/var/vcap/sys/cores/core-%e-%s-%p-%t"
     db_encryption_key: DB_ENCRYPTION_KEY
     db_logging_level: debug2
     dea_use_https: false

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -828,6 +828,8 @@ properties:
 
     dea_use_https: false
 
+    core_file_pattern: (( merge || "/var/vcap/sys/cores/core-%e-%s-%p-%t" ))
+
   ccdb: (( merge ))
 
   ha_proxy: (( merge || nil ))


### PR DESCRIPTION
Add default value for cc.core_file_pattern added in https://github.com/cloudfoundry/capi-release/pull/3 / https://github.com/cloudfoundry/cloud_controller_ng/pull/566.