### PR TITLE
openstack: Add static IP to jobs on z2 network

### DIFF
--- a/templates/cf-infrastructure-openstack.yml
+++ b/templates/cf-infrastructure-openstack.yml
@@ -189,25 +189,25 @@ jobs:
     instances: 0
     networks:
       - name: cf2
-        static_ips: []
+        static_ips: (( static_ips(2) ))
 
   - name: router_z2
     instances: 0
     networks:
       - name: cf2
-        static_ips: []
+        static_ips: (( static_ips(5) ))
 
   - name: etcd_z2
     instances: 0
     networks:
       - name: cf2
-        static_ips: []
+        static_ips: (( static_ips(8, 9, 10) ))
 
   - name: consul_z2
     instances: 0
     networks:
       - name: cf2
-        static_ips: []
+        static_ips: (( static_ips(12, 13, 14) ))
 
   - name: loggregator_z2
     instances: 0


### PR DESCRIPTION
This patch makes easier to enable jobs on z2 network in case of an Openstack deployment. It does not alter the default behaviour.