### PR TITLE
Adds security_event_logging property to trafficcontroller.

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -1363,6 +1363,8 @@ properties:
     outgoing_port: 8080
     zone: null
     disable_access_control: null
+    security_event_logging:
+      enabled: false
   uaa:
     admin:
       client_secret: ADMIN_SECRET

--- a/spec/fixtures/bosh-lite/cf-manifest.yml
+++ b/spec/fixtures/bosh-lite/cf-manifest.yml
@@ -3958,6 +3958,8 @@ properties:
     disable_access_control: null
     outgoing_port: 8080
     zone: null
+    security_event_logging:
+      enabled: false
   uaa:
     admin:
       client_secret: admin-secret

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -1358,6 +1358,8 @@ properties:
     disable_access_control: null
     outgoing_port: 8080
     zone: null
+    security_event_logging:
+      enabled: false
   uaa:
     admin:
       client_secret: ADMIN_SECRET

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -1364,6 +1364,8 @@ properties:
     outgoing_port: 8080
     zone: null
     disable_access_control: null
+    security_event_logging:
+      enabled: false
   uaa:
     admin:
       client_secret: ADMIN_SECRET

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -659,6 +659,8 @@ properties:
     outgoing_port: 8080
     zone: (( merge || nil ))
     disable_access_control: (( merge || nil ))
+    security_event_logging:
+      enabled: (( merge || false ))
 
   logger_endpoint: ~
 


### PR DESCRIPTION
- This is disabled by default

[#117740327]

Signed-off-by: Jason Keene <jkeene@pivotal.io>