### PR TITLE
Eliminate "MicroBOSH"; its use is deprecated

### DIFF
--- a/example_manifests/README.md
+++ b/example_manifests/README.md
@@ -10,10 +10,10 @@ it doesn't include features such as high availability and security.
 
 # Setup
 
-## Create MicroBOSH in AWS
-- http://docs.cloudfoundry.org/bosh/deploy-microbosh-to-aws.html
+## Deploy BOSH director in AWS
+- https://bosh.io/docs/init-aws.html
 
-##Update the microbosh Security Group to allow "cf logs" to work
+##Update the BOSH Security Group to allow "cf logs" to work
 - Click on "VPC" from the Amazon Web Services Dashboard
 - Click on "Security Groups" from the VPC Dashboard
 - Select the "bosh" Security Group
@@ -27,7 +27,7 @@ it doesn't include features such as high availability and security.
 - Click "Save"
 
 - Replace REPLACE_WITH_DIRECTOR_ID in the example manifest with the bosh director id (return by running "bosh status --uuid")
-- Replace REPLACE_WITH_BOSH_SECURITY_GROUP in the example manifest with the security group created for microbosh
+- Replace REPLACE_WITH_BOSH_SECURITY_GROUP in the example manifest with the security group created for BOSH
 
 ## Create a NAT Machine in the bosh subnet
 - Click on "EC2" from the Amazon Web Services Dashboard
@@ -38,8 +38,8 @@ it doesn't include features such as high availability and security.
 - Select "m1.small"
 - Click "Next: Configure Instance Details"
 - Fill in
-  - Network: microbosh
-  - Subnet: microbosh
+  - Network: bosh
+  - Subnet: bosh
   - Auto-assign Public IP: Enable
 - Click "Next: Add Storage"
   - If asked to choose boot volume for instance, select the "Continue with Magnetic..." option.
@@ -68,13 +68,13 @@ it doesn't include features such as high availability and security.
 - Click "Create Subnet"
 - Fill in
   - Name tag: cf
-  - VPC: microbosh
-  - Availability Zone: Pick the same Availability Zone as the microbosh Subnet
+  - VPC: bosh
+  - Availability Zone: Pick the same Availability Zone as the bosh Subnet
     - Replace REPLACE_WITH_AZ in the example manifest with the Availability Zone you chose
   - CIDR block: 10.0.16.0/24
   - Click "Yes, Create"
 - Replace REPLACE_WITH_PRIVATE_SUBNET_ID in the example manifest with the Subnet ID for the cf Subnet
-- Replace REPLACE_WITH_PUBLIC_SUBNET_ID in the example manifest with the Subnet ID for the microbosh Subnet
+- Replace REPLACE_WITH_PUBLIC_SUBNET_ID in the example manifest with the Subnet ID for the bosh Subnet
 - Select the cf Subnet from the Subnet list
 - Click the name of the "Route table:" to view the route tables
 - Select the route table from the list
@@ -182,7 +182,7 @@ or perform some other actions. To do this you first need to get a list of vms wi
 acccess your machines with the following command:
 
 ```sh
-bosh ssh VM_FROM_BOSH_VMS_COMMAND/INSTANCE_NUMBER --gateway_host YOUR_PUBLIC_MICROBOSH_ADDRESS --gateway_user vcap
+bosh ssh VM_FROM_BOSH_VMS_COMMAND/INSTANCE_NUMBER --gateway_host YOUR_PUBLIC_BOSH_ADDRESS --gateway_user vcap
 ```
 
 Note that this command will ask you to setup the password for sudo during the login processs.


### PR DESCRIPTION
- The term "MicroBOSH" (single-VM deployment of a BOSH director) is deprecated. Its use is both unimportant and confusing.
- Instructions for deploying BOSH director refer to *bosh-init*; the *bosh micro* plugin is deprecated should not be referenced (note that *bosh micro* plugin has nothing to do with a microBOSH director, which is another reason to get away from the term "micro".