### PR TITLE
Make possible to add new resource pools

### DIFF
--- a/templates/cf-infrastructure-openstack.yml
+++ b/templates/cf-infrastructure-openstack.yml
@@ -86,6 +86,7 @@ compilation:
   cloud_properties: (( merge || meta.resource_pools.medium.cloud_properties ))
 
 resource_pools:
+  - <<: (( merge ))
   - name: small_z1
     cloud_properties: (( merge || meta.resource_pools.small.cloud_properties ))
 

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -1031,6 +1031,7 @@ update:
   serial: true
 
 resource_pools:
+  - <<: (( merge ))
   - name: small_z1
     network: cf1
     stemcell: (( meta.stemcell ))


### PR DESCRIPTION
Currently we only can overload the existing resource pools. For enabling the use of OpenStack anti-affinity ServerGroup we had to add new resource pools and assign them by type of CF components. It was not possible because some resource pools were shared between differents types. So we add a merge instruction to add new custom resource pools.