### PR TITLE
Broken login links 

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -1273,8 +1273,8 @@ properties:
     enabled: true
     invitations_enabled: null
     links:
-      passwd: https://console.SYSTEM_DOMAIN/password_resets/new
-      signup: https://console.SYSTEM_DOMAIN/register
+      passwd: https://login.SYSTEM_DOMAIN/forgot_password
+      signup: https://login.SYSTEM_DOMAIN/create_account
     logout: null
     messages: null
     notifications:

--- a/spec/fixtures/bosh-lite/cf-manifest.yml
+++ b/spec/fixtures/bosh-lite/cf-manifest.yml
@@ -3870,8 +3870,8 @@ properties:
     enabled: true
     invitations_enabled: null
     links:
-      passwd: https://console.bosh-lite.com/password_resets/new
-      signup: https://console.bosh-lite.com/register
+      passwd: https://login.bosh-lite.com/forgot_password
+      signup: https://login.bosh-lite.com/create_account
     logout: null
     messages: null
     notifications:

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -1278,8 +1278,8 @@ properties:
     enabled: true
     invitations_enabled: null
     links:
-      passwd: https://console.SYSTEM_DOMAIN/password_resets/new
-      signup: https://console.SYSTEM_DOMAIN/register
+      passwd: https://login.SYSTEM_DOMAIN/forgot_password
+      signup: https://login.SYSTEM_DOMAIN/create_account
     logout: null
     messages: null
     notifications:

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -1283,8 +1283,8 @@ properties:
     enabled: true
     invitations_enabled: null
     links:
-      passwd: https://console.SYSTEM_DOMAIN/password_resets/new
-      signup: https://console.SYSTEM_DOMAIN/register
+      passwd: https://login.SYSTEM_DOMAIN/forgot_password
+      signup: https://login.SYSTEM_DOMAIN/create_account
     logout: null
     messages: null
     notifications:

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -872,8 +872,8 @@ properties:
       password: ~
 
     links:
-      passwd: (( "https://console." system_domain "/password_resets/new" ))
-      signup: (( "https://console." system_domain "/register" ))
+      passwd: (( "https://login." system_domain "/forgot_password" ))
+      signup: (( "https://login." system_domain "/create_account" ))
 
     logout: ~
 


### PR DESCRIPTION
Hi!
I have changed broken login links in cf template, current values for passwd and signup return 404:
```
~$ curl -kI https://console.cf.example.corp/password_resets/new
HTTP/1.1 404 Not Found
~$ curl -kI https://console.cf.example.corp/register
HTTP/1.1 404 Not Found
```
Could you confirm this changes?
Thanks!