### PR TITLE
Loggregator etcd tls

### DIFF
--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -1227,12 +1227,12 @@ meta:
     release: (( meta.loggregator_release_name ))
 
   clock_templates:
+  - name: consul_agent
+    release: (( meta.consul_release_name ))
   - name: cloud_controller_clock
     release: (( meta.capi_release_name ))
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
-  - name: consul_agent
-    release: (( meta.consul_release_name ))
 
   consul_templates:
   - name: consul_agent
@@ -1251,22 +1251,22 @@ meta:
     release: (( meta.loggregator_release_name ))
 
   etcd_templates:
+  - name: consul_agent
+    release: (( meta.consul_release_name ))
   - name: etcd
     release: (( meta.etcd_release_name ))
   - name: etcd_metrics_server
     release: (( meta.etcd_release_name ))
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
-  - name: consul_agent
-    release: (( meta.consul_release_name ))
 
   ha_proxy_templates:
+  - name: consul_agent
+    release: (( meta.consul_release_name ))
   - name: haproxy
     release: (( meta.cf_release_name ))
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
-  - name: consul_agent
-    release: (( meta.consul_release_name ))
 
   hm9000_routes:
   - name: hm9000
@@ -1288,14 +1288,14 @@ meta:
     release: (( meta.cf_release_name ))
 
   loggregator_templates:
+  - name: consul_agent
+    release: (( meta.consul_release_name ))
   - name: doppler
     release: (( meta.loggregator_release_name ))
   - name: syslog_drain_binder
     release: (( meta.loggregator_release_name ))
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
-  - name: consul_agent
-    release: (( meta.consul_release_name ))
 
   loggregator_trafficcontroller_routes:
   - name: doppler
@@ -1310,24 +1310,24 @@ meta:
     - (( "loggregator." .properties.system_domain ))
 
   loggregator_trafficcontroller_templates:
+  - name: consul_agent
+    release: (( meta.consul_release_name ))
   - name: loggregator_trafficcontroller
     release: (( meta.loggregator_release_name ))
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
   - name: route_registrar
     release: (( meta.cf_release_name ))
-  - name: consul_agent
-    release: (( meta.consul_release_name ))
 
   nats_templates:
+  - name: consul_agent
+    release: (( meta.consul_release_name ))
   - name: nats
     release: (( meta.cf_release_name ))
   - name: nats_stream_forwarder
     release: (( meta.cf_release_name ))
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
-  - name: consul_agent
-    release: (( meta.consul_release_name ))
 
   blobstore_routes:
   - name: blobstore
@@ -1361,12 +1361,12 @@ meta:
     release: (( meta.cf_release_name ))
 
   postgres_templates:
+  - name: consul_agent
+    release: (( meta.consul_release_name ))
   - name: postgres
     release: (( meta.cf_release_name ))
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
-  - name: consul_agent
-    release: (( meta.consul_release_name ))
 
   router_templates:
   - name: consul_agent
@@ -1377,12 +1377,12 @@ meta:
     release: (( meta.loggregator_release_name ))
 
   stats_templates:
+  - name: consul_agent
+    release: (( meta.consul_release_name ))
   - name: collector
     release: (( meta.cf_release_name ))
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
-  - name: consul_agent
-    release: (( meta.consul_release_name ))
 
   uaa_routes:
   - name: uaa
@@ -1400,12 +1400,12 @@ meta:
       script_path: /var/vcap/jobs/uaa/bin/health_check
 
   uaa_templates:
+  - name: consul_agent
+    release: (( meta.consul_release_name ))
   - name: uaa
     release: (( meta.uaa_release_name ))
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
-  - name: consul_agent
-    release: (( meta.consul_release_name ))
   - name: route_registrar
     release: (( meta.cf_release_name ))
   - name: statsd-injector

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -618,6 +618,8 @@ properties:
     tls:
       ca_cert: ~
     etcd:
+      ca_cert: (( .properties.etcd.ca_cert ))
+      require_ssl: (( .properties.etcd.require_ssl ))
       machines: (( .properties.etcd.machines ))
 
   loggregator_endpoint:
@@ -631,6 +633,9 @@ properties:
     blacklisted_syslog_ranges: ~
     unmarshaller_count: (( merge || 5 ))
     port: (( merge || 4443 ))
+    etcd:
+      client_cert: ~
+      client_key: ~
     tls:
       server_cert: ~
       server_key: ~
@@ -645,6 +650,9 @@ properties:
     preferred_protocol: ~
     enable_buffer: ~
     buffer_size: ~
+    etcd:
+      client_cert: ~
+      client_key: ~
     tls:
       client_cert: ~
       client_key: ~
@@ -656,6 +664,9 @@ properties:
     outgoing_port: 8080
     zone: (( merge || nil ))
     disable_access_control: (( merge || nil ))
+    etcd:
+      client_cert: ~
+      client_key: ~
     security_event_logging:
       enabled: (( merge || false ))
 

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -97,6 +97,10 @@ jobs:
     properties:
       metron_agent:
         zone: z1
+      consul:
+        agent:
+          services:
+            etcd: {name: cf-etcd}
     update:
       serial: true
       max_in_flight: 1
@@ -112,6 +116,10 @@ jobs:
     properties:
       metron_agent:
         zone: z2
+      consul:
+        agent:
+          services:
+            etcd: {name: cf-etcd}
     update:
       serial: true
       max_in_flight: 1
@@ -568,9 +576,22 @@ properties:
 
   etcd:
     machines: (( merge || jobs.etcd_z1.networks.cf1.static_ips jobs.etcd_z2.networks.cf2.static_ips ))
-    require_ssl: false
-    peer_require_ssl: false
+    require_ssl: (( merge || false ))
+    peer_require_ssl: (( merge || false ))
     advertise_urls_dns_suffix: (( merge || "etcd.service.cf.internal" ))
+    cluster:
+    - instances: (( jobs.etcd_z1.instances ))
+      name: etcd_z1
+    - instances: (( jobs.etcd_z2.instances ))
+      name: etcd_z2
+    ca_cert: (( merge || nil ))
+    server_cert: (( merge || nil ))
+    server_key: (( merge || nil ))
+    client_cert: (( merge || nil ))
+    client_key: (( merge || nil ))
+    peer_ca_cert: (( merge || nil ))
+    peer_cert: (( merge || nil ))
+    peer_key: (( merge || nil ))
 
   etcd_metrics_server:
     nats:
@@ -1210,6 +1231,8 @@ meta:
     release: (( meta.capi_release_name ))
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
+  - name: consul_agent
+    release: (( meta.consul_release_name ))
 
   consul_templates:
   - name: consul_agent
@@ -1234,6 +1257,8 @@ meta:
     release: (( meta.etcd_release_name ))
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
+  - name: consul_agent
+    release: (( meta.consul_release_name ))
 
   ha_proxy_templates:
   - name: haproxy
@@ -1269,6 +1294,8 @@ meta:
     release: (( meta.loggregator_release_name ))
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
+  - name: consul_agent
+    release: (( meta.consul_release_name ))
 
   loggregator_trafficcontroller_routes:
   - name: doppler
@@ -1289,6 +1316,8 @@ meta:
     release: (( meta.loggregator_release_name ))
   - name: route_registrar
     release: (( meta.cf_release_name ))
+  - name: consul_agent
+    release: (( meta.consul_release_name ))
 
   nats_templates:
   - name: nats
@@ -1297,6 +1326,8 @@ meta:
     release: (( meta.cf_release_name ))
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
+  - name: consul_agent
+    release: (( meta.consul_release_name ))
 
   blobstore_routes:
   - name: blobstore
@@ -1334,6 +1365,8 @@ meta:
     release: (( meta.cf_release_name ))
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
+  - name: consul_agent
+    release: (( meta.consul_release_name ))
 
   router_templates:
   - name: consul_agent
@@ -1348,6 +1381,8 @@ meta:
     release: (( meta.cf_release_name ))
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
+  - name: consul_agent
+    release: (( meta.consul_release_name ))
 
   uaa_routes:
   - name: uaa


### PR DESCRIPTION
- Adds properties for loggregator to work with etcd-tls
- Adds consul agents to templates that have metron agents
- Adds etcd TLS properties to template
- Changes `etcd.require_ssl` and `etcd.peer_require_ssl` to merge from stub with a default of false, rather than being forced to false

The first commit shouldn't have any changes that collide with changes from other teams.  The second commit is separate because it has changes related to more global properties, which may have conflicts with changes from other teams.