### PR TITLE
BOSH-lite manifest template allows custom users

### DIFF
--- a/templates/cf-infrastructure-bosh-lite.yml
+++ b/templates/cf-infrastructure-bosh-lite.yml
@@ -580,6 +580,7 @@ properties:
     scim:
       users:
       - admin|admin|scim.write,scim.read,openid,cloud_controller.admin,clients.read,clients.write,doppler.firehose,routing.router_groups.read
+      - <<: (( merge ))
 
   router:
     status:


### PR DESCRIPTION
We would like to be able to add extra users to our bosh-lite deployment.

Other infrastructure templates support this.

