### PR TITLE
Use 'default_networks' pattern for all jobs

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -9,7 +9,6 @@ director_uuid: DIRECTOR_UUID
 jobs:
 - default_networks:
     - name: cf1
-      static_ips: null
   instances: 2
   name: consul_z1
   networks:
@@ -36,7 +35,6 @@ jobs:
 - instances: 1
   default_networks:
     - name: cf2
-      static_ips: null
   name: consul_z2
   networks:
   - name: cf2
@@ -60,12 +58,10 @@ jobs:
     serial: true
 - default_networks:
   - name: cf1
-    static_ips: null
   instances: 0
   name: ha_proxy_z1
   networks:
   - name: cf1
-    static_ips: null
   properties:
     ha_proxy: null
     metron_agent:
@@ -82,6 +78,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+    - name: cf1
   name: nats_z1
   networks:
   - name: cf1
@@ -100,6 +98,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+    - name: cf2
   name: nats_z2
   networks:
   - name: cf2
@@ -118,6 +118,8 @@ jobs:
     release: cf
   update: {}
 - instances: 2
+  default_networks:
+    - name: cf1
   name: etcd_z1
   networks:
   - name: cf1
@@ -140,6 +142,8 @@ jobs:
     serial: true
     max_in_flight: 1
 - instances: 1
+  default_networks:
+    - name: cf2
   name: etcd_z2
   networks:
   - name: cf2
@@ -161,6 +165,8 @@ jobs:
     serial: true
     max_in_flight: 1
 - instances: 1
+  default_networks:
+    - name: cf1
   name: stats_z1
   networks:
   - name: cf1
@@ -175,10 +181,11 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+    - name: cf1
   name: nfs_z1
   networks:
   - name: cf1
-    static_ips: null
   persistent_disk: 102400
   properties:
     consul:
@@ -210,10 +217,11 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+    - name: cf1
   name: blobstore_z1
   networks:
   - name: cf1
-    static_ips: null
   persistent_disk: 102400
   properties:
     consul:
@@ -243,10 +251,11 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+    - name: cf1
   name: postgres_z1
   networks:
   - name: cf1
-    static_ips: null
   persistent_disk: 4096
   properties:
     metron_agent:
@@ -259,6 +268,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+    - name: cf1
   name: uaa_z1
   networks:
   - name: cf1
@@ -301,6 +312,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+    - name: cf2
   name: uaa_z2
   networks:
   - name: cf2
@@ -343,6 +356,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+    - name: cf1
   name: api_z1
   networks:
   - name: cf1
@@ -401,6 +416,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+    - name: cf2
   name: api_z2
   networks:
   - name: cf2
@@ -459,6 +476,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+    - name: cf1
   name: clock_global
   networks:
   - name: cf1
@@ -474,6 +493,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+    - name: cf1
   name: api_worker_z1
   networks:
   - name: cf1
@@ -497,6 +518,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+    - name: cf2
   name: api_worker_z2
   networks:
   - name: cf2
@@ -520,6 +543,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+    - name: cf1
   name: hm9000_z1
   networks:
   - name: cf1
@@ -551,6 +576,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+    - name: cf2
   name: hm9000_z2
   networks:
   - name: cf2
@@ -582,10 +609,11 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+    - name: cf1
   name: runner_z1
   networks:
   - name: cf1
-    static_ips: null
   properties:
     consul:
       agent:
@@ -613,10 +641,11 @@ jobs:
   update:
     max_in_flight: 1
 - instances: 1
+  default_networks:
+    - name: cf2
   name: runner_z2
   networks:
   - name: cf2
-    static_ips: null
   properties:
     consul:
       agent:
@@ -644,6 +673,8 @@ jobs:
   update:
     max_in_flight: 1
 - instances: 0
+  default_networks:
+    - name: cf1
   name: loggregator_z1
   networks:
   - name: cf1
@@ -662,6 +693,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+    - name: cf2
   name: loggregator_z2
   networks:
   - name: cf2
@@ -680,6 +713,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+    - name: cf1
   name: doppler_z1
   networks:
   - name: cf1
@@ -698,6 +733,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+    - name: cf2
   name: doppler_z2
   networks:
   - name: cf2
@@ -716,6 +753,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+    - name: cf1
   name: loggregator_trafficcontroller_z1
   networks:
   - name: cf1
@@ -746,6 +785,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+    - name: cf2
   name: loggregator_trafficcontroller_z2
   networks:
   - name: cf2
@@ -777,7 +818,6 @@ jobs:
   update: {}
 - default_networks:
   - name: cf1
-    static_ips: null
   instances: 1
   name: router_z1
   networks:
@@ -801,7 +841,6 @@ jobs:
   update: {}
 - default_networks:
   - name: cf2
-    static_ips: null
   instances: 1
   name: router_z2
   networks:
@@ -824,6 +863,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+    - name: cf1
   lifecycle: errand
   name: acceptance_tests
   networks:
@@ -833,6 +874,8 @@ jobs:
   - name: acceptance-tests
     release: cf
 - instances: 1
+  default_networks:
+    - name: cf1
   lifecycle: errand
   name: smoke_tests
   networks:

--- a/spec/fixtures/bosh-lite/cf-manifest.yml
+++ b/spec/fixtures/bosh-lite/cf-manifest.yml
@@ -8,7 +8,6 @@ director_uuid: DIRECTOR_UUID
 jobs:
 - default_networks:
   - name: cf1
-    static_ips: null
   instances: 1
   name: consul_z1
   networks:
@@ -33,7 +32,6 @@ jobs:
     serial: true
 - default_networks:
   - name: cf2
-    static_ips: null
   instances: 0
   name: consul_z2
   networks:
@@ -57,7 +55,6 @@ jobs:
     serial: true
 - default_networks:
   - name: cf1
-    static_ips: null
   instances: 1
   name: ha_proxy_z1
   networks:
@@ -170,6 +167,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: nats_z1
   networks:
   - name: cf1
@@ -188,6 +187,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf2
   name: nats_z2
   networks:
   - name: cf2
@@ -205,6 +206,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: etcd_z1
   networks:
   - name: cf1
@@ -226,6 +229,8 @@ jobs:
     max_in_flight: 1
     serial: true
 - instances: 0
+  default_networks:
+  - name: cf2
   name: etcd_z2
   networks:
   - name: cf2
@@ -246,6 +251,8 @@ jobs:
     max_in_flight: 1
     serial: true
 - instances: 0
+  default_networks:
+  - name: cf1
   name: stats_z1
   networks:
   - name: cf1
@@ -260,10 +267,11 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf1
   name: nfs_z1
   networks:
   - name: cf1
-    static_ips: null
   persistent_disk: 102400
   properties:
     consul:
@@ -295,10 +303,11 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: blobstore_z1
   networks:
   - name: cf1
-    static_ips: null
   persistent_disk: 102400
   properties:
     consul:
@@ -328,6 +337,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: postgres_z1
   networks:
   - name: cf1
@@ -345,6 +356,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: uaa_z1
   networks:
   - name: cf1
@@ -388,6 +401,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf2
   name: uaa_z2
   networks:
   - name: cf2
@@ -431,6 +446,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: api_z1
   networks:
   - name: cf1
@@ -493,6 +510,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf2
   name: api_z2
   networks:
   - name: cf2
@@ -551,6 +570,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf1
   name: clock_global
   networks:
   - name: cf1
@@ -566,6 +587,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf1
   name: api_worker_z1
   networks:
   - name: cf1
@@ -589,6 +612,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf2
   name: api_worker_z2
   networks:
   - name: cf2
@@ -612,6 +637,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: hm9000_z1
   networks:
   - name: cf1
@@ -643,6 +670,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf2
   name: hm9000_z2
   networks:
   - name: cf2
@@ -674,6 +703,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: runner_z1
   networks:
   - name: cf1
@@ -706,10 +737,11 @@ jobs:
   update:
     max_in_flight: 1
 - instances: 0
+  default_networks:
+  - name: cf2
   name: runner_z2
   networks:
   - name: cf2
-    static_ips: null
   properties:
     consul:
       agent:
@@ -737,6 +769,8 @@ jobs:
   update:
     max_in_flight: 1
 - instances: 0
+  default_networks:
+  - name: cf1
   name: loggregator_z1
   networks:
   - name: cf1
@@ -755,6 +789,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf2
   name: loggregator_z2
   networks:
   - name: cf2
@@ -773,6 +809,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: doppler_z1
   networks:
   - name: cf1
@@ -791,6 +829,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf2
   name: doppler_z2
   networks:
   - name: cf2
@@ -809,6 +849,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: loggregator_trafficcontroller_z1
   networks:
   - name: cf1
@@ -839,6 +881,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf2
   name: loggregator_trafficcontroller_z2
   networks:
   - name: cf2
@@ -870,7 +914,6 @@ jobs:
   update: {}
 - default_networks:
   - name: cf1
-    static_ips: null
   instances: 1
   name: router_z1
   networks:
@@ -895,7 +938,6 @@ jobs:
   update: {}
 - default_networks:
   - name: cf2
-    static_ips: null
   instances: 0
   name: router_z2
   networks:
@@ -918,6 +960,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   lifecycle: errand
   name: acceptance_tests
   networks:
@@ -927,6 +971,8 @@ jobs:
   - name: acceptance-tests
     release: cf
 - instances: 1
+  default_networks:
+  - name: cf1
   lifecycle: errand
   name: smoke_tests
   networks:

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -7,8 +7,7 @@ compilation:
 director_uuid: DIRECTOR_UUID
 jobs:
 - default_networks:
-    - name: cf1
-      static_ips: null
+  - name: cf1
   instances: 1
   name: consul_z1
   networks:
@@ -32,8 +31,7 @@ jobs:
     max_in_flight: 1
     serial: true
 - default_networks:
-    - name: cf2
-      static_ips: null
+  - name: cf2
   instances: 0
   name: consul_z2
   networks:
@@ -57,7 +55,6 @@ jobs:
     serial: true
 - default_networks:
   - name: cf1
-    static_ips: null
   instances: 1
   name: ha_proxy_z1
   networks:
@@ -83,7 +80,7 @@ jobs:
       zone: z1
     router:
       servers:
-        - 10.10.0.130
+      - 10.10.0.130
   resource_pool: router_z1
   templates:
   - name: haproxy
@@ -94,6 +91,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: nats_z1
   networks:
   - name: cf1
@@ -112,6 +111,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf2
   name: nats_z2
   networks:
   - name: cf2
@@ -129,6 +130,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: etcd_z1
   networks:
   - name: cf1
@@ -150,6 +153,8 @@ jobs:
     serial: true
     max_in_flight: 1
 - instances: 0
+  default_networks:
+  - name: cf2
   name: etcd_z2
   networks:
   - name: cf2
@@ -170,6 +175,8 @@ jobs:
     serial: true
     max_in_flight: 1
 - instances: 1
+  default_networks:
+  - name: cf1
   name: stats_z1
   networks:
   - name: cf1
@@ -184,6 +191,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf1
   name: nfs_z1
   networks:
   - name: cf1
@@ -219,10 +228,11 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: blobstore_z1
   networks:
   - name: cf1
-    static_ips: null
   persistent_disk: 102400
   properties:
     consul:
@@ -252,6 +262,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: postgres_z1
   networks:
   - name: cf1
@@ -269,6 +281,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: uaa_z1
   networks:
   - name: cf1
@@ -312,6 +326,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf2
   name: uaa_z2
   networks:
   - name: cf2
@@ -355,6 +371,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: api_z1
   networks:
   - name: cf1
@@ -411,6 +429,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf2
   name: api_z2
   networks:
   - name: cf2
@@ -469,6 +489,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf1
   name: clock_global
   networks:
   - name: cf1
@@ -484,6 +506,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf1
   name: api_worker_z1
   networks:
   - name: cf1
@@ -507,6 +531,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf2
   name: api_worker_z2
   networks:
   - name: cf2
@@ -530,6 +556,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: hm9000_z1
   networks:
   - name: cf1
@@ -561,6 +589,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf2
   name: hm9000_z2
   networks:
   - name: cf2
@@ -592,10 +622,11 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: runner_z1
   networks:
   - name: cf1
-    static_ips: null
   properties:
     consul:
       agent:
@@ -623,10 +654,11 @@ jobs:
   update:
     max_in_flight: 1
 - instances: 0
+  default_networks:
+  - name: cf2
   name: runner_z2
   networks:
   - name: cf2
-    static_ips: null
   properties:
     consul:
       agent:
@@ -654,6 +686,8 @@ jobs:
   update:
     max_in_flight: 1
 - instances: 0
+  default_networks:
+  - name: cf1
   name: loggregator_z1
   networks:
   - name: cf1
@@ -672,6 +706,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf2
   name: loggregator_z2
   networks:
   - name: cf2
@@ -690,6 +726,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: doppler_z1
   networks:
   - name: cf1
@@ -708,9 +746,11 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf2
   name: doppler_z2
   networks:
-  - name: cf2
+  - name: cf1
   properties:
     doppler:
       zone: z2
@@ -726,6 +766,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: loggregator_trafficcontroller_z1
   networks:
   - name: cf1
@@ -756,6 +798,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf2
   name: loggregator_trafficcontroller_z2
   networks:
   - name: cf2
@@ -787,7 +831,6 @@ jobs:
   update: {}
 - default_networks:
   - name: cf1
-    static_ips: null
   instances: 1
   name: router_z1
   networks:
@@ -812,7 +855,6 @@ jobs:
   update: {}
 - default_networks:
   - name: cf2
-    static_ips: null
   instances: 0
   name: router_z2
   networks:
@@ -835,6 +877,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   lifecycle: errand
   name: acceptance_tests
   networks:
@@ -844,6 +888,8 @@ jobs:
   - name: acceptance-tests
     release: cf
 - instances: 0
+  default_networks:
+  - name: cf1
   lifecycle: errand
   name: smoke_tests
   networks:

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -9,8 +9,7 @@ compilation:
 director_uuid: DIRECTOR_UUID
 jobs:
 - default_networks:
-    - name: cf1
-      static_ips: null
+  - name: cf1
   instances: 2
   name: consul_z1
   networks:
@@ -35,8 +34,7 @@ jobs:
     max_in_flight: 1
     serial: true
 - default_networks:
-    - name: cf2
-      static_ips: null
+  - name: cf2
   instances: 1
   name: consul_z2
   networks:
@@ -61,7 +59,6 @@ jobs:
     serial: true
 - default_networks:
   - name: cf1
-    static_ips: null
   instances: 1
   name: ha_proxy_z1
   networks:
@@ -81,8 +78,8 @@ jobs:
       zone: z1
     router:
       servers:
-        - 10.85.9.235
-        - 10.85.10.235
+      - 10.85.9.235
+      - 10.85.10.235
   resource_pool: router_z1
   templates:
   - name: haproxy
@@ -93,6 +90,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: nats_z1
   networks:
   - name: cf1
@@ -111,6 +110,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf2
   name: nats_z2
   networks:
   - name: cf2
@@ -129,6 +130,8 @@ jobs:
     release: cf
   update: {}
 - instances: 2
+  default_networks:
+  - name: cf1
   name: etcd_z1
   networks:
   - name: cf1
@@ -151,6 +154,8 @@ jobs:
     serial: true
     max_in_flight: 1
 - instances: 1
+  default_networks:
+  - name: cf2
   name: etcd_z2
   networks:
   - name: cf2
@@ -172,6 +177,8 @@ jobs:
     serial: true
     max_in_flight: 1
 - instances: 1
+  default_networks:
+  - name: cf1
   name: stats_z1
   networks:
   - name: cf1
@@ -186,6 +193,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf1
   name: nfs_z1
   networks:
   - name: cf1
@@ -221,10 +230,11 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: blobstore_z1
   networks:
   - name: cf1
-    static_ips: null
   persistent_disk: 102400
   properties:
     consul:
@@ -254,6 +264,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: postgres_z1
   networks:
   - name: cf1
@@ -271,6 +283,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: uaa_z1
   networks:
   - name: cf1
@@ -315,6 +329,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf2
   name: uaa_z2
   networks:
   - name: cf2
@@ -359,6 +375,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: api_z1
   networks:
   - name: cf1
@@ -417,6 +435,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf2
   name: api_z2
   networks:
   - name: cf2
@@ -475,6 +495,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: clock_global
   networks:
   - name: cf1
@@ -490,6 +512,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: api_worker_z1
   networks:
   - name: cf1
@@ -513,6 +537,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf2
   name: api_worker_z2
   networks:
   - name: cf2
@@ -536,6 +562,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: hm9000_z1
   networks:
   - name: cf1
@@ -567,6 +595,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf2
   name: hm9000_z2
   networks:
   - name: cf2
@@ -598,10 +628,11 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: runner_z1
   networks:
   - name: cf1
-    static_ips: null
   properties:
     consul:
       agent:
@@ -629,10 +660,11 @@ jobs:
   update:
     max_in_flight: 1
 - instances: 1
+  default_networks:
+  - name: cf2
   name: runner_z2
   networks:
   - name: cf2
-    static_ips: null
   properties:
     consul:
       agent:
@@ -660,6 +692,8 @@ jobs:
   update:
     max_in_flight: 1
 - instances: 0
+  default_networks:
+  - name: cf1
   name: loggregator_z1
   networks:
   - name: cf1
@@ -678,6 +712,8 @@ jobs:
     release: cf
   update: {}
 - instances: 0
+  default_networks:
+  - name: cf2
   name: loggregator_z2
   networks:
   - name: cf2
@@ -696,6 +732,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: doppler_z1
   networks:
   - name: cf1
@@ -714,6 +752,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf2
   name: doppler_z2
   networks:
   - name: cf2
@@ -732,6 +772,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   name: loggregator_trafficcontroller_z1
   networks:
   - name: cf1
@@ -762,6 +804,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf2
   name: loggregator_trafficcontroller_z2
   networks:
   - name: cf2
@@ -793,7 +837,6 @@ jobs:
   update: {}
 - default_networks:
   - name: cf1
-    static_ips: null
   instances: 1
   name: router_z1
   networks:
@@ -818,7 +861,6 @@ jobs:
   update: {}
 - default_networks:
   - name: cf2
-    static_ips: null
   instances: 1
   name: router_z2
   networks:
@@ -842,6 +884,8 @@ jobs:
     release: cf
   update: {}
 - instances: 1
+  default_networks:
+  - name: cf1
   lifecycle: errand
   name: acceptance_tests
   networks:
@@ -851,6 +895,8 @@ jobs:
   - name: acceptance-tests
     release: cf
 - instances: 1
+  default_networks:
+  - name: cf1
   lifecycle: errand
   name: smoke_tests
   networks:

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -15,7 +15,6 @@ jobs:
     resource_pool: small_z1
     default_networks:
     - name: cf1
-      static_ips: ~
     networks: (( merge || default_networks ))
     update:
       serial: true
@@ -34,7 +33,6 @@ jobs:
     resource_pool: small_z2
     default_networks:
     - name: cf2
-      static_ips: ~
     networks: (( merge || default_networks ))
     update:
       serial: true
@@ -52,7 +50,6 @@ jobs:
     resource_pool: router_z1
     default_networks:
       - name: cf1
-        static_ips: ~
     networks: (( merge || default_networks ))
     properties:
       ha_proxy:
@@ -66,9 +63,9 @@ jobs:
     templates: (( merge || meta.nats_templates ))
     instances: 1
     resource_pool: medium_z1
-    networks:
+    default_networks:
       - name: cf1
-        static_ips: (( merge || nil ))
+    networks: (( merge || default_networks ))
     properties:
       metron_agent:
         zone: z1
@@ -78,9 +75,9 @@ jobs:
     templates: (( merge || meta.nats_templates ))
     instances: 1
     resource_pool: medium_z2
-    networks:
+    default_networks:
       - name: cf2
-        static_ips: (( merge || nil ))
+    networks: (( merge || default_networks ))
     properties:
       metron_agent:
         zone: z2
@@ -91,9 +88,9 @@ jobs:
     instances: 2
     persistent_disk: 10024
     resource_pool: medium_z1
-    networks:
+    default_networks:
       - name: cf1
-        static_ips: (( merge || nil ))
+    networks: (( merge || default_networks ))
     properties:
       metron_agent:
         zone: z1
@@ -106,9 +103,9 @@ jobs:
     instances: 1
     persistent_disk: 10024
     resource_pool: medium_z2
-    networks:
+    default_networks:
       - name: cf2
-        static_ips: (( merge || nil ))
+    networks: (( merge || default_networks ))
     properties:
       metron_agent:
         zone: z2
@@ -120,8 +117,9 @@ jobs:
     templates: (( merge || meta.stats_templates ))
     instances: 1
     resource_pool: small_z1
-    networks:
+    default_networks:
       - name: cf1
+    networks: (( merge || default_networks ))
     properties:
       metron_agent:
         zone: z1
@@ -132,9 +130,9 @@ jobs:
     instances: 0
     resource_pool: medium_z1
     persistent_disk: 102400
-    networks:
+    default_networks:
       - name: cf1
-        static_ips: ~
+    networks: (( merge || default_networks ))
     properties:
       consul:
         agent:
@@ -151,9 +149,9 @@ jobs:
     instances: 0
     resource_pool: medium_z1
     persistent_disk: 102400
-    networks:
+    default_networks:
       - name: cf1
-        static_ips: ~
+    networks: (( merge || default_networks ))
     properties:
       consul:
         agent:
@@ -170,9 +168,9 @@ jobs:
     instances: 0
     resource_pool: medium_z1
     persistent_disk: 4096
-    networks:
+    default_networks:
     - name: cf1
-      static_ips: ~
+    networks: (( merge || default_networks ))
     properties:
       metron_agent:
         zone: z1
@@ -182,8 +180,9 @@ jobs:
     templates: (( merge || meta.uaa_templates ))
     instances: 1
     resource_pool: medium_z1
-    networks:
+    default_networks:
       - name: cf1
+    networks: (( merge || default_networks ))
     properties:
       consul:
         agent:
@@ -202,8 +201,9 @@ jobs:
     templates: (( merge || meta.uaa_templates ))
     instances: 1
     resource_pool: medium_z2
-    networks:
+    default_networks:
       - name: cf2
+    networks: (( merge || default_networks ))
     properties:
       consul:
         agent:
@@ -223,8 +223,9 @@ jobs:
     instances: 1
     resource_pool: large_z1
     persistent_disk: 0
-    networks:
+    default_networks:
       - name: cf1
+    networks: (( merge || default_networks ))
     properties:
       consul:
         agent:
@@ -241,8 +242,9 @@ jobs:
     instances: 1
     resource_pool: large_z2
     persistent_disk: 0
-    networks:
+    default_networks:
       - name: cf2
+    networks: (( merge || default_networks ))
     properties:
       consul:
         agent:
@@ -259,8 +261,9 @@ jobs:
     instances: 1
     resource_pool: medium_z1
     persistent_disk: 0
-    networks:
+    default_networks:
       - name: cf1
+    networks: (( merge || default_networks ))
     properties:
       metron_agent:
         zone: z1
@@ -271,8 +274,9 @@ jobs:
     instances: 1
     resource_pool: small_z1
     persistent_disk: 0
-    networks:
+    default_networks:
       - name: cf1
+    networks: (( merge || default_networks ))
     properties:
       metron_agent:
         zone: z1
@@ -284,8 +288,9 @@ jobs:
     instances: 1
     resource_pool: small_z2
     persistent_disk: 0
-    networks:
+    default_networks:
       - name: cf2
+    networks: (( merge || default_networks ))
     properties:
       metron_agent:
         zone: z2
@@ -296,8 +301,9 @@ jobs:
     templates: (( merge || meta.hm9000_templates ))
     instances: 1
     resource_pool: medium_z1
-    networks:
+    default_networks:
       - name: cf1
+    networks: (( merge || default_networks ))
     properties:
       consul:
         agent:
@@ -313,8 +319,9 @@ jobs:
     templates: (( merge || meta.hm9000_templates ))
     instances: 1
     resource_pool: medium_z2
-    networks:
+    default_networks:
       - name: cf2
+    networks: (( merge || default_networks ))
     properties:
       consul:
         agent:
@@ -330,9 +337,9 @@ jobs:
     templates: (( merge || meta.dea_templates ))
     instances: 1
     resource_pool: runner_z1
-    networks:
+    default_networks:
       - name: cf1
-        static_ips: ~
+    networks: (( merge || default_networks ))
     properties:
       dea_next:
         zone: (( merge || "z1" ))
@@ -354,9 +361,9 @@ jobs:
     templates: (( merge || meta.dea_templates ))
     instances: 1
     resource_pool: runner_z2
-    networks:
+    default_networks:
       - name: cf2
-        static_ips: ~
+    networks: (( merge || default_networks ))
     properties:
       dea_next:
         zone: (( merge || "z2" ))
@@ -378,8 +385,9 @@ jobs:
     templates: (( merge || meta.loggregator_templates ))
     instances: 0
     resource_pool: medium_z1
-    networks:
+    default_networks:
       - name: cf1
+    networks: (( merge || default_networks ))
     properties:
       doppler:
         zone: z1
@@ -391,8 +399,9 @@ jobs:
     templates: (( merge || meta.loggregator_templates ))
     instances: 0
     resource_pool: medium_z2
-    networks:
+    default_networks:
       - name: cf2
+    networks: (( merge || default_networks ))
     properties:
       doppler:
         zone: z2
@@ -404,8 +413,9 @@ jobs:
     templates: (( merge || meta.loggregator_templates ))
     instances: 1
     resource_pool: medium_z1
-    networks:
+    default_networks:
       - name: cf1
+    networks: (( merge || default_networks ))
     properties:
       doppler:
         zone: z1
@@ -417,8 +427,9 @@ jobs:
     templates: (( merge || meta.loggregator_templates ))
     instances: 1
     resource_pool: medium_z2
-    networks:
+    default_networks:
       - name: cf2
+    networks: (( merge || default_networks ))
     properties:
       doppler:
         zone: z2
@@ -430,8 +441,9 @@ jobs:
     templates: (( merge || meta.loggregator_trafficcontroller_templates ))
     instances: 1
     resource_pool: small_z1
-    networks:
+    default_networks:
       - name: cf1
+    networks: (( merge || default_networks ))
     properties:
       traffic_controller:
         zone: z1
@@ -445,8 +457,9 @@ jobs:
     templates: (( merge || meta.loggregator_trafficcontroller_templates ))
     instances: 1
     resource_pool: small_z2
-    networks:
+    default_networks:
       - name: cf2
+    networks: (( merge || default_networks ))
     properties:
       traffic_controller:
         zone: z2
@@ -462,7 +475,6 @@ jobs:
     resource_pool: router_z1
     default_networks:
       - name: cf1
-        static_ips: ~
     networks: (( merge || default_networks ))
     properties:
       consul:
@@ -479,7 +491,6 @@ jobs:
     resource_pool: router_z2
     default_networks:
       - name: cf2
-        static_ips: ~
     networks: (( merge || default_networks ))
     properties:
       consul:
@@ -497,8 +508,9 @@ jobs:
     instances: 1
     resource_pool: small_errand
     lifecycle: errand
-    networks:
+    default_networks:
       - name: cf1
+    networks: (( merge || default_networks ))
 
   - name: smoke_tests
     templates:
@@ -507,8 +519,9 @@ jobs:
     instances: 0
     resource_pool: small_errand
     lifecycle: errand
-    networks:
+    default_networks:
       - name: cf1
+    networks: (( merge || default_networks ))
     properties:
       <<: (( merge ))
 


### PR DESCRIPTION
Some infrastructures require a job to be associated with multiple networks with different configurations. While the templates used a pattern to enable that for some of the jobs (those with static IPs), it was not applied uniformly. This extends the pattern to all of the jobs in the template.