### PR TITLE
Cf login failed with status code: 400

### DIFF
--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -1288,7 +1288,7 @@ properties:
     messages: null
     notifications:
       url: null
-    protocol: http
+    protocol: https
     restricted_ips_regex: null
     saml: null
     self_service_links_enabled: null

--- a/spec/fixtures/openstack/cf-stub.yml
+++ b/spec/fixtures/openstack/cf-stub.yml
@@ -77,7 +77,7 @@ properties:
   loggregator_endpoint:
     shared_secret: LOGGREGATOR_ENDPOINT_SHARED_SECRET
   login:
-    protocol: http
+    protocol: https
   nats:
     user: NATS_USER
     password: NATS_PASSWORD


### PR DESCRIPTION
When test for #995 ,with https://github.com/cloudfoundry/cf-release/blob/master/CONTRIBUTING.md,update and run manifest generation tests and other basic tests ./scripts/test, error is founded,so modify the value of expected.

Failures:

  1) Manifest Generation openstack behaves like generating manifests builds the correct manifest for openstack
     Failure/Error: expect(actual).to yaml_eq(expected)
       Mismatched values in ["properties", "login", "protocol"]:
          actual=https
        expected=http
     Shared Example Group: "generating manifests" called from ./spec/manifest_generation_spec.rb:29
     # ./spec/manifest_generation_spec.rb:16:in `block (3 levels) in <top (required)>'

Finished in 2.44 seconds (files took 0.23925 seconds to load)
4 examples, 1 failure