### PR TITLE
allow `login.prompt` property to be overridden in template

### DIFF
--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -883,6 +883,7 @@ properties:
     invitations_enabled: ~
     spring_profiles: ~
     messages: ~
+    prompt: ~
 
     notifications:
       url: ~


### PR DESCRIPTION
* useful for when ldap uaa backend is being used and email
  address is not the user key
* see related https://github.com/cloudfoundry/cli/issues/810