### PR TITLE
Modify the cf template to support login branding and home redirect properties

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -1319,6 +1319,8 @@ properties:
       code: null
       domain: null
     asset_base_url: null
+    home_redirect: null
+    branding: null
     brand: oss
     catalina_opts: null
     enabled: true

--- a/spec/fixtures/bosh-lite/cf-manifest.yml
+++ b/spec/fixtures/bosh-lite/cf-manifest.yml
@@ -3928,6 +3928,8 @@ properties:
       code: null
       domain: null
     asset_base_url: null
+    home_redirect: null
+    branding: null
     brand: oss
     catalina_opts: null
     enabled: true

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -1335,6 +1335,8 @@ properties:
       code: null
       domain: null
     asset_base_url: null
+    home_redirect: null
+    branding: null
     brand: oss
     catalina_opts: null
     enabled: true

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -1343,6 +1343,8 @@ properties:
       domain: null
     asset_base_url: null
     brand: oss
+    home_redirect: null
+    branding: null
     catalina_opts: null
     enabled: true
     invitations_enabled: null

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -868,6 +868,8 @@ properties:
       client_key:
 
   login:
+    home_redirect: ~
+    branding: (( merge || nil ))
     enabled: true
     analytics:
       code: ~


### PR DESCRIPTION
Hi:

Cloudops would like to be able specify the branding and home redirect properties in our stub file, 
Here is the PR for it, could you help review it. 

With many thanks.
