### PR TITLE
Add consul_agent to the api_z1 job in the example manifest stub

### DIFF
--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -401,6 +401,8 @@ jobs:
         - api.SYSTEM_DOMAIN
   resource_pool: large_z1
   templates:
+  - name: consul_agent
+    release: cf
   - name: go-buildpack
     release: cf
   - name: binary-buildpack

--- a/spec/fixtures/openstack/cf-stub.yml
+++ b/spec/fixtures/openstack/cf-stub.yml
@@ -154,6 +154,8 @@ jobs:
           -----END CERTIFICATE-----
   - name: api_z1
     templates:
+      - name: consul_agent
+        release: cf
       - name: go-buildpack
         release: cf
       - name: binary-buildpack


### PR DESCRIPTION
We noticed that the `consul_agent` is missing from the `api_z1` job in the example stub at [https://docs.cloudfoundry.org/deploying/openstack/cf-stub.html](https://docs.cloudfoundry.org/deploying/openstack/cf-stub.html). Without it the api VM won't come up properly.

I also noticed that `java-buildpack` and `java-offline-buildpack` are missing and `cloud_controller_clock`  and `cloud_controller_worker` were added compared to the default values. Are those changes still supposed to be there?