### PR TITLE
Make the update script work in a single pass.

### DIFF
--- a/scripts/update
+++ b/scripts/update
@@ -9,18 +9,20 @@ echo "===> Unversioned changes will be clobbered <==="
 echo ""
 
 root_dir=$(cd $(dirname $0)/.. && pwd)
-cd $root_dir 
+cd $root_dir
 
 set -x # show the commands we are running
 
 git rev-parse @{u} > /dev/null 2>&1 && git pull
 
-# Update submodule pointers; Clean out any submodule changes
-git submodule sync
-git submodule foreach --recursive 'git submodule sync; git clean -d --force --force'
+# Update submodule pointers
+git submodule sync --recursive
 
 # Update submodule content, checkout if necessary
 git submodule update --init --recursive --force
+
+# Clean out any submodule changes
+git submodule foreach --recursive 'git clean -ffd'
 
 git clean -ffd
 


### PR DESCRIPTION
The Release Engineering team has noticed that we have to run the update script multiple times in order to get a clean copy of a given version of cf-release. This seems to be a problem with cleaning up after updating the submodules of releases that are submoduled into this release.

To solve this problem, we reversed the order in which submodules are updated and cleaned, which allowed us to checkout any release and cleanse it with a single run of the script.