### PR TITLE
Add consul registration to trafficcontroller

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -775,8 +775,15 @@ jobs:
         - loggregator.SYSTEM_DOMAIN
     traffic_controller:
       zone: z1
+    consul:
+      agent:
+        services:
+          loggregator_trafficcontroller: {}
+
   resource_pool: small_z1
   templates:
+  - name: consul_agent
+    release: cf
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent
@@ -807,8 +814,14 @@ jobs:
         - loggregator.SYSTEM_DOMAIN
     traffic_controller:
       zone: z2
+    consul:
+      agent:
+        services:
+          loggregator_trafficcontroller: {}
   resource_pool: small_z2
   templates:
+  - name: consul_agent
+    release: cf
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent

--- a/spec/fixtures/bosh-lite/cf-manifest.yml
+++ b/spec/fixtures/bosh-lite/cf-manifest.yml
@@ -871,8 +871,14 @@ jobs:
         - loggregator.bosh-lite.com
     traffic_controller:
       zone: z1
+    consul:
+      agent:
+        services:
+          loggregator_trafficcontroller: {}
   resource_pool: small_z1
   templates:
+  - name: consul_agent
+    release: cf
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent
@@ -903,8 +909,14 @@ jobs:
         - loggregator.bosh-lite.com
     traffic_controller:
       zone: z2
+    consul:
+      agent:
+        services:
+          loggregator_trafficcontroller: {}
   resource_pool: small_z2
   templates:
+  - name: consul_agent
+    release: cf
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -788,8 +788,14 @@ jobs:
         - loggregator.SYSTEM_DOMAIN
     traffic_controller:
       zone: z1
+    consul:
+      agent:
+        services:
+          loggregator_trafficcontroller: {}
   resource_pool: small_z1
   templates:
+  - name: consul_agent
+    release: cf
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent
@@ -820,8 +826,14 @@ jobs:
         - loggregator.SYSTEM_DOMAIN
     traffic_controller:
       zone: z2
+    consul:
+      agent:
+        services:
+          loggregator_trafficcontroller: {}
   resource_pool: small_z2
   templates:
+  - name: consul_agent
+    release: cf
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -794,8 +794,14 @@ jobs:
         - loggregator.SYSTEM_DOMAIN
     traffic_controller:
       zone: z1
+    consul:
+      agent:
+        services:
+          loggregator_trafficcontroller: {}
   resource_pool: small_z1
   templates:
+  - name: consul_agent
+    release: cf
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent
@@ -826,8 +832,14 @@ jobs:
         - loggregator.SYSTEM_DOMAIN
     traffic_controller:
       zone: z2
+    consul:
+      agent:
+        services:
+          loggregator_trafficcontroller: {}
   resource_pool: small_z2
   templates:
+  - name: consul_agent
+    release: cf
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -447,6 +447,10 @@ jobs:
     properties:
       traffic_controller:
         zone: z1
+      consul:
+        agent:
+          services:
+            loggregator_trafficcontroller: {}
       metron_agent:
         zone: z1
       route_registrar:
@@ -463,6 +467,10 @@ jobs:
     properties:
       traffic_controller:
         zone: z2
+      consul:
+        agent:
+          services:
+            loggregator_trafficcontroller: {}
       metron_agent:
         zone: z2
       route_registrar:
@@ -1302,6 +1310,8 @@ meta:
     - (( "loggregator." .properties.system_domain ))
 
   loggregator_trafficcontroller_templates:
+  - name: consul_agent
+    release: (( meta.consul_release_name ))
   - name: loggregator_trafficcontroller
     release: (( meta.loggregator_release_name ))
   - name: metron_agent


### PR DESCRIPTION
This adds consul to loggregator trafficcontroller so that the TC can register itself with consul.  This shouldn't break anything on its own, but the route won't work properly until [185657bc13ab2ace36b370aa8505b39cf8e82fd8](https://github.com/cloudfoundry/loggregator/commit/185657bc13ab2ace36b370aa8505b39cf8e82fd8) is bumped for the health check script.