### PR TITLE
Support to pass etcd TLS creds to all client jobs

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -1250,6 +1250,7 @@ properties:
   doppler:
     blacklisted_syslog_ranges: null
     debug: false
+    etcd: null
     maxRetainedLogMessages: 100
     message_drain_buffer_size: null
     port: 4443
@@ -1265,13 +1266,29 @@ properties:
   dropsonde:
     enabled: true
   etcd:
+    advertise_urls_dns_suffix: null
+    ca_cert: null
+    client_cert: null
+    client_key: null
+    cluster:
+    - instances: 2
+      name: etcd_z1
+    - instances: 1
+      name: etcd_z2
     machines:
     - 10.10.16.20
     - 10.10.16.35
     - 10.10.80.19
+    peer_ca_cert: null
+    peer_cert: null
+    peer_client: null
+    peer_key: null
     peer_require_ssl: false
     require_ssl: false
+    server_cert: null
+    server_key: null
   etcd_metrics_server:
+    etcd: null
     nats:
       machines:
       - 10.10.16.11
@@ -1304,10 +1321,14 @@ properties:
       start: 10.10.0.0
     debug: false
     etcd:
+      ca_cert: null
+      client_cert: null
+      client_key: null
       machines:
       - 10.10.16.20
       - 10.10.16.35
       - 10.10.80.19
+      require_ssl: null
     maxRetainedLogMessages: 100
     outgoing_dropsonde_port: 8081
     tls:
@@ -1350,6 +1371,7 @@ properties:
     buffer_size: null
     deployment: ENVIRONMENT
     enable_buffer: null
+    etcd: null
     preferred_protocol: null
     tls:
       client_cert: null
@@ -1405,6 +1427,7 @@ properties:
     skip_cert_verify: true
   support_address: http://support.cloudfoundry.com
   syslog_daemon_config: null
+  syslog_drain_binder: null
   system_domain: SYSTEM_DOMAIN
   system_domain_organization: SYSTEM_DOMAIN_ORGANIZATION
   template_only:
@@ -1418,6 +1441,7 @@ properties:
         cf2: SUBNET_ID_2
   traffic_controller:
     outgoing_port: 8080
+    etcd: null
     zone: null
     disable_access_control: null
     security_event_logging:

--- a/spec/fixtures/bosh-lite/cf-manifest.yml
+++ b/spec/fixtures/bosh-lite/cf-manifest.yml
@@ -3734,6 +3734,7 @@ properties:
   doppler:
     blacklisted_syslog_ranges: null
     debug: false
+    etcd: null
     maxRetainedLogMessages: 100
     message_drain_buffer_size: null
     port: 4443
@@ -3749,11 +3750,27 @@ properties:
   dropsonde:
     enabled: true
   etcd:
+    advertise_urls_dns_suffix: null
+    ca_cert: null
+    client_cert: null
+    client_key: null
+    cluster:
+    - instances: 1
+      name: etcd_z1
+    - instances: 0
+      name: etcd_z2
     machines:
     - 10.244.0.42
+    peer_ca_cert: null
+    peer_cert: null
+    peer_client: null
+    peer_key: null
     peer_require_ssl: false
     require_ssl: false
+    server_cert: null
+    server_key: null
   etcd_metrics_server:
+    etcd: null
     nats:
       machines:
       - 10.244.0.6
@@ -3915,8 +3932,12 @@ properties:
     blacklisted_syslog_ranges: null
     debug: false
     etcd:
+      ca_cert: null
+      client_cert: null
+      client_key: null
       machines:
       - 10.244.0.42
+      require_ssl: null
     maxRetainedLogMessages: 100
     outgoing_dropsonde_port: 8081
     tls:
@@ -3959,6 +3980,7 @@ properties:
     buffer_size: null
     deployment: cf-warden
     enable_buffer: null
+    etcd: null
     preferred_protocol: null
     tls:
       client_cert: null
@@ -4021,10 +4043,12 @@ properties:
     skip_cert_verify: true
   support_address: http://support.cloudfoundry.com
   syslog_daemon_config: null
+  syslog_drain_binder: null
   system_domain: bosh-lite.com
   system_domain_organization: null
   traffic_controller:
     disable_access_control: null
+    etcd: null
     outgoing_port: 8080
     zone: null
     security_event_logging:

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -1275,6 +1275,7 @@ properties:
   doppler:
     blacklisted_syslog_ranges: null
     debug: false
+    etcd: null
     maxRetainedLogMessages: 100
     message_drain_buffer_size: null
     port: 4443
@@ -1290,11 +1291,27 @@ properties:
   dropsonde:
     enabled: true
   etcd:
+    advertise_urls_dns_suffix: null
+    ca_cert: null
+    client_cert: null
+    client_key: null
+    cluster:
+    - instances: 1
+      name: etcd_z1
+    - instances: 0
+      name: etcd_z2
     machines:
     - 10.10.0.133
+    peer_ca_cert: null
+    peer_cert: null
+    peer_client: null
+    peer_key: null
     peer_require_ssl: false
     require_ssl: false
+    server_cert: null
+    server_key: null
   etcd_metrics_server:
+    etcd: null
     nats:
       machines:
       - 10.10.0.127
@@ -1322,8 +1339,12 @@ properties:
     blacklisted_syslog_ranges: null
     debug: false
     etcd:
+      ca_cert: null
+      client_cert: null
+      client_key: null
       machines:
       - 10.10.0.133
+      require_ssl: null
     maxRetainedLogMessages: 100
     outgoing_dropsonde_port: 8081
     tls:
@@ -1366,6 +1387,7 @@ properties:
     buffer_size: null
     deployment: ENVIRONMENT
     enable_buffer: null
+    etcd: null
     preferred_protocol: null
     tls:
       client_cert: null
@@ -1420,10 +1442,12 @@ properties:
     skip_cert_verify: true
   support_address: http://support.cloudfoundry.com
   syslog_daemon_config: null
+  syslog_drain_binder: null
   system_domain: SYSTEM_DOMAIN
   system_domain_organization: SYSTEM_DOMAIN_ORGANIZATION
   traffic_controller:
     disable_access_control: null
+    etcd: null
     outgoing_port: 8080
     zone: null
     security_event_logging:

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -1276,6 +1276,7 @@ properties:
   doppler:
     blacklisted_syslog_ranges: null
     debug: false
+    etcd: null
     maxRetainedLogMessages: 100
     message_drain_buffer_size: null
     port: 4443
@@ -1291,13 +1292,29 @@ properties:
   dropsonde:
     enabled: true
   etcd:
+    advertise_urls_dns_suffix: null
+    ca_cert: null
+    client_cert: null
+    client_key: null
+    cluster:
+    - instances: 2
+      name: etcd_z1
+    - instances: 1
+      name: etcd_z2
     machines:
     - 10.85.9.244
     - 10.85.9.245
     - 10.85.10.243
+    peer_ca_cert: null
+    peer_cert: null
+    peer_client: null
+    peer_key: null
     peer_require_ssl: false
     require_ssl: false
+    server_cert: null
+    server_key: null
   etcd_metrics_server:
+    etcd: null
     nats:
       machines:
       - 10.85.9.231
@@ -1327,10 +1344,14 @@ properties:
     blacklisted_syslog_ranges: null
     debug: false
     etcd:
+      ca_cert: null
+      client_cert: null
+      client_key: null
       machines:
       - 10.85.9.244
       - 10.85.9.245
       - 10.85.10.243
+      require_ssl: null
     maxRetainedLogMessages: 100
     outgoing_dropsonde_port: 8081
     tls:
@@ -1373,6 +1394,7 @@ properties:
     buffer_size: null
     deployment: ENVIRONMENT
     enable_buffer: null
+    etcd: null
     preferred_protocol: null
     tls:
       client_cert: null
@@ -1428,10 +1450,12 @@ properties:
     skip_cert_verify: true
   support_address: http://support.cloudfoundry.com
   syslog_daemon_config: null
+  syslog_drain_binder: null
   system_domain: SYSTEM_DOMAIN
   system_domain_organization: SYSTEM_DOMAIN_ORGANIZATION
   traffic_controller:
     outgoing_port: 8080
+    etcd: null
     zone: null
     disable_access_control: null
     security_event_logging:

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -45,7 +45,7 @@ jobs:
         zone: z2
 
   - name: ha_proxy_z1
-    templates: (( merge || meta.ha_proxy_templates ))
+    templates: (( merge || meta.user_ha_proxy_templates meta.ha_proxy_templates ))
     instances: 0
     resource_pool: router_z1
     default_networks:
@@ -60,7 +60,7 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: nats_z1
-    templates: (( merge || meta.nats_templates ))
+    templates: (( merge || meta.user_nats_templates meta.nats_templates ))
     instances: 1
     resource_pool: medium_z1
     default_networks:
@@ -72,7 +72,7 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: nats_z2
-    templates: (( merge || meta.nats_templates ))
+    templates: (( merge || meta.user_nats_templates meta.nats_templates ))
     instances: 1
     resource_pool: medium_z2
     default_networks:
@@ -84,7 +84,7 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: etcd_z1
-    templates: (( merge || meta.etcd_templates ))
+    templates: (( merge || meta.user_etcd_templates meta.etcd_templates ))
     instances: 2
     persistent_disk: 10024
     resource_pool: medium_z1
@@ -92,6 +92,7 @@ jobs:
       - name: cf1
     networks: (( merge || default_networks ))
     properties:
+      <<: (( merge ))
       metron_agent:
         zone: z1
     update:
@@ -99,7 +100,7 @@ jobs:
       max_in_flight: 1
 
   - name: etcd_z2
-    templates: (( merge || meta.etcd_templates ))
+    templates: (( merge || meta.user_etcd_templates meta.etcd_templates ))
     instances: 1
     persistent_disk: 10024
     resource_pool: medium_z2
@@ -107,6 +108,7 @@ jobs:
       - name: cf2
     networks: (( merge || default_networks ))
     properties:
+      <<: (( merge ))
       metron_agent:
         zone: z2
     update:
@@ -114,7 +116,7 @@ jobs:
       max_in_flight: 1
 
   - name: stats_z1
-    templates: (( merge || meta.stats_templates ))
+    templates: (( merge || meta.user_stats_templates meta.stats_templates ))
     instances: 1
     resource_pool: small_z1
     default_networks:
@@ -164,7 +166,7 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: postgres_z1
-    templates: (( merge || meta.postgres_templates ))
+    templates: (( merge || meta.user_postgres_templates meta.postgres_templates ))
     instances: 0
     resource_pool: medium_z1
     persistent_disk: 4096
@@ -257,7 +259,7 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: clock_global
-    templates: (( merge || meta.clock_templates ))
+    templates: (( merge || meta.user_clock_templates meta.clock_templates ))
     instances: 1
     resource_pool: medium_z1
     persistent_disk: 0
@@ -382,7 +384,7 @@ jobs:
       max_in_flight: 1
 
   - name: loggregator_z1
-    templates: (( merge || meta.loggregator_templates ))
+    templates: (( merge || meta.user_loggregator_templates meta.loggregator_templates ))
     instances: 0
     resource_pool: medium_z1
     default_networks:
@@ -396,7 +398,7 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: loggregator_z2
-    templates: (( merge || meta.loggregator_templates ))
+    templates: (( merge || meta.user_loggregator_templates meta.loggregator_templates ))
     instances: 0
     resource_pool: medium_z2
     default_networks:
@@ -410,7 +412,7 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: doppler_z1
-    templates: (( merge || meta.loggregator_templates ))
+    templates: (( merge || meta.user_loggregator_templates meta.loggregator_templates ))
     instances: 1
     resource_pool: medium_z1
     default_networks:
@@ -424,7 +426,7 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: doppler_z2
-    templates: (( merge || meta.loggregator_templates ))
+    templates: (( merge || meta.user_loggregator_templates meta.loggregator_templates ))
     instances: 1
     resource_pool: medium_z2
     default_networks:
@@ -438,7 +440,7 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: loggregator_trafficcontroller_z1
-    templates: (( merge || meta.loggregator_trafficcontroller_templates ))
+    templates: (( merge || meta.user_loggregator_trafficcontroller_templates meta.loggregator_trafficcontroller_templates ))
     instances: 1
     resource_pool: small_z1
     default_networks:
@@ -454,7 +456,7 @@ jobs:
     update: (( merge || empty_hash ))
 
   - name: loggregator_trafficcontroller_z2
-    templates: (( merge || meta.loggregator_trafficcontroller_templates ))
+    templates: (( merge || meta.user_loggregator_trafficcontroller_templates meta.loggregator_trafficcontroller_templates ))
     instances: 1
     resource_pool: small_z2
     default_networks:
@@ -583,8 +585,24 @@ properties:
     machines: (( merge || jobs.etcd_z1.networks.cf1.static_ips jobs.etcd_z2.networks.cf2.static_ips ))
     require_ssl: false
     peer_require_ssl: false
+    advertise_urls_dns_suffix:
+    ca_cert:
+    client_cert:
+    client_key:
+    cluster:
+    - instances: (( jobs.etcd_z1.instances ))
+      name: etcd_z1
+    - instances: (( jobs.etcd_z2.instances ))
+      name: etcd_z2
+    peer_ca_cert:
+    peer_client:
+    peer_cert:
+    peer_key:
+    server_cert:
+    server_key:
 
   etcd_metrics_server:
+    etcd:
     nats:
       machines: (( .properties.nats.machines ))
       username: (( .properties.nats.user ))
@@ -631,6 +649,10 @@ properties:
       ca_cert: ~
     etcd:
       machines: (( .properties.etcd.machines ))
+      require_ssl:
+      ca_cert:
+      client_cert:
+      client_key:
 
   loggregator_endpoint:
     shared_secret: (( merge ))
@@ -643,6 +665,7 @@ properties:
     blacklisted_syslog_ranges: ~
     unmarshaller_count: (( merge || 5 ))
     port: (( merge || 4443 ))
+    etcd:
     tls:
       server_cert: ~
       server_key: ~
@@ -660,9 +683,12 @@ properties:
     tls:
       client_cert: ~
       client_key: ~
+    etcd:
 
   metron_endpoint:
     shared_secret: (( .properties.loggregator_endpoint.shared_secret ))
+
+  syslog_drain_binder:
 
   traffic_controller:
     outgoing_port: 8080
@@ -670,6 +696,7 @@ properties:
     disable_access_control: (( merge || nil ))
     security_event_logging:
       enabled: (( merge || false ))
+    etcd:
 
   logger_endpoint: ~
 
@@ -1224,6 +1251,8 @@ meta:
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
 
+  user_clock_templates: (( merge || [] ))
+
   clock_templates:
   - name: cloud_controller_clock
     release: (( meta.capi_release_name ))
@@ -1246,6 +1275,8 @@ meta:
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
 
+  user_etcd_templates: (( merge || [] ))
+
   etcd_templates:
   - name: etcd
     release: (( meta.etcd_release_name ))
@@ -1253,6 +1284,8 @@ meta:
     release: (( meta.etcd_release_name ))
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
+
+  user_ha_proxy_templates: (( merge || [] ))
 
   ha_proxy_templates:
   - name: haproxy
@@ -1281,6 +1314,8 @@ meta:
   - name: route_registrar
     release: (( meta.cf_release_name ))
 
+  user_loggregator_templates: (( merge || [] ))
+
   loggregator_templates:
   - name: doppler
     release: (( meta.loggregator_release_name ))
@@ -1301,6 +1336,8 @@ meta:
     uris:
     - (( "loggregator." .properties.system_domain ))
 
+  user_loggregator_trafficcontroller_templates: (( merge || [] ))
+
   loggregator_trafficcontroller_templates:
   - name: loggregator_trafficcontroller
     release: (( meta.loggregator_release_name ))
@@ -1308,6 +1345,8 @@ meta:
     release: (( meta.loggregator_release_name ))
   - name: route_registrar
     release: (( meta.cf_release_name ))
+
+  user_nats_templates: (( merge || [] ))
 
   nats_templates:
   - name: nats
@@ -1348,6 +1387,8 @@ meta:
   - name: route_registrar
     release: (( meta.cf_release_name ))
 
+  user_postgres_templates: (( merge || [] ))
+
   postgres_templates:
   - name: postgres
     release: (( meta.postgres_release_name ))
@@ -1361,6 +1402,8 @@ meta:
     release: (( meta.cf_release_name ))
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
+
+  user_stats_templates: (( merge || [] ))
 
   stats_templates:
   - name: collector

--- a/templates/etcd_tls_stub.yml
+++ b/templates/etcd_tls_stub.yml
@@ -1,0 +1,120 @@
+jobs:
+- name: etcd_z1
+  properties:
+    metron_agent:
+      zone: z1
+    consul:
+      agent:
+        services:
+          etcd:
+            name: cf-etcd
+- name: etcd_z2
+  properties:
+    metron_agent:
+      zone: z2
+    consul:
+      agent:
+        services:
+          etcd:
+            name: cf-etcd
+properties:
+  doppler:
+    etcd:
+      require_ssl: true
+      ca_cert: (( properties.etcd.ca_cert ))
+      client_cert: (( properties.etcd.client_cert ))
+      client_key: (( properties.etcd.client_key ))
+
+  etcd:
+    advertise_urls_dns_suffix: cf-etcd.service.cf.internal
+    require_ssl: true
+    ca_cert: (( merge ))
+    client_cert: (( merge ))
+    client_key: (( merge ))
+    machines:
+    - cf-etcd.service.cf.internal
+    peer_ca_cert: (( merge ))
+    peer_client: (( merge ))
+    peer_key: (( merge ))
+    peer_cert: ((( merge ))
+    peer_require_ssl: (( merge ))
+    server_cert: (( merge ))
+    server_key: (( merge ))
+
+  etcd_metrics_server:
+    etcd:
+      require_ssl: true
+      ca_cert: (( properties.etcd.ca_cert ))
+      client_cert: (( properties.etcd.client_cert ))
+      client_key: (( properties.etcd.client_key ))
+      dns_suffix: (( properties.etcd.advertise_urls_dns_suffix ))
+
+  hm9000:
+    etcd:
+      require_ssl: true
+      ca_cert: (( properties.etcd.ca_cert ))
+      client_cert: (( properties.etcd.client_cert ))
+      client_key: (( properties.etcd.client_key ))
+
+  loggregator:
+    etcd:
+      require_ssl: true
+      ca_cert: (( properties.etcd.ca_cert ))
+      client_cert: (( properties.etcd.client_cert ))
+      client_key: (( properties.etcd.client_key ))
+
+  metron_agent:
+    etcd:
+      machines: (( properties.etcd.machines ))
+      require_ssl: true
+      ca_cert: (( properties.etcd.ca_cert ))
+      client_cert: (( properties.etcd.client_cert ))
+      client_key: (( properties.etcd.client_key ))
+
+  syslog_drain_binder:
+    etcd:
+      machines: (( properties.etcd.machines ))
+      require_ssl: true
+      ca_cert: (( properties.etcd.ca_cert ))
+      client_cert: (( properties.etcd.client_cert ))
+      client_key: (( properties.etcd.client_key ))
+
+  traffic_controller:
+    etcd:
+      machines: (( properties.etcd.machines ))
+      require_ssl: true
+      ca_cert: (( properties.etcd.ca_cert ))
+      client_cert: (( properties.etcd.client_cert ))
+      client_key: (( properties.etcd.client_key ))
+
+meta:
+  user_clock_templates:
+  - name: consul_agent
+    release: cf
+
+  user_postgres_templates:
+  - name: consul_agent
+    release: cf
+
+  user_ha_proxy_templates:
+  - name: consul_agent
+    release: cf
+
+  user_nats_templates:
+  - name: consul_agent
+    release: cf
+
+  user_stats_templates:
+  - name: consul_agent
+    release: cf
+
+  user_etcd_templates:
+    - name: consul_agent
+      release: cf
+  user_loggregator_templates:
+    - name: consul_agent
+      release: cf
+  user_loggregator_trafficcontroller_templates:
+    - name: consul_agent
+      release: cf
+


### PR DESCRIPTION
- Creates an etcd TLS cluster
- Can pass templates/etcd_tls_stub.yml to scripts/generate_deployment_manifest
- Requires an etcd certs stub containing etcd certs

Sample etcd_cert.yml looks like
```
properties:
  etcd:
    ca_cert:
    client_cert:
    client_key:
    peer_ca_cert:
    peer_cert:
    peer_client:
    peer_key:
    peer_require_ssl: true
    server_cert:
    server_key:
```

[#122070663](https://www.pivotaltracker.com/story/show/122070663)

@evanfarrar @christianang 