### PR TITLE
Update loggregator properties

### DIFF
--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -685,6 +685,7 @@ properties:
     blacklisted_syslog_ranges: ~
     unmarshaller_count: (( merge || 5 ))
     port: (( merge || 4443 ))
+    outgoing_port: (( merge || 8080 ))
     tls:
       server_cert: ~
       server_key: ~
@@ -700,8 +701,6 @@ properties:
   metron_agent:
     deployment: (( meta.environment ))
     preferred_protocol: ~
-    enable_buffer: ~
-    buffer_size: ~
     protocols: ~
     etcd:
       client_cert: (( .properties.etcd.client_cert ))


### PR DESCRIPTION
@Amit-PivotalLabs There are a few properties in Loggregator that have been deprecated for a while now. We believe that now is as good a time as any to remove them from the cf-release template. We wanted to make a PR to make sure that removing these properties won't break anything.

In the future, when we'd like to remove properties that we deprecated several versions ago, should we continue to make PRs, or just push directly to develop?

-Jeremy & Sam