### PR TITLE
Add dns_config into the cf template

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -1249,6 +1249,7 @@ properties:
       tag: admin
   collector: null
   consul:
+    dns_config: null
     agent:
       domain: cf.internal
       log_level: null

--- a/spec/fixtures/bosh-lite/cf-manifest.yml
+++ b/spec/fixtures/bosh-lite/cf-manifest.yml
@@ -3134,6 +3134,7 @@ properties:
       tag: admin
   collector: null
   consul:
+    dns_config: null
     agent:
       domain: cf.internal
       log_level: null

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -1255,6 +1255,7 @@ properties:
       tag: admin
   collector: null
   consul:
+    dns_config: null
     agent:
       domain: cf.internal
       log_level: null

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -1252,6 +1252,7 @@ properties:
       tag: admin
   collector: null
   consul:
+    dns_config: null
     agent:
       domain: cf.internal
       log_level: null

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -566,6 +566,7 @@ properties:
       ca_cert: ~
 
   consul:
+    dns_config: (( merge || nil ))
     agent:
       domain: cf.internal
       log_level: (( merge || nil ))


### PR DESCRIPTION
Hi:

We'd like to be able to config consul.agent.dns_config.allow_stale in our stub file, so that we can use the feature [here](https://github.com/cloudfoundry-incubator/consul-release/pull/35/commits/9617c96f24a14a3a0dcb0114ece07def063e2d4f)


Could you help review the PR?

With many thanks.
