### PR TITLE
Increase discoverability of CI pipeline in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains the Cloud Foundry source code. Cloud Foundry is deploye
 
 * [Documentation](http://docs.cloudfoundry.org/)
 * [Release Notes](https://github.com/cloudfoundry/cf-release/releases)
-* [CI](https://runtime.ci.cf-app.com/pipelines/cf-release?groups=cf-release)
+* [Continuous Integration Pipeline](https://runtime.ci.cf-app.com/pipelines/cf-release?groups=cf-release)
 * [Mailing List](https://lists.cloudfoundry.org/archives/list/cf-dev@lists.cloudfoundry.org/)
 
 #### Table of Contents


### PR DESCRIPTION
Spelling this out in the README is arguably nicer for users who are either searching the README or typing something like "cloud foundry ci pipeline" into a search engine.