### PR TITLE
Symlink metron_agent_windows from loggregator

### DIFF
--- a/jobs/metron_agent_windows
+++ b/jobs/metron_agent_windows
@@ -1,0 +1,1 @@
+../src/loggregator/jobs/metron_agent_windows

--- a/packages/golang1.7-windows
+++ b/packages/golang1.7-windows
@@ -1,0 +1,1 @@
+../src/loggregator/packages/golang1.7-windows

--- a/packages/metron_agent_windows
+++ b/packages/metron_agent_windows
@@ -1,0 +1,1 @@
+../src/loggregator/packages/metron_agent_windows


### PR DESCRIPTION
Enables garden-windows release to no longer submodule loggregator

* Add metron_agent_windows job
* Add metron_agent_windows package
* Add golang1.7-windows package

golang1.7-windows blob to be uploaded can be found here: https://storage.googleapis.com/golang/go1.7.windows-amd64.zip

Signed-off-by: Sunjay Bhatia <sbhatia@pivotal.io>