### PR TITLE
Shorter cf oauth client RT validity

### DIFF
--- a/example_manifests/minimal-aws.yml
+++ b/example_manifests/minimal-aws.yml
@@ -758,7 +758,7 @@ properties:
         authorized-grant-types: implicit,password,refresh_token
         autoapprove: true
         override: true
-        refresh-token-validity: 2592000
+        refresh-token-validity: 604800
         scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read
       cc-service-dashboards:
         authorities: clients.read,clients.write,clients.admin

--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -1526,7 +1526,7 @@ properties:
         authorities: uaa.none
         authorized-grant-types: password,refresh_token
         override: true
-        refresh-token-validity: 2592000
+        refresh-token-validity: 604800
         scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,cloud_controller.admin_read_only,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write
       cloud_controller_username_lookup:
         authorities: scim.userids

--- a/spec/fixtures/bosh-lite/cf-manifest.yml
+++ b/spec/fixtures/bosh-lite/cf-manifest.yml
@@ -3832,7 +3832,7 @@ properties:
         authorities: uaa.none
         authorized-grant-types: password,refresh_token
         override: true
-        refresh-token-validity: 2592000
+        refresh-token-validity: 604800
         scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,cloud_controller.admin_read_only,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write
       cloud_controller_username_lookup:
         authorities: scim.userids

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -1542,7 +1542,7 @@ properties:
         authorities: uaa.none
         authorized-grant-types: password,refresh_token
         override: true
-        refresh-token-validity: 2592000
+        refresh-token-validity: 604800
         scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,cloud_controller.admin_read_only,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write
       cloud_controller_username_lookup:
         authorities: scim.userids

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -1539,7 +1539,7 @@ properties:
         authorities: uaa.none
         authorized-grant-types: password,refresh_token
         override: true
-        refresh-token-validity: 2592000
+        refresh-token-validity: 604800
         scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,cloud_controller.admin_read_only,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write
       cloud_controller_username_lookup:
         authorities: scim.userids

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -1024,7 +1024,7 @@ properties:
         authorized-grant-types: password,refresh_token
         scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,cloud_controller.admin_read_only,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write
         authorities: uaa.none
-        access-token-validity: 600 # 1 hour
+        access-token-validity: 600 # 10 mins
         refresh-token-validity: 604800 # 7 days
       notifications:
         secret: (( merge ))

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -1024,8 +1024,8 @@ properties:
         authorized-grant-types: password,refresh_token
         scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,cloud_controller.admin_read_only,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write
         authorities: uaa.none
-        access-token-validity: 600
-        refresh-token-validity: 2592000
+        access-token-validity: 600 # 1 hour
+        refresh-token-validity: 604800 # 7 days
       notifications:
         secret: (( merge ))
         authorities: cloud_controller.admin,scim.read


### PR DESCRIPTION
30 days is likely to be a too large default for most organizations (e.g. PWS sets 1 day)

In addition, a long refresh token validity (30 days) has the current side effect of growing the UAA db potentially up to its total capacity potentially creating outages, see https://github.com/cloudfoundry/uaa/issues/466: UAA stores all refresh tokens which have not expired or were invalidated.
