### PR TITLE
Add placeholders to make the etcd cluster run in secure TLS mode

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -1295,8 +1295,8 @@ properties:
     blacklisted_syslog_ranges: null
     debug: false
     etcd:
-      client_cert: ""
-      client_key: ""
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
     maxRetainedLogMessages: 100
     message_drain_buffer_size: null
     port: 4443
@@ -1314,9 +1314,9 @@ properties:
     enabled: true
   etcd:
     advertise_urls_dns_suffix: cf-etcd.service.cf.internal
-    ca_cert: ""
-    client_cert: ""
-    client_key: ""
+    ca_cert: ETCD_CA_CERT
+    client_cert: ETCD_CLIENT_CERT
+    client_key: ETCD_CLIENT_KEY
     cluster:
     - instances: 2
       name: etcd_z1
@@ -1326,32 +1326,32 @@ properties:
     - 10.10.16.20
     - 10.10.16.35
     - 10.10.80.19
-    peer_ca_cert: ""
-    peer_cert: ""
-    peer_key: ""
-    peer_require_ssl: false
-    require_ssl: false
-    server_cert: ""
-    server_key: ""
+    peer_ca_cert: ETCD_PEER_CA_CERT
+    peer_cert: ETCD_PEER_CERT
+    peer_key: ETC_PEER_KEY
+    peer_require_ssl: true
+    require_ssl: true
+    server_cert: ETCD_SERVER_CERT
+    server_key: ETCD_SERVER_KEY
   etcd_metrics_server:
     etcd:
-      ca_cert: ""
-      client_cert: ""
-      client_key: ""
+      ca_cert: ETCD_CA_CERT
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
       dns_suffix: cf-etcd.service.cf.internal
-      require_ssl: false
+      require_ssl: true
   ha_proxy: null
   hm9000:
     ca_cert: HM9000_CA_CERT
     client_cert: HM9000_CLIENT_CERT
     client_key: HM9000_CLIENT_KEY
     etcd:
-      ca_cert: ""
-      client_cert: ""
-      client_key: ""
+      ca_cert: ETCD_CA_CERT
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
       machines:
       - cf-etcd.service.cf.internal
-      require_ssl: false
+      require_ssl: true
     port: 5155
     server_cert: HM9000_SERVER_CERT
     server_key: HM9000_SERVER_KEY
@@ -1364,10 +1364,10 @@ properties:
       start: 10.10.0.0
     debug: false
     etcd:
-      ca_cert: ""
+      ca_cert: ETCD_CA_CERT
       machines:
       - cf-etcd.service.cf.internal
-      require_ssl: false
+      require_ssl: true
     maxRetainedLogMessages: 100
     outgoing_dropsonde_port: 8081
     tls:
@@ -1403,8 +1403,8 @@ properties:
   metron_agent:
     deployment: ENVIRONMENT
     etcd:
-      client_cert: ""
-      client_key: ""
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
     preferred_protocol: null
     protocols: null
     tls:
@@ -1470,8 +1470,8 @@ properties:
   syslog_daemon_config: null
   syslog_drain_binder:
     etcd:
-      client_cert: ""
-      client_key: ""
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
   system_domain: SYSTEM_DOMAIN
   system_domain_organization: SYSTEM_DOMAIN_ORGANIZATION
   template_only:
@@ -1486,8 +1486,8 @@ properties:
   traffic_controller:
     disable_access_control: null
     etcd:
-      client_cert: ""
-      client_key: ""
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
     security_event_logging:
       enabled: false
     zone: null

--- a/spec/fixtures/aws/cf-stub.yml
+++ b/spec/fixtures/aws/cf-stub.yml
@@ -79,6 +79,16 @@ properties:
     server_key: CONSUL_SERVER_KEY
     agent_cert: CONSUL_AGENT_CERT
     agent_key: CONSUL_AGENT_KEY
+  etcd:
+    require_ssl: true
+    ca_cert: ETCD_CA_CERT
+    client_cert: ETCD_CLIENT_CERT
+    client_key: ETCD_CLIENT_KEY
+    peer_ca_cert: ETCD_PEER_CA_CERT
+    peer_cert: ETCD_PEER_CERT
+    peer_key: ETC_PEER_KEY
+    server_cert: ETCD_SERVER_CERT
+    server_key: ETCD_SERVER_KEY
   loggregator_endpoint:
     shared_secret: LOGGREGATOR_ENDPOINT_SHARED_SECRET
   nats:

--- a/spec/fixtures/bosh-lite/cf-manifest.yml
+++ b/spec/fixtures/bosh-lite/cf-manifest.yml
@@ -3467,8 +3467,8 @@ properties:
     blacklisted_syslog_ranges: null
     debug: false
     etcd:
-      client_cert: ""
-      client_key: ""
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
     maxRetainedLogMessages: 100
     message_drain_buffer_size: null
     port: 4443
@@ -3486,9 +3486,9 @@ properties:
     enabled: true
   etcd:
     advertise_urls_dns_suffix: cf-etcd.service.cf.internal
-    ca_cert: ""
-    client_cert: ""
-    client_key: ""
+    ca_cert: ETCD_CA_CERT
+    client_cert: ETCD_CLIENT_CERT
+    client_key: ETCD_CLIENT_KEY
     cluster:
     - instances: 1
       name: etcd_z1
@@ -3496,20 +3496,20 @@ properties:
       name: etcd_z2
     machines:
     - 10.244.0.42
-    peer_ca_cert: ""
-    peer_cert: ""
-    peer_key: ""
-    peer_require_ssl: false
-    require_ssl: false
-    server_cert: ""
-    server_key: ""
+    peer_ca_cert: ETCD_PEER_CA_CERT
+    peer_cert: ETCD_PEER_CERT
+    peer_key: ETC_PEER_KEY
+    peer_require_ssl: true
+    require_ssl: true
+    server_cert: ETCD_SERVER_CERT
+    server_key: ETCD_SERVER_KEY
   etcd_metrics_server:
     etcd:
-      ca_cert: ""
-      client_cert: ""
-      client_key: ""
+      ca_cert: ETCD_CA_CERT
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
       dns_suffix: cf-etcd.service.cf.internal
-      require_ssl: false
+      require_ssl: true
   ha_proxy: null
   hm9000:
     ca_cert: |+
@@ -3597,12 +3597,12 @@ properties:
       ZYj59Q6AUR9BvPeli7gwedfGWyAl35NGcNq8JG6rL+FWubDWqqc=
       -----END RSA PRIVATE KEY-----
     etcd:
-      ca_cert: ""
-      client_cert: ""
-      client_key: ""
+      ca_cert: ETCD_CA_CERT
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
       machines:
       - cf-etcd.service.cf.internal
-      require_ssl: false
+      require_ssl: true
     port: 5155
     server_cert: |+
       -----BEGIN CERTIFICATE-----
@@ -3666,10 +3666,10 @@ properties:
     blacklisted_syslog_ranges: null
     debug: false
     etcd:
-      ca_cert: ""
+      ca_cert: ETCD_CA_CERT
       machines:
       - cf-etcd.service.cf.internal
-      require_ssl: false
+      require_ssl: true
     maxRetainedLogMessages: 100
     outgoing_dropsonde_port: 8081
     tls:
@@ -3705,8 +3705,8 @@ properties:
   metron_agent:
     deployment: cf-warden
     etcd:
-      client_cert: ""
-      client_key: ""
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
     preferred_protocol: null
     protocols: null
     tls:
@@ -3779,15 +3779,15 @@ properties:
   syslog_daemon_config: null
   syslog_drain_binder:
     etcd:
-      client_cert: ""
-      client_key: ""
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
   system_domain: bosh-lite.com
   system_domain_organization: null
   traffic_controller:
     disable_access_control: null
     etcd:
-      client_cert: ""
-      client_key: ""
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
     security_event_logging:
       enabled: false
     zone: null

--- a/spec/fixtures/bosh-lite/cf-stub.yml
+++ b/spec/fixtures/bosh-lite/cf-stub.yml
@@ -1,2 +1,14 @@
 ---
 director_uuid: DIRECTOR_UUID
+
+properties:
+  etcd:
+    require_ssl: true
+    ca_cert: ETCD_CA_CERT
+    client_cert: ETCD_CLIENT_CERT
+    client_key: ETCD_CLIENT_KEY
+    peer_ca_cert: ETCD_PEER_CA_CERT
+    peer_cert: ETCD_PEER_CERT
+    peer_key: ETC_PEER_KEY
+    server_cert: ETCD_SERVER_CERT
+    server_key: ETCD_SERVER_KEY

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -1325,8 +1325,8 @@ properties:
     blacklisted_syslog_ranges: null
     debug: false
     etcd:
-      client_cert: ""
-      client_key: ""
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
     maxRetainedLogMessages: 100
     message_drain_buffer_size: null
     port: 4443
@@ -1344,9 +1344,9 @@ properties:
     enabled: true
   etcd:
     advertise_urls_dns_suffix: cf-etcd.service.cf.internal
-    ca_cert: ""
-    client_cert: ""
-    client_key: ""
+    ca_cert: ETCD_CA_CERT
+    client_cert: ETCD_CLIENT_CERT
+    client_key: ETCD_CLIENT_KEY
     cluster:
     - instances: 1
       name: etcd_z1
@@ -1354,32 +1354,32 @@ properties:
       name: etcd_z2
     machines:
     - 10.10.0.133
-    peer_ca_cert: ""
-    peer_cert: ""
-    peer_key: ""
-    peer_require_ssl: false
-    require_ssl: false
-    server_cert: ""
-    server_key: ""
+    peer_ca_cert: ETCD_PEER_CA_CERT
+    peer_cert: ETCD_PEER_CERT
+    peer_key: ETC_PEER_KEY
+    peer_require_ssl: true
+    require_ssl: true
+    server_cert: ETCD_SERVER_CERT
+    server_key: ETCD_SERVER_KEY
   etcd_metrics_server:
     etcd:
-      ca_cert: ""
-      client_cert: ""
-      client_key: ""
+      ca_cert: ETCD_CA_CERT
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
       dns_suffix: cf-etcd.service.cf.internal
-      require_ssl: false
+      require_ssl: true
   ha_proxy: null
   hm9000:
     ca_cert: HM9000_CA_CERT
     client_cert: HM9000_CLIENT_CERT
     client_key: HM9000_CLIENT_KEY
     etcd:
-      ca_cert: ""
-      client_cert: ""
-      client_key: ""
+      ca_cert: ETCD_CA_CERT
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
       machines:
       - cf-etcd.service.cf.internal
-      require_ssl: false
+      require_ssl: true
     port: 5155
     server_cert: HM9000_SERVER_CERT
     server_key: HM9000_SERVER_KEY
@@ -1390,10 +1390,10 @@ properties:
     blacklisted_syslog_ranges: null
     debug: false
     etcd:
-      ca_cert: ""
+      ca_cert: ETCD_CA_CERT
       machines:
       - cf-etcd.service.cf.internal
-      require_ssl: false
+      require_ssl: true
     maxRetainedLogMessages: 100
     outgoing_dropsonde_port: 8081
     tls:
@@ -1429,8 +1429,8 @@ properties:
   metron_agent:
     deployment: ENVIRONMENT
     etcd:
-      client_cert: ""
-      client_key: ""
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
     preferred_protocol: null
     protocols: null
     tls:
@@ -1495,15 +1495,15 @@ properties:
   syslog_daemon_config: null
   syslog_drain_binder:
     etcd:
-      client_cert: ""
-      client_key: ""
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
   system_domain: SYSTEM_DOMAIN
   system_domain_organization: SYSTEM_DOMAIN_ORGANIZATION
   traffic_controller:
     disable_access_control: null
     etcd:
-      client_cert: ""
-      client_key: ""
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
     security_event_logging:
       enabled: false
     zone: null

--- a/spec/fixtures/openstack/cf-stub.yml
+++ b/spec/fixtures/openstack/cf-stub.yml
@@ -73,6 +73,16 @@ properties:
   dea_next:
     disk_mb: 2048
     memory_mb: 1024
+  etcd:
+    require_ssl: true
+    ca_cert: ETCD_CA_CERT
+    client_cert: ETCD_CLIENT_CERT
+    client_key: ETCD_CLIENT_KEY
+    peer_ca_cert: ETCD_PEER_CA_CERT
+    peer_cert: ETCD_PEER_CERT
+    peer_key: ETC_PEER_KEY
+    server_cert: ETCD_SERVER_CERT
+    server_key: ETCD_SERVER_KEY
   loggregator_endpoint:
     shared_secret: LOGGREGATOR_ENDPOINT_SHARED_SECRET
   login:

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -1320,8 +1320,8 @@ properties:
     blacklisted_syslog_ranges: null
     debug: false
     etcd:
-      client_cert: ""
-      client_key: ""
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
     maxRetainedLogMessages: 100
     message_drain_buffer_size: null
     port: 4443
@@ -1339,9 +1339,9 @@ properties:
     enabled: true
   etcd:
     advertise_urls_dns_suffix: cf-etcd.service.cf.internal
-    ca_cert: ""
-    client_cert: ""
-    client_key: ""
+    ca_cert: ETCD_CA_CERT
+    client_cert: ETCD_CLIENT_CERT
+    client_key: ETCD_CLIENT_KEY
     cluster:
     - instances: 2
       name: etcd_z1
@@ -1351,32 +1351,32 @@ properties:
     - 10.85.9.244
     - 10.85.9.245
     - 10.85.10.243
-    peer_ca_cert: ""
-    peer_cert: ""
-    peer_key: ""
-    peer_require_ssl: false
-    require_ssl: false
-    server_cert: ""
-    server_key: ""
+    peer_ca_cert: ETCD_PEER_CA_CERT
+    peer_cert: ETCD_PEER_CERT
+    peer_key: ETC_PEER_KEY
+    peer_require_ssl: true
+    require_ssl: true
+    server_cert: ETCD_SERVER_CERT
+    server_key: ETCD_SERVER_KEY
   etcd_metrics_server:
     etcd:
-      ca_cert: ""
-      client_cert: ""
-      client_key: ""
+      ca_cert: ETCD_CA_CERT
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
       dns_suffix: cf-etcd.service.cf.internal
-      require_ssl: false
+      require_ssl: true
   ha_proxy: null
   hm9000:
     ca_cert: HM9000_CA_CERT
     client_cert: HM9000_CLIENT_CERT
     client_key: HM9000_CLIENT_KEY
     etcd:
-      ca_cert: ""
-      client_cert: ""
-      client_key: ""
+      ca_cert: ETCD_CA_CERT
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
       machines:
       - cf-etcd.service.cf.internal
-      require_ssl: false
+      require_ssl: true
     port: 5155
     server_cert: HM9000_SERVER_CERT
     server_key: HM9000_SERVER_KEY
@@ -1386,10 +1386,10 @@ properties:
     blacklisted_syslog_ranges: null
     debug: false
     etcd:
-      ca_cert: ""
+      ca_cert: ETCD_CA_CERT
       machines:
       - cf-etcd.service.cf.internal
-      require_ssl: false
+      require_ssl: true
     maxRetainedLogMessages: 100
     outgoing_dropsonde_port: 8081
     tls:
@@ -1425,8 +1425,8 @@ properties:
   metron_agent:
     deployment: ENVIRONMENT
     etcd:
-      client_cert: ""
-      client_key: ""
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
     preferred_protocol: null
     protocols: null
     tls:
@@ -1492,15 +1492,15 @@ properties:
   syslog_daemon_config: null
   syslog_drain_binder:
     etcd:
-      client_cert: ""
-      client_key: ""
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
   system_domain: SYSTEM_DOMAIN
   system_domain_organization: SYSTEM_DOMAIN_ORGANIZATION
   traffic_controller:
     disable_access_control: null
     etcd:
-      client_cert: ""
-      client_key: ""
+      client_cert: ETCD_CLIENT_CERT
+      client_key: ETCD_CLIENT_KEY
     security_event_logging:
       enabled: false
     zone: null

--- a/spec/fixtures/vsphere/cf-stub.yml
+++ b/spec/fixtures/vsphere/cf-stub.yml
@@ -73,6 +73,16 @@ properties:
   dea_next:
     disk_mb: 2048
     memory_mb: 1024
+  etcd:
+    require_ssl: true
+    ca_cert: ETCD_CA_CERT
+    client_cert: ETCD_CLIENT_CERT
+    client_key: ETCD_CLIENT_KEY
+    peer_ca_cert: ETCD_PEER_CA_CERT
+    peer_cert: ETCD_PEER_CERT
+    peer_key: ETC_PEER_KEY
+    server_cert: ETCD_SERVER_CERT
+    server_key: ETCD_SERVER_KEY
   loggregator_endpoint:
     shared_secret: LOGGREGATOR_ENDPOINT_SHARED_SECRET
   login:


### PR DESCRIPTION
I wanted to update the [docs](https://docs.cloudfoundry.org/deploying/aws/cf-stub.html#stub) but it turns out that the cf-stub comes from `cf-release`, hence my Pull Request here. I tried to keep this change as concise and small as possible, and I am sorry in advance if I might have missed something.
# 

cf-release v241 release notes tell us:

[..]
This release introduces official support for running the etcd cluster
(shared by several components such as Routing API and the loggregator
subsystem, but not Diego which uses its own secure cluster) in secure
TLS mode. Upgrading an existing deployment with an insecure etcd cluster
to a secure one with minimal downtime is non-trivial. Instructions and
additional information for this procedure can be found here. If you are
using the manifest generation scripts included within the cf-release
repo to generate manifests, you're strongly recommended to upgrade to a
secure etcd cluster at this point. The instructions above assume you are
upgrading to a secure etcd cluster from a pre-v241 Cloud Foundry
deployment and will not apply as smoothly if you later attempt to
upgrade a post-v241 non-TLS etcd cluster to a TLS cluster within the
Cloud Foundry deployment.
[..]

See: https://github.com/cloudfoundry/cf-release/releases/tag/v241
