### PR TITLE
Correct name of release containing java-offline-buildpack job in cf.yml template

### DIFF
--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -1222,6 +1222,7 @@ meta:
   etcd_release_name: (( releases.etcd.name || "cf" ))
   postgres_release_name: (( releases.postgres.name || "cf" ))
   java_buildpack_release_name: (( releases.java-buildpack.name || "cf" ))
+  java_offline_buildpack_release_name: (( releases.java-offline-buildpack.name || "cf" ))
   go_buildpack_release_name: (( releases.go-buildpack.name || "cf" ))
   binary_buildpack_release_name: (( releases.binary-buildpack.name || "cf" ))
   nodejs_buildpack_release_name: (( releases.nodejs-buildpack.name || "cf" ))
@@ -1261,7 +1262,7 @@ meta:
   - name: java-buildpack
     release: (( meta.java_buildpack_release_name ))
   - name: java-offline-buildpack
-    release: (( meta.java_buildpack_release_name ))
+    release: (( meta.java_offline_buildpack_release_name ))
   - name: go-buildpack
     release: (( meta.go_buildpack_release_name ))
   - name: binary-buildpack


### PR DESCRIPTION
The java-offline-buildpack job is in the java-offline-buildpack BOSH release, not the java-buildpack BOSH release. This change corrects the template to account for that.
