### PR TITLE
Allow configuration of artifacts directory for smoke tests

### DIFF
--- a/jobs/smoke-tests/spec
+++ b/jobs/smoke-tests/spec
@@ -49,6 +49,8 @@ properties:
   smoke_tests.enable_windows_tests:
     default: false
     description: Toggles a portion of the suite that exercises Windows platform support
+  smoke_tests.artifacts_directory:
+    description: The directory in which to store test CF_TRACE output.
   smoke_tests.backend:
     default: ''
     description: Defines the backend to be used. ('dea', 'diego', '' (default))

--- a/jobs/smoke-tests/templates/config.json.erb
+++ b/jobs/smoke-tests/templates/config.json.erb
@@ -18,6 +18,9 @@
   end
 %>
 {
+<% if_p("smoke_tests.artifacts_directory") do |artifacts_directory| %>
+  "artifacts_directory"  : "<%= artifacts_directory %>",
+<% end %>
   "suite_name"           : "<%= properties.smoke_tests.suite_name %>",
   "api"                  : "<%= properties.smoke_tests.api %>",
   "apps_domain"          : "<%= Array(properties.smoke_tests.apps_domain).first %>",


### PR DESCRIPTION
## Why

This pull request has been raised regarding https://github.com/cloudfoundry/cf-release/issues/1089

It is useful to be able to ship the CF_TRACE output to temporary storage, so it can be used to debug failed tests. This pull request has been raised to allow the configuration of the artifacts directory from the manifest, which will enable the logging more easily.

## What

Add some logic to check if the `smoke_tests.artifacts_directory` property is set and add it to the smoke test configuration. This makes it possible to turn on logging of CF_TRACE output from the manifest.

Once the template is rendered you will be left with some fairly hideous whitespace (a linefeed before and after the artifacts directory key). I did not implement trimming of this because the Bosh repository shows inconsistent support for the `trim_mode` parameters in ERB[1].

The artifacts directory is hard coded for the acceptance tests job[2]. Other than a mild inconsistency there is no reason to change this behaviour.

[1] http://ruby-doc.org/stdlib-2.3.1/libdoc/erb/rdoc/ERB.html#method-c-new
[2] https://github.com/cloudfoundry/cf-release/blob/v245/jobs/acceptance-tests/templates/config.json.erb#L24