### PR TITLE
Allow router resource pools to receive extra properties

### DIFF
--- a/templates/cf-infrastructure-aws.yml
+++ b/templates/cf-infrastructure-aws.yml
@@ -130,6 +130,7 @@ resource_pools:
         type: gp2
       availability_zone: (( meta.zones.z1 ))
       elbs: (( merge || ["cfrouter"] ))
+      <<: (( merge ))
 
   - name: router_z2
     cloud_properties:
@@ -139,6 +140,7 @@ resource_pools:
         type: gp2
       availability_zone: (( meta.zones.z2 ))
       elbs: (( merge || ["cfrouter"] ))
+      <<: (( merge ))
 
   - name: small_errand
     cloud_properties:


### PR DESCRIPTION
- This enables using a bbl'd up environment for deploying from cf-release using its manifest generation
- Also incidentally allow extra cloud_properties to be added to router resource pools

Signed-off-by: Aakash Shah <ashah@pivotal.io>