### PR TITLE
Add acceptance tests configuration properties into spec

### DIFF
--- a/jobs/acceptance-tests/spec
+++ b/jobs/acceptance-tests/spec
@@ -107,4 +107,12 @@ properties:
   acceptance_tests.persistent_app_quota_name:
     description: "The default name for the persistent app quota name."
   acceptance_tests.cf_dial_timeout_in_seconds:
-    description: Sets the cli timeout (CF_DIAL_TIMEOUT)
+    description: "Sets the cli timeout (CF_DIAL_TIMEOUT)."
+  acceptance_tests.detect_timeout:
+    description: "Timeout for buildpack detection."
+  acceptance_tests.timeout_scale:
+    description: "Used primarily to scale default timeouts for test setup and teardown actions (e.g. creating an org) as opposed to main test actions (e.g. pushing an app)."
+  acceptance_tests.sleep_timeout:
+    description: "Configures SleepTimeout variable used by some tests that wait for some actions to happen."
+  acceptance_tests.test_password:
+    description: "Password to use for temporary user created during tests."


### PR DESCRIPTION
Add `detect_timeout`, `timeout_scale`,` sleep_timeout` and `test_password` properties into acceptance tests job spec, so that these can be configured in the manifest. The properties are already passed by [config erb template](https://github.com/cloudfoundry/cf-release/blob/master/jobs/acceptance-tests/templates/config.json.erb) and [parsed by the tests](https://github.com/cloudfoundry/cf-acceptance-tests/blob/dc410aa3cc94e55b296ba7da8a6914ad3c707c44/helpers/config/config_struct.go).

I have also noticed there are further properties defined in the [cf-test-helpers](https://github.com/cloudfoundry/cf-acceptance-tests/blob/d25456f3c194fdba376fa1cc7faa919b68cbafeb/vendor/github.com/cloudfoundry-incubator/cf-test-helpers/config/config.go#L11) that are currently not defined in the [acceptance tests config struct](https://github.com/cloudfoundry/cf-acceptance-tests/blob/dc410aa3cc94e55b296ba7da8a6914ad3c707c44/helpers/config/config_struct.go). Not sure if these are being retired, or planned to be used in the upcoming tests. If they will be used in the future, here's a template for adding them to acceptance tests job spec:

```
  acceptance_tests.secure_address:
    description:
  acceptance_tests.docker_email:
    description:
  acceptance_tests.docker_executable:
    description:
  acceptance_tests.docker_parameters:
    description:
  acceptance_tests.docker_password:
    description:
  acceptance_tests.docker_private_image:
    description:
  acceptance_tests.docker_registry_address:
    description:
  acceptance_tests.docker_user:
    description:
```