### PR TITLE
Generalize running_in_container function

### DIFF
--- a/src/common/utils.sh
+++ b/src/common/utils.sh
@@ -84,5 +84,6 @@ kill_and_wait() {
 }
 
 running_in_container() {
-  grep -q -E '/instance|/docker/' /proc/self/cgroup
+  # look for a non-root cgroup
+  grep --quiet --invert-match ':/$' /proc/self/cgroup
 }


### PR DESCRIPTION
This change allows jobs to run correctly in garden-runc containers
as well as in the previously supported garden-linux and docker containers.