### PR TITLE
Further highlight that the admin user password should be replaced

### DIFF
--- a/example_manifests/minimal-aws.yml
+++ b/example_manifests/minimal-aws.yml
@@ -415,7 +415,7 @@ jobs:
         userids_enabled: true
         users:
           - name: admin
-            password: PASSWORD
+            password: REPLACE_WITH_PASSWORD
             groups:
               - scim.write
               - scim.read


### PR DESCRIPTION
The current deployment works by making an admin user with a password
of 'PASSWORD'