### PR TITLE
Move clock_global into clock_z{1,2} to enable HA mode

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -485,7 +485,7 @@ jobs:
 - default_networks:
   - name: cf1
   instances: 1
-  name: clock_global
+  name: clock_z1
   networks:
   - name: cf1
   persistent_disk: 0
@@ -522,6 +522,25 @@ jobs:
   - name: consul_agent
     release: cf
   - name: cloud_controller_worker
+    release: cf
+  - name: metron_agent
+    release: cf
+  update: {}
+- default_networks:
+  - name: cf2
+  instances: 1
+  name: clock_z2
+  networks:
+  - name: cf2
+  persistent_disk: 0
+  properties:
+    metron_agent:
+      zone: z2
+  resource_pool: medium_z2
+  templates:
+  - name: consul_agent
+    release: cf
+  - name: cloud_controller_clock
     release: cf
   - name: metron_agent
     release: cf

--- a/spec/fixtures/bosh-lite/cf-manifest.yml
+++ b/spec/fixtures/bosh-lite/cf-manifest.yml
@@ -487,7 +487,7 @@ jobs:
 - default_networks:
   - name: cf1
   instances: 0
-  name: clock_global
+  name: clock_z1
   networks:
   - name: cf1
   persistent_disk: 4096
@@ -524,6 +524,25 @@ jobs:
   - name: consul_agent
     release: cf
   - name: cloud_controller_worker
+    release: cf
+  - name: metron_agent
+    release: cf
+  update: {}
+- default_networks:
+  - name: cf2
+  instances: 0
+  name: clock_z2
+  networks:
+  - name: cf2
+  persistent_disk: 4096
+  properties:
+    metron_agent:
+      zone: z2
+  resource_pool: medium_z2
+  templates:
+  - name: consul_agent
+    release: cf
+  - name: cloud_controller_clock
     release: cf
   - name: metron_agent
     release: cf

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -487,7 +487,7 @@ jobs:
   update: {}
 - default_networks:
   - name: cf1
-  instances: 1
+  instances: 0
   name: clock_z1
   networks:
   - name: cf1
@@ -531,7 +531,7 @@ jobs:
   update: {}
 - default_networks:
   - name: cf2
-  instances: 1
+  instances: 0
   name: clock_z2
   networks:
   - name: cf2

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -487,8 +487,8 @@ jobs:
   update: {}
 - default_networks:
   - name: cf1
-  instances: 0
-  name: clock_global
+  instances: 1
+  name: clock_z1
   networks:
   - name: cf1
   persistent_disk: 0
@@ -525,6 +525,25 @@ jobs:
   - name: consul_agent
     release: cf
   - name: cloud_controller_worker
+    release: cf
+  - name: metron_agent
+    release: cf
+  update: {}
+- default_networks:
+  - name: cf2
+  instances: 1
+  name: clock_z2
+  networks:
+  - name: cf2
+  persistent_disk: 0
+  properties:
+    metron_agent:
+      zone: z2
+  resource_pool: medium_z2
+  templates:
+  - name: consul_agent
+    release: cf
+  - name: cloud_controller_clock
     release: cf
   - name: metron_agent
     release: cf

--- a/spec/fixtures/openstack/cf-stub.yml
+++ b/spec/fixtures/openstack/cf-stub.yml
@@ -212,7 +212,7 @@ jobs:
 
   - name: api_worker_z1
     instances: 0
-  - name: clock_global
-    instances: 0
+  - name: clock_z1
+    instances: 1
 # code_snippet cf-stub-openstack end
 # The previous line helps maintain current documentation at http://docs.cloudfoundry.org.

--- a/spec/fixtures/openstack/cf-stub.yml
+++ b/spec/fixtures/openstack/cf-stub.yml
@@ -213,6 +213,8 @@ jobs:
   - name: api_worker_z1
     instances: 0
   - name: clock_z1
-    instances: 1
+    instances: 0
+  - name: clock_z2
+    instances: 0
 # code_snippet cf-stub-openstack end
 # The previous line helps maintain current documentation at http://docs.cloudfoundry.org.

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -493,7 +493,7 @@ jobs:
 - default_networks:
   - name: cf1
   instances: 1
-  name: clock_global
+  name: clock_z1
   networks:
   - name: cf1
   persistent_disk: 0
@@ -530,6 +530,25 @@ jobs:
   - name: consul_agent
     release: cf
   - name: cloud_controller_worker
+    release: cf
+  - name: metron_agent
+    release: cf
+  update: {}
+- default_networks:
+  - name: cf2
+  instances: 1
+  name: clock_z2
+  networks:
+  - name: cf2
+  persistent_disk: 0
+  properties:
+    metron_agent:
+      zone: z2
+  resource_pool: medium_z2
+  templates:
+  - name: consul_agent
+    release: cf
+  - name: cloud_controller_clock
     release: cf
   - name: metron_agent
     release: cf

--- a/templates/cf-infrastructure-bosh-lite.yml
+++ b/templates/cf-infrastructure-bosh-lite.yml
@@ -1313,7 +1313,10 @@ jobs:
   - name: api_z2
     persistent_disk: 4096
     instances: 0
-  - name: clock_global
+  - name: clock_z1
+    persistent_disk: 4096
+    instances: 0
+  - name: clock_z2
     persistent_disk: 4096
     instances: 0
   - name: api_worker_z2

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -251,7 +251,7 @@ jobs:
       nfs_server: (( meta.nfs_server ))
     update: (( merge || empty_hash ))
 
-  - name: clock_global
+  - name: clock_z1
     templates: (( merge || meta.clock_templates ))
     instances: 1
     resource_pool: medium_z1
@@ -276,6 +276,19 @@ jobs:
       metron_agent:
         zone: z1
       nfs_server: (( meta.nfs_server ))
+    update: (( merge || empty_hash ))
+
+  - name: clock_z2
+    templates: (( merge || meta.clock_templates ))
+    instances: 1
+    resource_pool: medium_z2
+    persistent_disk: 0
+    default_networks:
+      - name: cf2
+    networks: (( merge || default_networks ))
+    properties:
+      metron_agent:
+        zone: z2
     update: (( merge || empty_hash ))
 
   - name: api_worker_z2


### PR DESCRIPTION
-- **DO NOT MERGE UNTIL https://www.pivotaltracker.com/story/show/136621261 IS RELEASED** --

This requires https://www.pivotaltracker.com/story/show/136621261 to be
released and merged into cf-release before it can be merged.

The clock job will hold onto a lock in the CCDB to ensure only one clock
is scheduling jobs at a time, which enables deploying more than one
instance of it.