### PR TITLE
Add "monitor fail" to haproxy health check

### DIFF
--- a/jobs/haproxy/templates/haproxy.conf.erb
+++ b/jobs/haproxy/templates/haproxy.conf.erb
@@ -36,6 +36,9 @@ listen health_check_http_url
     bind :8080
     mode http
     monitor-uri /health
+    acl http-routers_down nbsrv(http-routers) eq 0
+    acl tcp-routers_down nbsrv(tcp-routers) eq 0
+    monitor fail if http-routers_down OR tcp-routers_down
 
 <% if p("ha_proxy.ssl_pem") %>
 frontend https-in

--- a/jobs/haproxy/templates/haproxy.ctmpl.erb
+++ b/jobs/haproxy/templates/haproxy.ctmpl.erb
@@ -36,6 +36,9 @@ listen health_check_http_url
     bind :8080
     mode http
     monitor-uri /health
+    acl http-routers_down nbsrv(http-routers) eq 0
+    acl tcp-routers_down nbsrv(tcp-routers) eq 0
+    monitor fail if http-routers_down OR tcp-routers_down
 
 <% if p("ha_proxy.ssl_pem") %>
 frontend https-in


### PR DESCRIPTION
In case no servers (i.e. routers) are available, haproxy is still reporting "HTTP 200 - Service ready". When using this health endpoint in an IAAS load balancer it would make more sense to report an error (HTTP 503) instead, so that the load balancer does not forward any requests to this instance.

Signed-off-by: Amin Chawki <amin.chawki@sap.com>