### PR TITLE
Add diego.bbs.etcd.machines property to minimal AWS manifest

### DIFF
--- a/example_manifests/minimal-aws.yml
+++ b/example_manifests/minimal-aws.yml
@@ -1156,6 +1156,7 @@ properties:
         passphrase: REPLACE_WITH_PASSWORD
       ca_cert: ""
       etcd:
+        machines: []
         ca_cert: ""
         client_cert: ""
         client_key: ""


### PR DESCRIPTION
Since diego etcd has been removed from the sample AWS manifest, deployment with current manifest will fail because bbs is trying to use the default `diego.bbs.etcd.machines` property. 
https://github.com/cloudfoundry/diego-release/blob/v1.5.4/jobs/bbs/spec#L83
This property should be set to an empty array to override the default bbs properties.
Here is the reference to the `bbs-overrides-no-etcd.yml` stub.
https://github.com/cloudfoundry/diego-release/blob/v1.5.4/manifest-generation/bbs-overrides-no-etcd.yml#L17