### PR TITLE
CAPI jobs consume nil nats links

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -417,6 +417,7 @@ jobs:
     release: cf
   - name: cloud_controller_ng
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   - name: statsd-injector
@@ -480,6 +481,7 @@ jobs:
     release: cf
   - name: cloud_controller_ng
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   - name: statsd-injector
@@ -504,6 +506,7 @@ jobs:
     release: cf
   - name: cloud_controller_clock
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   update: {}
@@ -529,6 +532,7 @@ jobs:
     release: cf
   - name: cloud_controller_worker
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   update: {}
@@ -548,6 +552,7 @@ jobs:
     release: cf
   - name: cloud_controller_clock
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   update: {}
@@ -573,6 +578,7 @@ jobs:
     release: cf
   - name: cloud_controller_worker
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   update: {}

--- a/spec/fixtures/bosh-lite/cf-manifest.yml
+++ b/spec/fixtures/bosh-lite/cf-manifest.yml
@@ -415,10 +415,13 @@ jobs:
     release: cf
   - name: cloud_controller_ng
     release: cf
+    consumes: {nats: nil}
   - name: cloud_controller_clock
     release: cf
+    consumes: {nats: nil}
   - name: cloud_controller_worker
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   - name: statsd-injector
@@ -482,6 +485,7 @@ jobs:
     release: cf
   - name: cloud_controller_ng
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   - name: statsd-injector
@@ -506,6 +510,7 @@ jobs:
     release: cf
   - name: cloud_controller_clock
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   update: {}
@@ -531,6 +536,7 @@ jobs:
     release: cf
   - name: cloud_controller_worker
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   update: {}
@@ -550,6 +556,7 @@ jobs:
     release: cf
   - name: cloud_controller_clock
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   update: {}
@@ -575,6 +582,7 @@ jobs:
     release: cf
   - name: cloud_controller_worker
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   update: {}

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -416,10 +416,13 @@ jobs:
     release: cf
   - name: cloud_controller_ng
     release: cf
+    consumes: {nats: nil}
   - name: cloud_controller_clock
     release: cf
+    consumes: {nats: nil}
   - name: cloud_controller_worker
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   - name: statsd-injector
@@ -483,6 +486,7 @@ jobs:
     release: cf
   - name: cloud_controller_ng
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   - name: statsd-injector
@@ -507,6 +511,7 @@ jobs:
     release: cf
   - name: cloud_controller_clock
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   update: {}
@@ -532,6 +537,7 @@ jobs:
     release: cf
   - name: cloud_controller_worker
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   update: {}
@@ -551,6 +557,7 @@ jobs:
     release: cf
   - name: cloud_controller_clock
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   update: {}
@@ -576,6 +583,7 @@ jobs:
     release: cf
   - name: cloud_controller_worker
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   update: {}

--- a/spec/fixtures/openstack/cf-stub.yml
+++ b/spec/fixtures/openstack/cf-stub.yml
@@ -206,10 +206,13 @@ jobs:
         release: cf
       - name: cloud_controller_ng
         release: cf
+        consumes: {nats: nil}
       - name: cloud_controller_clock
         release: cf
+        consumes: {nats: nil}
       - name: cloud_controller_worker
         release: cf
+        consumes: {nats: nil}
       - name: metron_agent
         release: cf
       - name: statsd-injector

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -425,6 +425,7 @@ jobs:
     release: cf
   - name: cloud_controller_ng
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   - name: statsd-injector
@@ -488,6 +489,7 @@ jobs:
     release: cf
   - name: cloud_controller_ng
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   - name: statsd-injector
@@ -512,6 +514,7 @@ jobs:
     release: cf
   - name: cloud_controller_clock
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   update: {}
@@ -537,6 +540,7 @@ jobs:
     release: cf
   - name: cloud_controller_worker
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   update: {}
@@ -556,6 +560,7 @@ jobs:
     release: cf
   - name: cloud_controller_clock
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   update: {}
@@ -581,6 +586,7 @@ jobs:
     release: cf
   - name: cloud_controller_worker
     release: cf
+    consumes: {nats: nil}
   - name: metron_agent
     release: cf
   update: {}

--- a/templates/cf-infrastructure-bosh-lite.yml
+++ b/templates/cf-infrastructure-bosh-lite.yml
@@ -1325,10 +1325,13 @@ jobs:
         release: cf
       - name: cloud_controller_ng
         release: cf
+        consumes: {nats: nil}
       - name: cloud_controller_clock
         release: cf
+        consumes: {nats: nil}
       - name: cloud_controller_worker
         release: cf
+        consumes: {nats: nil}
       - name: metron_agent
         release: cf
       - name: statsd-injector

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -1364,6 +1364,7 @@ meta:
     release: (( meta.dotnet_core_buildpack_release_name ))
   - name: cloud_controller_ng
     release: (( meta.capi_release_name ))
+    consumes: {nats: nil}
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
   - name: statsd-injector
@@ -1377,6 +1378,7 @@ meta:
     release: (( meta.consul_release_name ))
   - name: cloud_controller_worker
     release: (( meta.capi_release_name ))
+    consumes: {nats: nil}
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
 
@@ -1385,6 +1387,7 @@ meta:
     release: (( meta.consul_release_name ))
   - name: cloud_controller_clock
     release: (( meta.capi_release_name ))
+    consumes: {nats: nil}
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
 


### PR DESCRIPTION
- cloud_controller_ng
- cloud_controller_worker
- cloud_controller_job

This is to allow the job specs to optionally consume the link. Without
this change, the jobs don't know which of the multiple nats jobs to
consume the link from.