### PR TITLE
Consul job consumes nil consul links

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -27,6 +27,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: metron_agent
     release: cf
   update:
@@ -51,6 +52,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: metron_agent
     release: cf
   update:
@@ -71,6 +73,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: nats
@@ -95,6 +98,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: nats
@@ -126,6 +130,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: etcd
     release: cf
   - name: etcd_metrics_server
@@ -156,6 +161,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: etcd
     release: cf
   - name: etcd_metrics_server
@@ -178,6 +184,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: collector
     release: cf
   - name: metron_agent
@@ -210,6 +217,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: debian_nfs_server
     release: cf
   - name: metron_agent
@@ -248,6 +256,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: metron_agent
     release: cf
   - name: blobstore
@@ -271,6 +280,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: postgres
     release: cf
   - name: metron_agent
@@ -311,6 +321,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: uaa
     release: cf
   - name: metron_agent
@@ -357,6 +368,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: uaa
     release: cf
   - name: metron_agent
@@ -401,6 +413,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: java-buildpack
     release: cf
   - name: java-offline-buildpack
@@ -467,6 +480,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: java-buildpack
     release: cf
   - name: java-offline-buildpack
@@ -514,6 +528,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: cloud_controller_clock
@@ -541,6 +556,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: cloud_controller_worker
@@ -568,6 +584,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: cloud_controller_worker
@@ -601,6 +618,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: hm9000
     release: cf
   - name: metron_agent
@@ -636,6 +654,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: hm9000
     release: cf
   - name: metron_agent
@@ -669,6 +688,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: dea_next
     release: cf
   - name: dea_logging_agent
@@ -701,6 +721,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: dea_next
     release: cf
   - name: dea_logging_agent
@@ -724,6 +745,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: doppler
     release: cf
   - name: syslog_drain_binder
@@ -746,6 +768,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: doppler
     release: cf
   - name: syslog_drain_binder
@@ -775,6 +798,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: doppler
     release: cf
   - name: syslog_drain_binder
@@ -804,6 +828,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: doppler
     release: cf
   - name: syslog_drain_binder
@@ -840,6 +865,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent
@@ -880,6 +906,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent
@@ -909,6 +936,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: gorouter
@@ -934,6 +962,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: gorouter
@@ -957,6 +986,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: haproxy
     release: cf
   - name: metron_agent

--- a/spec/fixtures/bosh-lite/cf-manifest.yml
+++ b/spec/fixtures/bosh-lite/cf-manifest.yml
@@ -25,6 +25,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: metron_agent
     release: cf
   update:
@@ -48,6 +49,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: metron_agent
     release: cf
   update:
@@ -68,6 +70,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: nats
@@ -91,6 +94,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: nats
@@ -121,6 +125,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: etcd
     release: cf
   - name: etcd_metrics_server
@@ -150,6 +155,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: etcd
     release: cf
   - name: etcd_metrics_server
@@ -172,6 +178,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: collector
     release: cf
   - name: metron_agent
@@ -204,6 +211,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: debian_nfs_server
     release: cf
   - name: metron_agent
@@ -242,6 +250,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: metron_agent
     release: cf
   - name: blobstore
@@ -267,6 +276,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: postgres
     release: cf
   - name: metron_agent
@@ -308,6 +318,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: uaa
     release: cf
   - name: metron_agent
@@ -355,6 +366,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: uaa
     release: cf
   - name: metron_agent
@@ -399,6 +411,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: java-buildpack
     release: cf
   - name: java-offline-buildpack
@@ -473,6 +486,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: java-buildpack
     release: cf
   - name: java-offline-buildpack
@@ -520,6 +534,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: cloud_controller_clock
@@ -547,6 +562,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: cloud_controller_worker
@@ -574,6 +590,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: cloud_controller_worker
@@ -607,6 +624,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: hm9000
     release: cf
   - name: metron_agent
@@ -642,6 +660,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: hm9000
     release: cf
   - name: metron_agent
@@ -677,6 +696,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: dea_next
     release: cf
   - name: dea_logging_agent
@@ -709,6 +729,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: dea_next
     release: cf
   - name: dea_logging_agent
@@ -732,6 +753,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: doppler
     release: cf
   - name: syslog_drain_binder
@@ -754,6 +776,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: doppler
     release: cf
   - name: syslog_drain_binder
@@ -783,6 +806,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: doppler
     release: cf
   - name: syslog_drain_binder
@@ -812,6 +836,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: doppler
     release: cf
   - name: syslog_drain_binder
@@ -848,6 +873,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent
@@ -888,6 +914,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent
@@ -918,6 +945,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: gorouter
@@ -943,6 +971,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: gorouter
@@ -1022,6 +1051,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: haproxy
     release: cf
   - name: metron_agent

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -25,6 +25,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: metron_agent
     release: cf
   update:
@@ -48,6 +49,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: metron_agent
     release: cf
   update:
@@ -68,6 +70,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: nats
@@ -91,6 +94,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: nats
@@ -121,6 +125,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: etcd
     release: cf
   - name: etcd_metrics_server
@@ -150,6 +155,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: etcd
     release: cf
   - name: etcd_metrics_server
@@ -172,6 +178,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: collector
     release: cf
   - name: metron_agent
@@ -205,6 +212,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: debian_nfs_server
     release: cf
   - name: metron_agent
@@ -243,6 +251,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: metron_agent
     release: cf
   - name: blobstore
@@ -268,6 +277,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: postgres
     release: cf
   - name: metron_agent
@@ -309,6 +319,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: uaa
     release: cf
   - name: metron_agent
@@ -356,6 +367,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: uaa
     release: cf
   - name: metron_agent
@@ -400,6 +412,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: java-buildpack
     release: cf
   - name: java-offline-buildpack
@@ -474,6 +487,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: java-buildpack
     release: cf
   - name: java-offline-buildpack
@@ -521,6 +535,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: cloud_controller_clock
@@ -548,6 +563,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: cloud_controller_worker
@@ -575,6 +591,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: cloud_controller_worker
@@ -608,6 +625,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: hm9000
     release: cf
   - name: metron_agent
@@ -643,6 +661,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: hm9000
     release: cf
   - name: metron_agent
@@ -676,6 +695,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: dea_next
     release: cf
   - name: dea_logging_agent
@@ -708,6 +728,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: dea_next
     release: cf
   - name: dea_logging_agent
@@ -731,6 +752,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: doppler
     release: cf
   - name: syslog_drain_binder
@@ -753,6 +775,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: doppler
     release: cf
   - name: syslog_drain_binder
@@ -782,6 +805,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: doppler
     release: cf
   - name: syslog_drain_binder
@@ -811,6 +835,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: doppler
     release: cf
   - name: syslog_drain_binder
@@ -847,6 +872,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent
@@ -887,6 +913,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent
@@ -917,6 +944,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: gorouter
@@ -942,6 +970,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: gorouter
@@ -981,6 +1010,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: haproxy
     release: cf
   - name: metron_agent

--- a/spec/fixtures/openstack/cf-stub.yml
+++ b/spec/fixtures/openstack/cf-stub.yml
@@ -199,6 +199,7 @@ jobs:
     templates:
       - name: consul_agent
         release: cf
+        consumes: {consul: nil}
       - name: java-buildpack
         release: cf
       - name: java-offline-buildpack

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -28,6 +28,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: metron_agent
     release: cf
   update:
@@ -52,6 +53,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: metron_agent
     release: cf
   update:
@@ -72,6 +74,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: nats
@@ -96,6 +99,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: nats
@@ -127,6 +131,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: etcd
     release: cf
   - name: etcd_metrics_server
@@ -157,6 +162,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: etcd
     release: cf
   - name: etcd_metrics_server
@@ -179,6 +185,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: collector
     release: cf
   - name: metron_agent
@@ -212,6 +219,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: debian_nfs_server
     release: cf
   - name: metron_agent
@@ -250,6 +258,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: metron_agent
     release: cf
   - name: blobstore
@@ -275,6 +284,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: postgres
     release: cf
   - name: metron_agent
@@ -317,6 +327,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: uaa
     release: cf
   - name: metron_agent
@@ -365,6 +376,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: uaa
     release: cf
   - name: metron_agent
@@ -409,6 +421,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: java-buildpack
     release: cf
   - name: java-offline-buildpack
@@ -475,6 +488,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: java-buildpack
     release: cf
   - name: java-offline-buildpack
@@ -522,6 +536,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: cloud_controller_clock
@@ -549,6 +564,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: cloud_controller_worker
@@ -576,6 +592,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: cloud_controller_worker
@@ -609,6 +626,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: hm9000
     release: cf
   - name: metron_agent
@@ -644,6 +662,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: hm9000
     release: cf
   - name: metron_agent
@@ -677,6 +696,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: dea_next
     release: cf
   - name: dea_logging_agent
@@ -709,6 +729,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: dea_next
     release: cf
   - name: dea_logging_agent
@@ -732,6 +753,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: doppler
     release: cf
   - name: syslog_drain_binder
@@ -754,6 +776,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: doppler
     release: cf
   - name: syslog_drain_binder
@@ -783,6 +806,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: doppler
     release: cf
   - name: syslog_drain_binder
@@ -812,6 +836,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: doppler
     release: cf
   - name: syslog_drain_binder
@@ -848,6 +873,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent
@@ -888,6 +914,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: loggregator_trafficcontroller
     release: cf
   - name: metron_agent
@@ -918,6 +945,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: gorouter
@@ -944,6 +972,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - consumes:
       nats: nil
     name: gorouter
@@ -978,6 +1007,7 @@ jobs:
   templates:
   - name: consul_agent
     release: cf
+    consumes: {consul: nil}
   - name: haproxy
     release: cf
   - name: metron_agent

--- a/templates/cf-infrastructure-bosh-lite.yml
+++ b/templates/cf-infrastructure-bosh-lite.yml
@@ -1358,6 +1358,7 @@ jobs:
     templates:
       - name: consul_agent
         release: cf
+        consumes: {consul: nil}
       - name: java-buildpack
         release: cf
       - name: java-offline-buildpack

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -1367,6 +1367,7 @@ meta:
   api_worker_templates:
   - name: consul_agent
     release: (( meta.consul_release_name ))
+    consumes: {consul: nil}
   - name: cloud_controller_worker
     release: (( meta.capi_release_name ))
     consumes: {nats: nil}
@@ -1376,6 +1377,7 @@ meta:
   clock_templates:
   - name: consul_agent
     release: (( meta.consul_release_name ))
+    consumes: {consul: nil}
   - name: cloud_controller_clock
     release: (( meta.capi_release_name ))
     consumes: {nats: nil}
@@ -1385,12 +1387,14 @@ meta:
   consul_templates:
   - name: consul_agent
     release: (( meta.consul_release_name ))
+    consumes: {consul: nil}
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
 
   dea_templates:
   - name: consul_agent
     release: (( meta.consul_release_name ))
+    consumes: {consul: nil}
   - name: dea_next
     release: (( meta.cf_release_name ))
   - name: dea_logging_agent
@@ -1401,6 +1405,7 @@ meta:
   etcd_templates:
   - name: consul_agent
     release: (( meta.consul_release_name ))
+    consumes: {consul: nil}
   - name: etcd
     release: (( meta.etcd_release_name ))
   - name: etcd_metrics_server
@@ -1411,6 +1416,7 @@ meta:
   ha_proxy_templates:
   - name: consul_agent
     release: (( meta.consul_release_name ))
+    consumes: {consul: nil}
   - name: haproxy
     release: (( meta.cf_release_name ))
   - name: metron_agent
@@ -1428,6 +1434,7 @@ meta:
   hm9000_templates:
   - name: consul_agent
     release: (( meta.consul_release_name ))
+    consumes: {consul: nil}
   - name: hm9000
     release: (( meta.cf_release_name ))
   - name: metron_agent
@@ -1439,6 +1446,7 @@ meta:
   loggregator_templates:
   - name: consul_agent
     release: (( meta.consul_release_name ))
+    consumes: {consul: nil}
   - name: doppler
     release: (( meta.loggregator_release_name ))
   - name: syslog_drain_binder
@@ -1456,6 +1464,7 @@ meta:
   loggregator_trafficcontroller_templates:
   - name: consul_agent
     release: (( meta.consul_release_name ))
+    consumes: {consul: nil}
   - name: loggregator_trafficcontroller
     release: (( meta.loggregator_release_name ))
   - name: metron_agent
@@ -1467,6 +1476,7 @@ meta:
   nats_templates:
   - name: consul_agent
     release: (( meta.consul_release_name ))
+    consumes: {consul: nil}
   - name: nats
     consumes: {nats: nil}
     release: (( meta.cf_release_name ))
@@ -1487,6 +1497,7 @@ meta:
   blobstore_templates:
   - name: consul_agent
     release: (( meta.consul_release_name ))
+    consumes: {consul: nil}
   - name: metron_agent
     release: (( meta.loggregator_release_name ))
   - name: blobstore
@@ -1498,6 +1509,7 @@ meta:
   nfs_templates:
   - name: consul_agent
     release: (( meta.consul_release_name ))
+    consumes: {consul: nil}
   - name: debian_nfs_server
     release: (( meta.capi_release_name ))
   - name: metron_agent
@@ -1511,6 +1523,7 @@ meta:
   postgres_templates:
   - name: consul_agent
     release: (( meta.consul_release_name ))
+    consumes: {consul: nil}
   - name: postgres
     release: (( meta.postgres_release_name ))
   - name: metron_agent
@@ -1519,6 +1532,7 @@ meta:
   router_templates:
   - name: consul_agent
     release: (( meta.consul_release_name ))
+    consumes: {consul: nil}
   - name: gorouter
     release: (( meta.cf_release_name ))
     consumes: {nats: nil}
@@ -1528,6 +1542,7 @@ meta:
   stats_templates:
   - name: consul_agent
     release: (( meta.consul_release_name ))
+    consumes: {consul: nil}
   - name: collector
     release: (( meta.cf_release_name ))
   - name: metron_agent
@@ -1551,6 +1566,7 @@ meta:
   uaa_templates:
   - name: consul_agent
     release: (( meta.consul_release_name ))
+    consumes: {consul: nil}
   - name: uaa
     release: (( meta.uaa_release_name ))
   - name: metron_agent


### PR DESCRIPTION
This is to allow the job spec to optionally consume the link. Without
this change, the job don't know which of the multiple consul jobs to
consume the link from.

Signed-off-by: Derek Richard <drichard@pivotal.io>