### PR TITLE
adds ServiceProviderCertificate property to openstack stub

### DIFF
--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -1516,6 +1516,7 @@ properties:
     protocol: http
     restricted_ips_regex: null
     saml:
+      serviceProviderCertificate: SERVICE_PROVIDER_CERTIFICATE
       serviceProviderKey: SERVICE_PROVIDER_PRIVATE_KEY
     self_service_links_enabled: null
     smtp:

--- a/spec/fixtures/openstack/cf-stub.yml
+++ b/spec/fixtures/openstack/cf-stub.yml
@@ -107,6 +107,7 @@ properties:
   login:
     protocol: http
     saml:
+      serviceProviderCertificate: SERVICE_PROVIDER_CERTIFICATE
       serviceProviderKey: SERVICE_PROVIDER_PRIVATE_KEY
   nats:
     user: NATS_USER


### PR DESCRIPTION
We received a PR on our documentation requesting that this property be added because the user was not able to proceed without it. 