### PR TITLE
Take 2: Make clock_global into clock_z{1,2} to enable HA mode

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -517,7 +517,7 @@ jobs:
 - default_networks:
   - name: cf1
   instances: 1
-  name: clock_global
+  name: clock_z1
   networks:
   - name: cf1
   persistent_disk: 0
@@ -560,6 +560,27 @@ jobs:
   - consumes:
       nats: nil
     name: cloud_controller_worker
+    release: cf
+  - name: metron_agent
+    release: cf
+  update: {}
+- default_networks:
+  - name: cf2
+  instances: 1
+  name: clock_z2
+  networks:
+  - name: cf2
+  persistent_disk: 0
+  properties:
+    metron_agent:
+      zone: z2
+  resource_pool: medium_z2
+  templates:
+  - name: consul_agent
+    release: cf
+  - consumes:
+      nats: nil
+    name: cloud_controller_clock
     release: cf
   - name: metron_agent
     release: cf

--- a/spec/fixtures/bosh-lite/cf-manifest.yml
+++ b/spec/fixtures/bosh-lite/cf-manifest.yml
@@ -523,7 +523,7 @@ jobs:
 - default_networks:
   - name: cf1
   instances: 0
-  name: clock_global
+  name: clock_z1
   networks:
   - name: cf1
   persistent_disk: 4096
@@ -566,6 +566,27 @@ jobs:
   - consumes:
       nats: nil
     name: cloud_controller_worker
+    release: cf
+  - name: metron_agent
+    release: cf
+  update: {}
+- default_networks:
+  - name: cf2
+  instances: 0
+  name: clock_z2
+  networks:
+  - name: cf2
+  persistent_disk: 4096
+  properties:
+    metron_agent:
+      zone: z2
+  resource_pool: medium_z2
+  templates:
+  - name: consul_agent
+    release: cf
+  - consumes:
+      nats: nil
+    name: cloud_controller_clock
     release: cf
   - name: metron_agent
     release: cf

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -523,8 +523,8 @@ jobs:
   update: {}
 - default_networks:
   - name: cf1
-  instances: 0
-  name: clock_global
+  instances: 1
+  name: clock_z1
   networks:
   - name: cf1
   persistent_disk: 0
@@ -567,6 +567,27 @@ jobs:
   - consumes:
       nats: nil
     name: cloud_controller_worker
+    release: cf
+  - name: metron_agent
+    release: cf
+  update: {}
+- default_networks:
+  - name: cf2
+  instances: 1
+  name: clock_z2
+  networks:
+  - name: cf2
+  persistent_disk: 0
+  properties:
+    metron_agent:
+      zone: z2
+  resource_pool: medium_z2
+  templates:
+  - name: consul_agent
+    release: cf
+  - consumes:
+      nats: nil
+    name: cloud_controller_clock
     release: cf
   - name: metron_agent
     release: cf

--- a/spec/fixtures/openstack/cf-stub.yml
+++ b/spec/fixtures/openstack/cf-stub.yml
@@ -242,7 +242,7 @@ jobs:
 
   - name: api_worker_z1
     instances: 0
-  - name: clock_global
-    instances: 0
+  - name: clock_z1
+    instances: 1
 # code_snippet cf-stub-openstack end
 # The previous line helps maintain current documentation at http://docs.cloudfoundry.org.

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -525,7 +525,7 @@ jobs:
 - default_networks:
   - name: cf1
   instances: 1
-  name: clock_global
+  name: clock_z1
   networks:
   - name: cf1
   persistent_disk: 0
@@ -568,6 +568,27 @@ jobs:
   - consumes:
       nats: nil
     name: cloud_controller_worker
+    release: cf
+  - name: metron_agent
+    release: cf
+  update: {}
+- default_networks:
+  - name: cf2
+  instances: 1
+  name: clock_z2
+  networks:
+  - name: cf2
+  persistent_disk: 0
+  properties:
+    metron_agent:
+      zone: z2
+  resource_pool: medium_z2
+  templates:
+  - name: consul_agent
+    release: cf
+  - consumes:
+      nats: nil
+    name: cloud_controller_clock
     release: cf
   - name: metron_agent
     release: cf

--- a/templates/cf-infrastructure-bosh-lite.yml
+++ b/templates/cf-infrastructure-bosh-lite.yml
@@ -1457,7 +1457,10 @@ jobs:
   - name: api_z2
     persistent_disk: 4096
     instances: 0
-  - name: clock_global
+  - name: clock_z1
+    persistent_disk: 4096
+    instances: 0
+  - name: clock_z2
     persistent_disk: 4096
     instances: 0
   - name: api_worker_z2

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -251,7 +251,7 @@ jobs:
       nfs_server: (( meta.nfs_server ))
     update: (( merge || empty_hash ))
 
-  - name: clock_global
+  - name: clock_z1
     templates: (( merge || meta.clock_templates ))
     instances: 1
     resource_pool: medium_z1
@@ -276,6 +276,19 @@ jobs:
       metron_agent:
         zone: z1
       nfs_server: (( meta.nfs_server ))
+    update: (( merge || empty_hash ))
+
+  - name: clock_z2
+    templates: (( merge || meta.clock_templates ))
+    instances: 1
+    resource_pool: medium_z2
+    persistent_disk: 0
+    default_networks:
+      - name: cf2
+    networks: (( merge || default_networks ))
+    properties:
+      metron_agent:
+        zone: z2
     update: (( merge || empty_hash ))
 
   - name: api_worker_z2


### PR DESCRIPTION
## WARNING: Do not merge until CAPI release 1.22.0 has been merged into cf-release

- Updated HA clock implementation to avoid long-lived CPU locks which caused us to revert the previous implementation

This reverts commit 689d69b9becfc9520e2260b8a88b3e7302633f71.

[#139564797]

Signed-off-by: Eric Promislow <eric.promislow@gmail.com>