### PR TITLE
Remove use of alias in the commit script

### DIFF
--- a/scripts/commit_with_shortlog
+++ b/scripts/commit_with_shortlog
@@ -1,4 +1,4 @@
 #!/bin/bash
 script_dir=$(dirname $0)
 
-$script_dir/staged_shortlog | git ci -F -
+$script_dir/staged_shortlog | git commit -F -


### PR DESCRIPTION
We are running this script in CI where the alias `ci` does not exist. Since there is no guarantee what `ci` is aliased to I would recommend being explicit with the command.