### PR TITLE
Add temporary_cc_uploader_mtls property to manifests

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -1137,6 +1137,7 @@ properties:
       temporary_local_tasks: null
       temporary_local_sync: null
       temporary_local_tps: null
+      temporary_cc_uploader_mtls: null
       use_privileged_containers_for_staging: null
     directories: null
     disable_custom_buildpacks: false

--- a/spec/fixtures/bosh-lite/cf-manifest.yml
+++ b/spec/fixtures/bosh-lite/cf-manifest.yml
@@ -2946,6 +2946,7 @@ properties:
       temporary_local_tasks: false
       temporary_local_sync: false
       temporary_local_tps: false
+      temporary_cc_uploader_mtls: false
       use_privileged_containers_for_staging: null
     directories: null
     disable_custom_buildpacks: false

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -1167,6 +1167,7 @@ properties:
       temporary_local_tasks: null
       temporary_local_sync: null
       temporary_local_tps: null
+      temporary_cc_uploader_mtls: null
       use_privileged_containers_for_staging: null
     directories: null
     disable_custom_buildpacks: false

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -1155,6 +1155,7 @@ properties:
       temporary_local_tasks: null
       temporary_local_sync: null
       temporary_local_tps: null
+      temporary_cc_uploader_mtls: null
       use_privileged_containers_for_staging: null
     directories: null
     disable_custom_buildpacks: false

--- a/templates/cf-infrastructure-bosh-lite.yml
+++ b/templates/cf-infrastructure-bosh-lite.yml
@@ -729,6 +729,7 @@ properties:
       temporary_local_apps: false
       temporary_local_sync: false
       temporary_local_tps: false
+      temporary_cc_uploader_mtls: false
 
     mutual_tls:
       ca_cert: |

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -776,6 +776,7 @@ properties:
       temporary_local_apps: (( merge || nil ))
       temporary_local_sync: (( merge || nil ))
       temporary_local_tps: (( merge || nil ))
+      temporary_cc_uploader_mtls: (( merge || nil ))
       bbs:
         url: (( merge || nil ))
     tls_port: (( merge || nil ))


### PR DESCRIPTION
- This flag tells CC whether to hand out mutual TLS droplet upload URLs to diego or the existing HTTP URLs

Signed-off-by: Sandy Cash <scarlet.tanager@gmail.com>

[#139996781]