### PR TITLE
Add errand to run smoke-tests on windows

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,6 @@
----
+cli/cf-cli_6.23.1_winx64.zip:
+  size: 6759874
+  sha: 22c09fbaaaed4ed305896de28a3c1bf9b346ff93
 debian_nfs_server/nfs-kernel-server_1%3a1.2.0-4ubuntu4.1_amd64.deb:
   object_id: rest/objects/4e4e78bca41e122204e4e9863d076304f307136db190
   sha: a44b3f8319984bace61f21bb6d15cee1419e5bf3

--- a/jobs/smoke-tests-windows/spec
+++ b/jobs/smoke-tests-windows/spec
@@ -1,0 +1,64 @@
+---
+name: smoke-tests-windows
+
+description: "The smoke tests errand can be configured to run quick set of tests against a specific Cloud Foundry API endpoint to determine is basic push-application functionality works. Consider running the acceptance tests errand for a more extensive set of tests."
+
+packages:
+  - golang1.7-windows
+  - cli-windows
+  - smoke-tests-windows
+
+templates:
+  run.ps1.erb: bin/run.ps1
+  config.json.erb: bin/config.json
+
+properties:
+  smoke_tests.suite_name:
+    default: CF_SMOKE_TESTS
+    description: A token used by the tests when creating Apps / Spaces
+  smoke_tests.api:
+    description: The Elastic Runtime API endpoint URL
+  smoke_tests.apps_domain:
+    description: The Elastic Runtime Application Domain
+  smoke_tests.user:
+    description: The Elastic Runtime API user
+  smoke_tests.password:
+    description: The Elastic Runtime API user's password
+  smoke_tests.org:
+    description: The Elastic Runtime organization name to use when running tests
+  smoke_tests.space:
+    description: The Elastic Runtime space name to use when running tests
+  smoke_tests.use_existing_org:
+    default: false
+    description: Toggles setup and cleanup of the Elastic Runtime organization
+  smoke_tests.use_existing_space:
+    default: false
+    description: Toggles setup and cleanup of the Elastic Runtime space
+  smoke_tests.logging_app:
+    default: ''
+    description: The Elastic Runtime app name to use when running logging tests
+  smoke_tests.runtime_app:
+    default: ''
+    description: The Elastic Runtime app name to use when running runtime tests
+  smoke_tests.skip_ssl_validation:
+    default: false
+    description: Toggles cli verification of the Elastic Runtime API SSL certificate
+  smoke_tests.ginkgo_opts:
+    default: ''
+    description: Ginkgo options for the smoke tests
+  smoke_tests.enable_windows_tests:
+    default: false
+    description: Toggles a portion of the suite that exercises Windows platform support
+  smoke_tests.artifacts_directory:
+    description: The directory in which to store test CF_TRACE output.
+  smoke_tests.backend:
+    default: ''
+    description: Defines the backend to be used. ('dea', 'diego', '' (default))
+  smoke_tests.cf_dial_timeout_in_seconds:
+    description: Sets the cli timeout (CF_DIAL_TIMEOUT)
+  smoke_tests.enable_etcd_cluster_check_tests:
+    default: false
+    description: Sets to validate the security of your etcd cluster; Must provide 'etcd_ip_address' along
+  smoke_tests.etcd_ip_address:
+    default: ''
+    description: Etcd ip address to use when running etcd cluster check tests

--- a/jobs/smoke-tests-windows/templates/config.json.erb
+++ b/jobs/smoke-tests-windows/templates/config.json.erb
@@ -1,0 +1,42 @@
+<%
+  def discover_external_ip
+    networks = spec.networks.marshal_dump
+
+    _, network = networks.find do |_name, network_spec|
+      network_spec.default
+    end
+
+    if !network
+      _, network = networks.first
+    end
+
+    if !network
+      raise "Could not determine IP via network spec: #{networks}"
+    end
+
+    network.ip
+  end
+%>
+{
+<% if_p("smoke_tests.artifacts_directory") do |artifacts_directory| %>
+  "artifacts_directory"             : "<%= artifacts_directory %>",
+<% end %>
+  "suite_name"                      : "<%= properties.smoke_tests.suite_name %>",
+  "api"                             : "<%= properties.smoke_tests.api %>",
+  "apps_domain"                     : "<%= Array(properties.smoke_tests.apps_domain).first %>",
+  "user"                            : "<%= properties.smoke_tests.user %>",
+  "password"                        : "<%= properties.smoke_tests.password %>",
+  "org"                             : "<%= properties.smoke_tests.org %>",
+  "space"                           : "<%= properties.smoke_tests.space %>",
+  "use_existing_org"                : <%= properties.smoke_tests.use_existing_org %>,
+  "use_existing_space"              : <%= properties.smoke_tests.use_existing_space %>,
+  "logging_app"                     : "<%= properties.smoke_tests.logging_app %>",
+  "runtime_app"                     : "<%= properties.smoke_tests.runtime_app %>",
+  "skip_ssl_validation"             : <%= properties.smoke_tests.skip_ssl_validation %>,
+  "syslog_drain_port"               : 514,
+  "syslog_ip_address"               : "<%= discover_external_ip %>",
+  "enable_windows_tests"            : <%= properties.smoke_tests.enable_windows_tests %>,
+  "backend"                         : "<%= properties.smoke_tests.backend %>",
+  "enable_etcd_cluster_check_tests" : <%= properties.smoke_tests.enable_etcd_cluster_check_tests %>,
+  "etcd_ip_address"                 : "<%= properties.smoke_tests.etcd_ip_address %>"
+}

--- a/jobs/smoke-tests-windows/templates/run.ps1.erb
+++ b/jobs/smoke-tests-windows/templates/run.ps1.erb
@@ -1,0 +1,31 @@
+$env:GOROOT="C:\var\vcap\packages\golang1.7-windows\go"
+$env:GOPATH="C:\var\vcap\packages\smoke-tests-windows"
+$env:PATH="${env:GOPATH}\bin;${env:GOROOT}\bin;${env:PATH}"
+$env:PATH="C:\var\vcap\packages\cli-windows\bin;${env:PATH}"
+
+cd "C:\var\vcap\packages\smoke-tests-windows\src\github.com\cloudfoundry\cf-smoke-tests"
+
+Create-Item -Type Directory -Force "${env:GOPATH}\src"
+Copy-Item -Recurse -Force ".\vendor\*" "${env:GOPATH}\src"
+
+go install github.com/onsi/ginkgo/ginkgo
+
+$env:CONFIG="C:\var\vcap\jobs\smoke-tests-windows\bin\config.json"
+<% if_p("smoke_tests.cf_dial_timeout_in_seconds") do |timeout| %>
+$env:CF_DIAL_TIMEOUT="<%= timeout %>"
+<% end %>
+
+Write-Host '################################################################################################################'
+go version
+Write-Host CONFIG=${env:CONFIG}
+Get-ChildItem env:
+Write-Host '################################################################################################################'
+
+Write-Host "Running smoke tests..."
+
+$EXITSTATUS=0
+ginkgo -r --succinct -slowSpecThreshold=300 <%= properties.smoke_tests.ginkgo_opts %>
+$EXITSTATUS=$LASTEXITCODE
+
+Write-Host "Smoke Tests Complete; exit status: $EXITSTATUS"
+exit $EXITSTATUS

--- a/packages/cli-windows/packaging
+++ b/packages/cli-windows/packaging
@@ -1,0 +1,23 @@
+. ./exiter.ps1
+$path = "cli/cf-cli_6.23.1_winx64.zip"
+$installTarget = "${env:BOSH_INSTALL_TARGET}/bin"
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+function Unzip {
+  param(
+    [string]$zipfile,
+    [string]$outpath
+  )
+
+  [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
+}
+
+try {
+  New-Item -Path $installTarget -ItemType directory -Force
+  Unzip $path $installTarget
+} catch {
+  $Host.UI.WriteErrorLine($_.Exception.Message)
+  Exit 1
+}
+
+Exit 0

--- a/packages/cli-windows/spec
+++ b/packages/cli-windows/spec
@@ -1,0 +1,5 @@
+---
+name: cli-windows
+files:
+  - exiter.ps1
+  - cli/cf-cli_6.23.1_winx64.zip

--- a/packages/smoke-tests-windows/packaging
+++ b/packages/smoke-tests-windows/packaging
@@ -1,0 +1,5 @@
+$REPO_DIR="${env:BOSH_INSTALL_TARGET}\src\github.com\cloudfoundry\cf-smoke-tests"
+
+mkdir ${REPO_DIR}
+
+Copy-Item -Recurse smoke-tests\* ${REPO_DIR}

--- a/packages/smoke-tests-windows/spec
+++ b/packages/smoke-tests-windows/spec
@@ -1,0 +1,10 @@
+---
+name: smoke-tests-windows
+dependencies:
+  - cli
+files:
+  - smoke-tests/**/*
+excluded_files:
+  - smoke-tests-windows/smoke/results/*
+  - smoke-tests-windows/*config.json
+  - smoke-tests-windows/**/*.test


### PR DESCRIPTION
This errand can be run on a windows machine. It depends on https://github.com/cloudfoundry/cf-smoke-tests/pull/25.

@mdelillo @pnikonowicz