### PR TITLE
Don't consume etcd link

### DIFF
--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -1433,6 +1433,7 @@ meta:
     consumes: {consul: nil}
   - name: etcd
     release: (( meta.etcd_release_name ))
+    consumes: {etcd: nil}
   - name: etcd_metrics_server
     release: (( meta.etcd_release_name ))
   - name: metron_agent


### PR DESCRIPTION
Once a new etcd-release is cut with links, we don't want to consume it within cf-release.

Thanks,
Christian and Nick