### PR TITLE
Optionally consume a router link for haproxy router servers

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -20,6 +20,10 @@ consumes:
     type: ssh_proxy
     optional: true
 
+  - name: router
+    type: router
+    optional: true
+
 properties:
   ha_proxy.ssl_pem:
     description: "SSL certificate (PEM file)"

--- a/jobs/haproxy/templates/haproxy.conf.erb
+++ b/jobs/haproxy/templates/haproxy.conf.erb
@@ -52,11 +52,21 @@ frontend ssl-in
     default_backend tcp-routers
 <% end %>
 
+<%
+  ips = []
+
+  if_p("router.servers") do |servers|
+    ips = servers
+  end.else do
+    ips = link("router").instances.map(&:address)
+  end
+%>
+
 backend http-routers
     mode http
     balance roundrobin
 
-    <% p("router.servers").each_with_index do |ip, index| %>
+    <% ips.each_with_index do |ip, index| %>
         server node<%= index %> <%= ip %>:<%= p("router.port") %> check inter 1000
     <% end %>
 
@@ -64,7 +74,7 @@ backend tcp-routers
     mode tcp
     balance roundrobin
 
-    <% p("router.servers").each_with_index do |ip, index| %>
+    <% ips.each_with_index do |ip, index| %>
         server node<%= index %> <%= ip %>:<%= p("router.port") %> check inter 1000
     <% end %>
 

--- a/jobs/haproxy/templates/haproxy.ctmpl.erb
+++ b/jobs/haproxy/templates/haproxy.ctmpl.erb
@@ -52,11 +52,21 @@ frontend ssl-in
     default_backend tcp-routers
 <% end %>
 
+<%
+  ips = []
+
+  if_p("router.servers") do |servers|
+    ips = servers
+  end.else do
+    ips = link("router").instances.map(&:address)
+  end
+%>
+
 backend http-routers
     mode http
     balance roundrobin
 
-    <% p("router.servers").each_with_index do |ip, index| %>
+    <% ips.each_with_index do |ip, index| %>
         server node<%= index %> <%= ip %>:<%= p("router.port") %> check inter 1000
     <% end %>
 
@@ -64,7 +74,7 @@ backend tcp-routers
     mode tcp
     balance roundrobin
 
-    <% p("router.servers").each_with_index do |ip, index| %>
+    <% ips.each_with_index do |ip, index| %>
         server node<%= index %> <%= ip %>:<%= p("router.port") %> check inter 1000
     <% end %>
 


### PR DESCRIPTION
This simplifies deployment manifests by allowing operators to rely on links to provide this information (e.g. from the gorouter) rather than needing to configure properties.