### PR TITLE
Don't deploy clock_z2 on OpenStack

### DIFF
--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -575,7 +575,7 @@ jobs:
   update: {}
 - default_networks:
   - name: cf2
-  instances: 1
+  instances: 0
   name: clock_z2
   networks:
   - name: cf2

--- a/templates/cf-infrastructure-openstack.yml
+++ b/templates/cf-infrastructure-openstack.yml
@@ -244,3 +244,6 @@ jobs:
 
   - name: runner_z2
     instances: 0
+
+  - name: clock_z2
+    instances: 0


### PR DESCRIPTION
* all `_z2` vms should be set to zero instances, per comments in
  `templates/cf-infrastructure-openstack.yml`
```
 This config is for the simplest Openstack config using just one AZ.
 All values for "z2" and network "cf2" are set to null. They'll end up
 in the final 'spiff merge' manifest with zero instances.
```
* fixes #1180