### PR TITLE
Rename router link type to http-router

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -21,7 +21,7 @@ consumes:
     optional: true
 
   - name: router
-    type: router
+    type: http-router
     optional: true
 
 properties:


### PR DESCRIPTION
This reflects a change in gorouter when providing the link