### PR TITLE
Use router link when property is missing

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -51,7 +51,6 @@ properties:
     default: 900
   router.servers:
     description: "Array of router IPs"
-    default: []
   router.port:
     description: "Listening port for Router"
     default: 80

--- a/jobs/haproxy/templates/haproxy.conf.erb
+++ b/jobs/haproxy/templates/haproxy.conf.erb
@@ -57,8 +57,8 @@ frontend ssl-in
 
   if_p("router.servers") do |servers|
     ips = servers
-  end.else do
-    ips = link("router").instances.map(&:address)
+  end.else_if_link("router") do |router|
+    ips = router.instances.map(&:address)
   end
 %>
 


### PR DESCRIPTION
This fixes two issues with my previous PR:

1. Because router.servers defaulted to [], if the property was not
defined in the deployment manifest, it would be defaulted and the link
would not be used.

2. The original behavior did not error if no servers were specified. The
previous change would error if the property and link were both not
present. This now safely defaults to [].