### PR TITLE
Adds exiter hack to smoke-tests-windows

### DIFF
--- a/packages/smoke-tests-windows/packaging
+++ b/packages/smoke-tests-windows/packaging
@@ -1,3 +1,5 @@
+. ./exiter.ps1
+
 $REPO_DIR="${env:BOSH_INSTALL_TARGET}\src\github.com\cloudfoundry\cf-smoke-tests"
 
 mkdir ${REPO_DIR}

--- a/packages/smoke-tests-windows/spec
+++ b/packages/smoke-tests-windows/spec
@@ -4,6 +4,7 @@ dependencies:
   - cli
 files:
   - smoke-tests/**/*
+  - exiter.ps1
 excluded_files:
   - smoke-tests-windows/smoke/results/*
   - smoke-tests-windows/*config.json


### PR DESCRIPTION
- this allows for cf-release to be precompiled on a Linux stemcell

[#143845067]