### PR TITLE
Allow variables section to be specified in stub

### DIFF
--- a/templates/generic-manifest-mask.yml
+++ b/templates/generic-manifest-mask.yml
@@ -15,3 +15,5 @@ compilation: (( merge ))
 update: (( merge ))
 
 resource_pools: (( merge ))
+
+variables: (( merge ))

--- a/templates/generic-manifest-mask.yml
+++ b/templates/generic-manifest-mask.yml
@@ -16,4 +16,4 @@ update: (( merge ))
 
 resource_pools: (( merge ))
 
-variables: (( merge ))
+variables: (( merge || nil ))


### PR DESCRIPTION
If operators wish to use the variable related features in the bosh CLI, this should allow them to specify a variables section in their stub and have it appear in the final manifest.