### PR TITLE
Reorder buildpacks

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -1091,6 +1091,8 @@ properties:
       package: java-buildpack
     - name: ruby_buildpack
       package: ruby-buildpack
+    - name: dotnet_core_buildpack
+      package: dotnet-core-buildpack
     - name: nodejs_buildpack
       package: nodejs-buildpack
     - name: go_buildpack
@@ -1101,8 +1103,6 @@ properties:
       package: php-buildpack
     - name: binary_buildpack
       package: binary-buildpack
-    - name: dotnet_core_buildpack
-      package: dotnet-core-buildpack
     default_health_check_timeout: 60
     default_quota_definition: default
     default_running_security_groups:
@@ -1158,6 +1158,8 @@ properties:
       package: java-buildpack
     - name: ruby_buildpack
       package: ruby-buildpack
+    - name: dotnet_core_buildpack
+      package: dotnet-core-buildpack
     - name: nodejs_buildpack
       package: nodejs-buildpack
     - name: go_buildpack
@@ -1168,8 +1170,6 @@ properties:
       package: php-buildpack
     - name: binary_buildpack
       package: binary-buildpack
-    - name: dotnet_core_buildpack
-      package: dotnet-core-buildpack
     internal_api_password: BULK_API_PASSWORD
     internal_api_user: internal_user
     internal_service_hostname: cloud-controller-ng.service.cf.internal
@@ -1294,6 +1294,8 @@ properties:
       package: java-buildpack
     - name: ruby_buildpack
       package: ruby-buildpack
+    - name: dotnet_core_buildpack
+      package: dotnet-core-buildpack
     - name: nodejs_buildpack
       package: nodejs-buildpack
     - name: go_buildpack
@@ -1304,8 +1306,6 @@ properties:
       package: php-buildpack
     - name: binary_buildpack
       package: binary-buildpack
-    - name: dotnet_core_buildpack
-      package: dotnet-core-buildpack
     system_hostnames: null
     thresholds:
       api:

--- a/spec/fixtures/bosh-lite/cf-manifest.yml
+++ b/spec/fixtures/bosh-lite/cf-manifest.yml
@@ -2894,6 +2894,8 @@ properties:
       package: java-buildpack
     - name: ruby_buildpack
       package: ruby-buildpack
+    - name: dotnet_core_buildpack
+      package: dotnet-core-buildpack
     - name: nodejs_buildpack
       package: nodejs-buildpack
     - name: go_buildpack
@@ -2904,8 +2906,6 @@ properties:
       package: php-buildpack
     - name: binary_buildpack
       package: binary-buildpack
-    - name: dotnet_core_buildpack
-      package: dotnet-core-buildpack
     default_health_check_timeout: 60
     default_quota_definition: default
     default_running_security_groups:
@@ -2981,6 +2981,8 @@ properties:
       package: java-buildpack
     - name: ruby_buildpack
       package: ruby-buildpack
+    - name: dotnet_core_buildpack
+      package: dotnet-core-buildpack
     - name: nodejs_buildpack
       package: nodejs-buildpack
     - name: go_buildpack
@@ -2991,8 +2993,6 @@ properties:
       package: php-buildpack
     - name: binary_buildpack
       package: binary-buildpack
-    - name: dotnet_core_buildpack
-      package: dotnet-core-buildpack
     internal_api_password: internal-password
     internal_api_user: internal_user
     internal_service_hostname: cloud-controller-ng.service.cf.internal
@@ -3248,6 +3248,8 @@ properties:
       package: java-buildpack
     - name: ruby_buildpack
       package: ruby-buildpack
+    - name: dotnet_core_buildpack
+      package: dotnet-core-buildpack
     - name: nodejs_buildpack
       package: nodejs-buildpack
     - name: go_buildpack
@@ -3258,8 +3260,6 @@ properties:
       package: php-buildpack
     - name: binary_buildpack
       package: binary-buildpack
-    - name: dotnet_core_buildpack
-      package: dotnet-core-buildpack
     system_hostnames: null
     thresholds:
       api:

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -1119,6 +1119,8 @@ properties:
       package: java-buildpack
     - name: ruby_buildpack
       package: ruby-buildpack
+    - name: dotnet_core_buildpack
+      package: dotnet-core-buildpack
     - name: nodejs_buildpack
       package: nodejs-buildpack
     - name: go_buildpack
@@ -1129,8 +1131,6 @@ properties:
       package: php-buildpack
     - name: binary_buildpack
       package: binary-buildpack
-    - name: dotnet_core_buildpack
-      package: dotnet-core-buildpack
     default_health_check_timeout: 60
     default_quota_definition: default
     default_running_security_groups:
@@ -1181,6 +1181,8 @@ properties:
       package: java-buildpack
     - name: ruby_buildpack
       package: ruby-buildpack
+    - name: dotnet_core_buildpack
+      package: dotnet-core-buildpack
     - name: nodejs_buildpack
       package: nodejs-buildpack
     - name: go_buildpack
@@ -1191,8 +1193,6 @@ properties:
       package: php-buildpack
     - name: binary_buildpack
       package: binary-buildpack
-    - name: dotnet_core_buildpack
-      package: dotnet-core-buildpack
     internal_api_password: BULK_API_PASSWORD
     internal_api_user: internal_user
     internal_service_hostname: cloud-controller-ng.service.cf.internal
@@ -1307,6 +1307,8 @@ properties:
       package: java-buildpack
     - name: ruby_buildpack
       package: ruby-buildpack
+    - name: dotnet_core_buildpack
+      package: dotnet-core-buildpack
     - name: nodejs_buildpack
       package: nodejs-buildpack
     - name: go_buildpack
@@ -1317,8 +1319,6 @@ properties:
       package: php-buildpack
     - name: binary_buildpack
       package: binary-buildpack
-    - name: dotnet_core_buildpack
-      package: dotnet-core-buildpack
     system_hostnames: null
     thresholds:
       api:

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -1107,6 +1107,8 @@ properties:
       package: java-buildpack
     - name: ruby_buildpack
       package: ruby-buildpack
+    - name: dotnet_core_buildpack
+      package: dotnet-core-buildpack
     - name: nodejs_buildpack
       package: nodejs-buildpack
     - name: go_buildpack
@@ -1117,8 +1119,6 @@ properties:
       package: php-buildpack
     - name: binary_buildpack
       package: binary-buildpack
-    - name: dotnet_core_buildpack
-      package: dotnet-core-buildpack
     default_health_check_timeout: 60
     default_quota_definition: default
     default_running_security_groups:
@@ -1169,6 +1169,8 @@ properties:
       package: java-buildpack
     - name: ruby_buildpack
       package: ruby-buildpack
+    - name: dotnet_core_buildpack
+      package: dotnet-core-buildpack
     - name: nodejs_buildpack
       package: nodejs-buildpack
     - name: go_buildpack
@@ -1179,8 +1181,6 @@ properties:
       package: php-buildpack
     - name: binary_buildpack
       package: binary-buildpack
-    - name: dotnet_core_buildpack
-      package: dotnet-core-buildpack
     internal_api_password: BULK_API_PASSWORD
     internal_api_user: internal_user
     internal_service_hostname: cloud-controller-ng.service.cf.internal
@@ -1295,6 +1295,8 @@ properties:
       package: java-buildpack
     - name: ruby_buildpack
       package: ruby-buildpack
+    - name: dotnet_core_buildpack
+      package: dotnet-core-buildpack
     - name: nodejs_buildpack
       package: nodejs-buildpack
     - name: go_buildpack
@@ -1305,8 +1307,6 @@ properties:
       package: php-buildpack
     - name: binary_buildpack
       package: binary-buildpack
-    - name: dotnet_core_buildpack
-      package: dotnet-core-buildpack
     system_hostnames: null
     thresholds:
       api:

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -822,6 +822,8 @@ properties:
         package: java-buildpack
       - name: ruby_buildpack
         package: ruby-buildpack
+      - name: dotnet_core_buildpack
+        package: dotnet-core-buildpack
       - name: nodejs_buildpack
         package: nodejs-buildpack
       - name: go_buildpack
@@ -832,8 +834,6 @@ properties:
         package: php-buildpack
       - name: binary_buildpack
         package: binary-buildpack
-      - name: dotnet_core_buildpack
-        package: dotnet-core-buildpack
 
     install_buildpacks: (( system_buildpacks user_buildpacks ))
 


### PR DESCRIPTION
Move dotnet buildpack before nodejs buildpack.

New dotnet projects include package.json at the root.

Signed-off-by: Sam Coward <scoward@pivotal.io>