### PR TITLE
Support uaa.limitedFunctionality in UAA job

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -1631,6 +1631,13 @@ properties:
       signing_key: JWT_SIGNING_KEY
       verification_key: JWT_VERIFICATION_KEY
     ldap: null
+    limitedFunctionality:
+      enabled: true
+      whitelist:
+        endpoints:
+          - UAA_WHITELISTED_ENDPOINT
+        methods:
+          - UAA_WHITELISTED_METHOD
     login: null
     newrelic: null
     no_ssl: null

--- a/spec/fixtures/aws/cf-stub.yml
+++ b/spec/fixtures/aws/cf-stub.yml
@@ -172,6 +172,14 @@ properties:
         - doppler.firehose
     sslCertificate: UAA_SERVER_CERT
     sslPrivateKey: UAA_SERVER_KEY
+
+    limitedFunctionality:
+      enabled: true
+      whitelist:
+        endpoints:
+          - UAA_WHITELISTED_ENDPOINT
+        methods:
+          - UAA_WHITELISTED_METHOD
   uaadb:
     db_scheme: UAADB_SCHEME
     roles:

--- a/spec/fixtures/bosh-lite/cf-manifest.yml
+++ b/spec/fixtures/bosh-lite/cf-manifest.yml
@@ -4198,6 +4198,11 @@ properties:
               4SlotYRHgPCEubokb2S1zfZDWIXW3HmggnGgM949TlY=
               -----END RSA PRIVATE KEY-----
     ldap: null
+    limitedFunctionality:
+      enabled: null
+      whitelist:
+        endpoints: null
+        methods: null
     login: null
     newrelic: null
     no_ssl: null

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -1657,6 +1657,11 @@ properties:
       signing_key: JWT_SIGNING_KEY
       verification_key: JWT_VERIFICATION_KEY
     ldap: null
+    limitedFunctionality:
+      enabled: null
+      whitelist:
+        endpoints: null
+        methods: null
     login: null
     newrelic: null
     no_ssl: null

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -1649,6 +1649,11 @@ properties:
       signing_key: JWT_SIGNING_KEY
       verification_key: JWT_VERIFICATION_KEY
     ldap: null
+    limitedFunctionality:
+      enabled: null
+      whitelist:
+        endpoints: null
+        methods: null
     login: null
     newrelic: null
     no_ssl: null

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -917,6 +917,10 @@ properties:
     no_ssl: ~
     require_https: ~
 
+    limitedFunctionality:
+      enabled: (( merge || nil ))
+      whitelist: (( merge || nil ))
+
     scim:
       userids_enabled: (( merge || true ))
       users: (( merge ))

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -919,7 +919,9 @@ properties:
 
     limitedFunctionality:
       enabled: (( merge || nil ))
-      whitelist: (( merge || nil ))
+      whitelist:
+        endpoints: (( merge || nil ))
+        methods: (( merge || nil ))
 
     scim:
       userids_enabled: (( merge || true ))


### PR DESCRIPTION
Add manifest generation support for `uaa.limitedFunctionality` in the UAA job.

Story: https://www.pivotaltracker.com/story/show/151223422

- Aakash & @6palace 