### PR TITLE
Refactor certificates generation scripts

### DIFF
--- a/on-tls-certificates.md
+++ b/on-tls-certificates.md
@@ -77,10 +77,10 @@ used by the Cloud Controller's interactions with other components.
 #### Consul
 Generate the certs and keys:
 ```
-./scripts/generate-consul-certs
+./scripts/generate-consul-certs [--with-ca]
 ```
 
-The script creates a CA for consul,
+The script creates a CA (if the parameter `--with-ca` is given) for consul,
 generates a keypair for both the agents and servers,
 and signs the them with the CA.
 Place the following generated values in the your stub or manifest:
@@ -96,10 +96,10 @@ Place the following generated values in the your stub or manifest:
 #### Etcd
 Generate the certs and keys:
 ```
-./scripts/generate-etcd-certs
+./scripts/generate-etcd-certs [--with-ca]
 ```
 
-The script creates two CAs,
+The script creates two CAs (if the parameter `--with-ca` is given),
 one for client/server interactions
 and another for internal peer interaction.
 It uses those CAs to sign the three keypairs it generates.
@@ -118,10 +118,10 @@ It uses those CAs to sign the three keypairs it generates.
 #### Blobstore (if you're deploying your own)
 Generate the certs and keys:
 ```
-./scripts/generate-blobstore-certs
+./scripts/generate-blobstore-certs [--with-ca]
 ```
 
-The script generates a CA and a certificate for the WebDAV blobstore.
+The script generates a CA (if the parameter `--with-ca` is given) and a certificate for the WebDAV blobstore.
 
 | Script Output | Properties |
 | ------------- | ---------- |
@@ -132,10 +132,10 @@ The script generates a CA and a certificate for the WebDAV blobstore.
 #### UAA
 Generate the certs and keys:
 ```
-./scripts/generate-uaa-certs
+./scripts/generate-uaa-certs [--with-ca]
 ```
 
-The script generates a CA and sert for the UAA.
+The script generates a CA (if the parameter `--with-ca` is given) and sert for the UAA.
 
 | Script Output | Properties |
 | ------------- | ---------- |
@@ -148,11 +148,11 @@ The script generates a CA and sert for the UAA.
 #### First, generate the `cf-diego-ca`
 Generate the certs and keys:
 ```
-./scripts/generate-cf-diego-certs
+./scripts/generate-cf-diego-certs [--with-ca]
 ```
 
 The script generates mutual TLS certs for the Cloud Controller,
-as well as the `cf-diego-ca` that will be used to sign other certificates.
+as well as the `cf-diego-ca` (if the parameter `--with-ca` is given) that will be used to sign other certificates.
 
 | Script Output | Properties |
 | ------------- | -------- |
@@ -181,12 +181,12 @@ These certs must be signed by `cf-diego-ca`:
 #### Generate the certificates for Loggregator
 Generate the certificates and keys:
 ```
-./scripts/generate-loggregator-certs cf-diego-certs/cf-diego-ca.crt cf-diego-certs/cf-diego-ca.key
+./scripts/generate-loggregator-certs cf-diego-certs/cf-diego-ca.crt cf-diego-certs/cf-diego-ca.key [--with-ca]
 ```
 
 This script creates certificates
 for traffic controller, doppler, metron, and syslog_drain_binder.
-The first three certificates are signed by a newly-generated loggregatorCA,
+The first three certificates are signed by a newly-generated (if the parameter `--with-ca` is given) loggregatorCA,
 and the syslog_drain_binder is signed by the `cf-diego-ca`.
 
 | Script Output | Properties |

--- a/scripts/generate-blobstore-certs
+++ b/scripts/generate-blobstore-certs
@@ -1,19 +1,20 @@
-#!/bin/bash
-set -e -x
+#!/usr/bin/env bash
 
-# Install certstrap
-go get -v github.com/square/certstrap
+set -e
 
-scripts_folder=$(dirname $0)
+scripts_folder="$(dirname "$0")"
 
 # Place keys and certificates here
 depot_path="blobstore-certs"
-mkdir -p ${depot_path}
+mkdir -p "${depot_path}"
+ca_name="blobstore-ca"
 
-# CA to generate server cert
-${scripts_folder}/generate_ca_cert --common-name "cert-authority" --depot-path ${depot_path} --output-file server-ca
+if [[ "$1" == "--recreate-ca" ]] || [[ -z "$1" && ! -f "$depot_path/$ca_name.crt" ]]; then
+  "${scripts_folder}"/generate_ca_cert --common-name "blobstoreCA" --depot-path "${depot_path}" --output-file $ca_name
+elif [[ -z "$1" && -f "$depot_path/$ca_name.crt" ]]; then
+  echo -e "\e[1m\e[33m[INFO] Using existing blobstore CA, recreating only client/server certificates\e[0m"
+fi
 
 # Certificate to use for the server
 server_cn="blobstore.service.cf.internal"
-${scripts_folder}/generate_end_entity_certs --common-name ${server_cn} --ca-name server-ca --depot-path ${depot_path} --output-file server
-
+"${scripts_folder}"/generate_end_entity_certs --common-name "${server_cn}" --ca-name $ca_name --depot-path "${depot_path}" --output-file server

--- a/scripts/generate-cf-certs
+++ b/scripts/generate-cf-certs
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Install certstrap
+go get -v github.com/square/certstrap
+
+pushd "$(dirname "$0")/.." > /dev/null
+    creds_folder="$1" && shift
+    recreate="$1"
+    scripts/generate-consul-certs "$recreate"
+    scripts/generate-etcd-certs "$recreate"
+    scripts/generate-blobstore-certs "$recreate"
+    scripts/generate-uaa-certs "$recreate"
+    scripts/generate-cf-diego-certs "$recreate"
+    scripts/generate-loggregator-certs "$creds_folder" "$recreate"
+    scripts/generate-statsd-injector-certs "$creds_folder" "$recreate"
+popd > /dev/null

--- a/scripts/generate-cf-diego-certs
+++ b/scripts/generate-cf-diego-certs
@@ -1,22 +1,25 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -e -x
+set -e
 
-# Install certstrap
-go get -v github.com/square/certstrap
+scripts_folder="$(dirname "$0")"
 
 # Place keys and certificates here
 depot_path="cf-diego-certs"
-mkdir -p ${depot_path}
+ca_name="cf-diego-ca"
+mkdir -p "${depot_path}"
 
-# CA to distribute to diego and cloud_controller
-certstrap --depot-path ${depot_path} init --passphrase '' --common-name cf-diego-ca
+if [[ "$1" == "--recreate-ca" ]] || [[ -z "$1" && ! -f "$depot_path/$ca_name.crt" ]]; then
+  # CA to distribute to diego and cloud_controller
+  "${scripts_folder}"/generate_ca_cert --common-name "cfdiegoCA" --depot-path ${depot_path} --output-file "$ca_name"
+elif [[ -z "$1" && -f "$depot_path/$ca_name.crt" ]]; then
+  echo -e "\e[1m\e[33m[INFO] Using existing cf-diego CA, recreating only client/server certificates\e[0m"
+fi
 
 # Server certificate for cloud controller to act as a TLS server
 cc_cn=cloud-controller-ng.service.cf.internal
 certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name $cc_cn
-certstrap --depot-path ${depot_path} sign $cc_cn --CA cf-diego-ca
+certstrap --depot-path ${depot_path} sign $cc_cn --CA "$ca_name"
 mv -f ${depot_path}/$cc_cn.key ${depot_path}/cloud-controller.key
 mv -f ${depot_path}/$cc_cn.csr ${depot_path}/cloud-controller.csr
 mv -f ${depot_path}/$cc_cn.crt ${depot_path}/cloud-controller.crt
-

--- a/scripts/generate-consul-certs
+++ b/scripts/generate-consul-certs
@@ -1,20 +1,22 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -e -x
+set -e
 
-scripts_folder=$(dirname $0)
-
-# Install certstrap
-go get -v github.com/square/certstrap
+scripts_folder="$(dirname "$0")"
 
 # Place keys and certificates here
 depot_path="consul-certs"
 mkdir -p ${depot_path}
+ca_name="consul-ca"
 
-${scripts_folder}/generate_ca_cert --common-name "consulCA" --depot-path ${depot_path} --output-file server-ca
+if [[ "$1" == "--recreate-ca" ]] || [[ -z "$1" && ! -f "$depot_path/$ca_name.crt" ]]; then
+  "${scripts_folder}"/generate_ca_cert --common-name "consulCA" --depot-path ${depot_path} --output-file "$ca_name"
+elif [[ -z "$1" && -f "$depot_path/$ca_name.crt" ]]; then
+  echo -e "\e[1m\e[33m[INFO] Using existing consul CA, recreating only client/server certificates\e[0m"
+fi
 
 # Server certificate to share across the consul cluster
-${scripts_folder}/generate_end_entity_certs --common-name server.dc1.cf.internal --ca-name server-ca --depot-path ${depot_path} --output-file server
+"${scripts_folder}"/generate_end_entity_certs --common-name server.dc1.cf.internal --ca-name "$ca_name" --depot-path ${depot_path} --output-file server
 
 # Agent certificate to distribute to jobs that access consul
-${scripts_folder}/generate_end_entity_certs --common-name 'consul agent' --ca-name server-ca --depot-path ${depot_path} --output-file agent
+"${scripts_folder}"/generate_end_entity_certs --common-name 'consul agent' --ca-name "$ca_name" --depot-path ${depot_path} --output-file agent

--- a/scripts/generate-etcd-certs
+++ b/scripts/generate-etcd-certs
@@ -1,27 +1,28 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -e -x
+set -e
 
-scripts_folder=$(dirname $0)
-
-# Install certstrap
-go get -v github.com/square/certstrap
+scripts_folder="$(dirname "$0")"
 
 # Place keys and certificates here
 depot_path="etcd-certs"
 mkdir -p ${depot_path}
 
-# CA to distribute to etcd clients and servers
-${scripts_folder}/generate_ca_cert --common-name "etcdCA" --depot-path ${depot_path} --output-file etcd-ca
+
+if [[ "$1" == "--recreate-ca" ]] || [[ -z "$1" && ! -f "$depot_path/etcd-ca.crt" ]]; then
+    # CA to distribute to etcd clients and servers
+    "${scripts_folder}"/generate_ca_cert --common-name "etcdCA" --depot-path "${depot_path}" --output-file etcd-ca
+    # CA to distribute across etcd peerss
+    "${scripts_folder}"/generate_ca_cert --common-name "peerCA" --depot-path "${depot_path}" --output-file peer-ca
+elif [[ -z "$1" && -f "$depot_path/etcd-ca.crt" ]]; then
+    echo -e "\e[1m\e[33m[INFO] Using existing etcd/peer CA, recreating only client/server certificates\e[0m"
+fi
 
 # Server certificate to share across the etcd cluster
-${scripts_folder}/generate_end_entity_certs --common-name "cf-etcd.service.cf.internal" --ca-name etcd-ca --domain '*.cf-etcd.service.cf.internal,cf-etcd.service.cf.internal' --depot-path ${depot_path} --output-file server
+"${scripts_folder}"/generate_end_entity_certs --common-name "cf-etcd.service.cf.internal" --ca-name etcd-ca --domain '*.cf-etcd.service.cf.internal,cf-etcd.service.cf.internal' --depot-path "${depot_path}" --output-file server
 
 # Client certificate to distribute to jobs that access etcd
-${scripts_folder}/generate_end_entity_certs --common-name "clientName" --ca-name etcd-ca --depot-path ${depot_path} --output-file client
-
-# CA to distribute across etcd peers
-${scripts_folder}/generate_ca_cert --common-name "peerCA" --depot-path ${depot_path} --output-file peer-ca
+"${scripts_folder}"/generate_end_entity_certs --common-name "clientName" --ca-name etcd-ca --depot-path "${depot_path}" --output-file client
 
 # Client certificate to distribute across etcd peers
-${scripts_folder}/generate_end_entity_certs --common-name cf-etcd.service.cf.internal --domain '*.cf-etcd.service.cf.internal,cf-etcd.service.cf.internal' --ca-name peer-ca --depot-path ${depot_path} --output-file peer
+"${scripts_folder}"/generate_end_entity_certs --common-name cf-etcd.service.cf.internal --domain '*.cf-etcd.service.cf.internal,cf-etcd.service.cf.internal' --ca-name peer-ca --depot-path "${depot_path}" --output-file peer

--- a/scripts/generate-loggregator-certs
+++ b/scripts/generate-loggregator-certs
@@ -1,65 +1,72 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 
 if [ "$1" = "" ]; then
-    echo "usage: $0 <bbs-ca.crt> <bbs-ca.key>"
-    echo "       $0 no-bbs-ca"
+    echo "usage: $0 <cf-credentials-folder> [--recreate-ca]"
+    echo "       $0 no-bbs-ca [--recreate-ca]"
     exit 1
 fi
 
-set -x
-
 readlink() {
   (
-    cd $(dirname $1)
-    echo $PWD/$(basename $1)
+    cd "$(dirname "$1")"
+    echo "$PWD/$(basename "$1")"
   )
 }
 
 # Place keys and certificates here
 depot_path=$(readlink ./loggregator-certs)
-mkdir -p ${depot_path}
+mkdir -p "${depot_path}"
+ca_name="loggregator-ca"
 
-if [ "$1" = "no-bbs-ca" ]; then
-    bbs_ca_name="loggregator-ca"
+if [ "$1" == "no-bbs-ca" ]; then
+    bbs_ca_name="$ca_name"
 else
-    bbs_ca_cert_path=$(readlink ${1})
-    bbs_ca_key_path=$(readlink ${2})
-    bbs_ca_name=$(basename ${bbs_ca_cert_path} ".crt")
-    ln -s ${bbs_ca_cert_path} ${depot_path}/
-    ln -s ${bbs_ca_key_path} ${depot_path}/
+    bbs_ca_cert_path="$(find "$1" -name 'cf-diego-ca.crt')"
+    bbs_ca_key_path="$(find "$1" -name 'cf-diego-ca.key')"
+    bbs_ca_name="cf-diego-ca"
+    if [[ ! -f "$bbs_ca_cert_path" || ! -f "$bbs_ca_key_path" ]]; then
+        echo -e "\e[1m\e[33m[ERROR] Please execute generate-cf-diego-certs before running this script.\e[0m"
+        exit 1
+    fi
+    ln -s "${bbs_ca_cert_path}" "${depot_path}"/
+    ln -s "${bbs_ca_key_path}" "${depot_path}"/
 fi
 
-# Install certstrap
-go get -v github.com/square/certstrap
-
-# CA to distribute to loggregator certs
-certstrap --depot-path ${depot_path} init --passphrase '' --common-name loggregatorCA
-mv -f ${depot_path}/loggregatorCA.crt ${depot_path}/loggregator-ca.crt
-mv -f ${depot_path}/loggregatorCA.key ${depot_path}/loggregator-ca.key
-mv -f ${depot_path}/loggregatorCA.crl ${depot_path}/loggregator-ca.crl
+if [[ "$2" == "--recreate-ca" ]] || [[ -z "$2" && ! -f "$depot_path/$ca_name.crt" ]]; then
+  # CA to distribute to loggregator certs
+  certstrap --depot-path "${depot_path}" init --passphrase '' --common-name loggregatorCA
+  mv -f "${depot_path}/loggregatorCA.crt" "${depot_path}/$ca_name.crt"
+  mv -f "${depot_path}/loggregatorCA.key" "${depot_path}/$ca_name.key"
+  mv -f "${depot_path}/loggregatorCA.crl" "${depot_path}/$ca_name.crl"
+elif [[ -z "$2" && -f "$depot_path/$ca_name.crt" ]]; then
+  echo -e "\e[1m\e[33m[INFO] Using existing loggregator CA, recreating only client/server certificates\e[0m"
+fi
+find "${depot_path}" -type f -not -name "$ca_name*" -delete
 
 # Doppler certificate
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name doppler
-certstrap --depot-path ${depot_path} sign doppler --CA loggregator-ca
+certstrap --depot-path "${depot_path}" request-cert --passphrase '' --common-name doppler
+certstrap --depot-path "${depot_path}" sign doppler --CA "$ca_name"
 
 # Traffic Controller certificate
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name trafficcontroller
-certstrap --depot-path ${depot_path} sign trafficcontroller --CA loggregator-ca
+certstrap --depot-path "${depot_path}" request-cert --passphrase '' --common-name trafficcontroller
+certstrap --depot-path "${depot_path}" sign trafficcontroller --CA "$ca_name"
 
 # Traffic Controller<->CAPI mutual TLS certificate
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name cc_trafficcontroller
-certstrap --depot-path ${depot_path} sign cc_trafficcontroller --CA ${bbs_ca_name}
+certstrap --depot-path "${depot_path}" request-cert --passphrase '' --common-name cc_trafficcontroller
+certstrap --depot-path "${depot_path}" sign cc_trafficcontroller --CA "${bbs_ca_name}"
 
 # Metron certificate
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name metron
-certstrap --depot-path ${depot_path} sign metron --CA loggregator-ca
+certstrap --depot-path "${depot_path}" request-cert --passphrase '' --common-name metron
+certstrap --depot-path "${depot_path}" sign metron --CA "$ca_name"
 
 # Reverse Log Proxy certificate
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name reverselogproxy
-certstrap --depot-path ${depot_path} sign reverselogproxy --CA loggregator-ca
+certstrap --depot-path "${depot_path}" request-cert --passphrase '' --common-name reverselogproxy
+certstrap --depot-path "${depot_path}" sign reverselogproxy --CA "$ca_name"
 
 # Syslog drain binder certificate
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name syslogdrainbinder
-certstrap --depot-path ${depot_path} sign syslogdrainbinder --CA ${bbs_ca_name}
+certstrap --depot-path "${depot_path}" request-cert --passphrase '' --common-name syslogdrainbinder
+certstrap --depot-path "${depot_path}" sign syslogdrainbinder --CA "${bbs_ca_name}"
+
+rm -f "${depot_path}"/cf-diego-ca.{crt,key}

--- a/scripts/generate-statsd-injector-certs
+++ b/scripts/generate-statsd-injector-certs
@@ -1,44 +1,38 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 
+scripts_folder="$(dirname "$0")"
+
 if [ "$1" = "" ]; then
-    echo "usage: $0 <loggregator-ca.crt> <loggregator-ca.key>"
-    echo "       $0 no-loggregator-ca"
+    echo "usage: $0 <cf-credentials-folder> [--recreate-ca]"
     exit 1
 fi
 
-set -x
-
-# Install certstrap
-go get -v github.com/square/certstrap
-
 readlink() {
   (
-    cd $(dirname $1)
-    echo $PWD/$(basename $1)
+    cd "$(dirname "$1")"
+    echo "$PWD/$(basename "$1")"
   )
 }
 
 # Place keys and certificates here
 depot_path=$(readlink ./statsd-injector-certs)
-mkdir -p ${depot_path}
+mkdir -p "${depot_path}"
 
-if [ "$1" = "no-loggregator-ca" ]; then
-    # CA to sign statsdinjector certs
-    certstrap --depot-path ${depot_path} init --passphrase '' --common-name loggregatorCA
-    mv -f ${depot_path}/loggregatorCA.crt ${depot_path}/loggregator-ca.crt
-    mv -f ${depot_path}/loggregatorCA.key ${depot_path}/loggregator-ca.key
-    mv -f ${depot_path}/loggregatorCA.crl ${depot_path}/loggregator-ca.crl
-    loggregator_ca_name=loggregator-ca
-else
-    loggregator_ca_cert_path=$(readlink ${1})
-    loggregator_ca_key_path=$(readlink ${2})
-    loggregator_ca_name=$(basename ${loggregator_ca_cert_path} ".crt")
-    ln -s ${loggregator_ca_cert_path} ${depot_path}/
-    ln -s ${loggregator_ca_key_path} ${depot_path}/
+loggregator_ca_cert_path="$(find "$1/loggregator-certs" -name 'loggregator-ca.crt')"
+loggregator_ca_key_path="$(find "$1/loggregator-certs" -name 'loggregator-ca.key')"
+if [[ ! -f "$loggregator_ca_cert_path" || ! -f "$loggregator_ca_key_path" ]]; then
+    echo -e "\e[1m\e[33m[ERROR] Please execute generate-loggregator-certs before running this script.\e[0m"
+    exit 1
 fi
 
+find "$depot_path" -type l -delete
+ln -s "${loggregator_ca_cert_path}" "${depot_path}/"
+ln -s "${loggregator_ca_key_path}" "${depot_path}/"
+
 # Statsd injector certificate
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name statsdinjector
-certstrap --depot-path ${depot_path} sign statsdinjector --CA ${loggregator_ca_name}
+server_cn="statsdinjector.service.cf.internal"
+"${scripts_folder}"/generate_end_entity_certs --common-name "${server_cn}" --ca-name loggregator-ca --depot-path "${depot_path}" --output-file statsdinjector
+
+find "$depot_path" -type l -delete

--- a/scripts/generate-uaa-certs
+++ b/scripts/generate-uaa-certs
@@ -1,19 +1,21 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e -x
+set -e
 
-scripts_folder=$(dirname $0)
-
-# Install certstrap
-go get -v github.com/square/certstrap
+scripts_folder="$(dirname "$0")"
 
 # Place keys and certificates here
 depot_path="uaa-certs"
-mkdir -p ${depot_path}
+mkdir -p "${depot_path}"
+ca_name="uaa-ca"
 
-# CA to generate client certs
-${scripts_folder}/generate_ca_cert --common-name "cert-authority" --depot-path ${depot_path} --output-file server-ca
+if [[ "$1" == "--recreate-ca" ]] || [[ -z "$1" && ! -f "$depot_path/$ca_name.crt" ]]; then
+  # CA to generate client certs
+  "${scripts_folder}"/generate_ca_cert --common-name "cert-authority" --depot-path "${depot_path}" --output-file "$ca_name"
+elif [[ -z "$1" && -f "$depot_path/$ca_name.crt" ]]; then
+  echo -e "\e[1m\e[33m[INFO] Using existing uaa CA, recreating only client/server certificates\e[0m"
+fi
 
 # Certificate to use as the client
 server_cn="uaa.service.cf.internal"
-${scripts_folder}/generate_end_entity_certs --common-name ${server_cn} --ca-name server-ca --depot-path ${depot_path} --output-file server
+"${scripts_folder}"/generate_end_entity_certs --common-name "${server_cn}" --ca-name "$ca_name" --depot-path "${depot_path}" --output-file server

--- a/scripts/generate_ca_cert
+++ b/scripts/generate_ca_cert
@@ -1,20 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 common_name=''
 depot_path=''
 output_path=''
 
-set -x
-
 show_help() {
-  set +x
   echo "Usage: generate_ca_cert [OPTIONS]"
   echo "Output Options:"
   echo "  -n --common-name [REQUIRED]     The common name for the CA"
   echo "  -p --depot-path  [REQUIRED]     The depot path (where all files will be written to) for the CA"
   echo "  -o --output-file [REQUIRED]     The output file name of the CA cert and key"
   echo "  -h --help            Show a help message"
-  set -x
   exit 0
 }
 
@@ -29,7 +25,7 @@ while true; do
   esac
 done
 
-if [ "${common_name}" == "" -o "${depot_path}" == "" -o "${output_path}" == "" ]; then
+if [[ "${common_name}" == "" || "${depot_path}" == "" || "${output_path}" == "" ]]; then
   show_help
 fi
 

--- a/scripts/generate_end_entity_certs
+++ b/scripts/generate_end_entity_certs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 common_name=''
 depot_path=''
@@ -6,7 +6,7 @@ output_path=''
 ca_name=''
 domain=''
 
-set -e -x
+set -e
 
 show_help() {
   set +x
@@ -35,7 +35,7 @@ while true; do
   esac
 done
 
-if [ "${common_name}" == "" -o "${depot_path}" == "" -o "${output_path}" == "" -o "${ca_name}" == "" ]; then
+if [[ "${common_name}" == "" || "${depot_path}" == "" || "${output_path}" == "" || "${ca_name}" == "" ]]; then
   show_help
 fi
 
@@ -43,7 +43,7 @@ if [ "${domain}" != "" ]; then
   domain_argument="--domain ${domain}"
 fi
 
-common_name_path=$(echo $common_name | tr ' ' _)
+common_name_path=$(echo "$common_name" | tr ' ' _)
 
 certstrap --depot-path "${depot_path}" request-cert --passphrase '' --common-name "${common_name}" ${domain_argument}
 certstrap --depot-path "${depot_path}" sign "${common_name_path}" --CA "${ca_name}"


### PR DESCRIPTION
- Recreating the CA by default will lead to a downtime if the "multi-step" deployment approach is not followed.
This PR introduces a new paramter (`--recreate-ca`) that, if passed to the scripts, will generate/recreate also the CA.
By default now all the scripts will skip the CA generation and will use the
existing one instead.

- fix shellcheck issues

- use `/usr/bin/env bash` as shebang, so MAC users have less issues

- one mandatory parameter ($1) is path to where the certs are store

- a second optional paramter is "--recreate-ca". If not specified, only the client/server certs will be recreated