### PR TITLE
Not default to debug2 logging level in CC

### DIFF
--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -744,8 +744,8 @@ properties:
     internal_api_user: "internal_user"
     internal_api_password: (( bulk_api_password ))
 
-    logging_level: debug
-    db_logging_level: debug
+    logging_level: info
+    db_logging_level: off
 
     staging_upload_user: (( merge ))
     staging_upload_password: (( merge ))

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -744,8 +744,8 @@ properties:
     internal_api_user: "internal_user"
     internal_api_password: (( bulk_api_password ))
 
-    logging_level: debug2
-    db_logging_level: debug2
+    logging_level: debug
+    db_logging_level: debug
 
     staging_upload_user: (( merge ))
     staging_upload_password: (( merge ))


### PR DESCRIPTION
debug2 logging level is too verbose and logs database queries. This could expose secrets.