### PR TITLE
Remove default bridge temporary_* flags for bosh-lite

### DIFF
--- a/spec/fixtures/bosh-lite/cf-manifest.yml
+++ b/spec/fixtures/bosh-lite/cf-manifest.yml
@@ -2920,13 +2920,13 @@ properties:
         url: null
       insecure_docker_registry_list: null
       pid_limit: null
-      temporary_cc_uploader_mtls: false
-      temporary_droplet_download_mtls: false
-      temporary_local_apps: false
-      temporary_local_staging: false
-      temporary_local_sync: false
-      temporary_local_tasks: false
-      temporary_local_tps: false
+      temporary_cc_uploader_mtls: null
+      temporary_droplet_download_mtls: null
+      temporary_local_apps: null
+      temporary_local_staging: null
+      temporary_local_sync: null
+      temporary_local_tasks: null
+      temporary_local_tps: null
       use_privileged_containers_for_running: null
       use_privileged_containers_for_staging: null
     directories: null

--- a/templates/cf-infrastructure-bosh-lite.yml
+++ b/templates/cf-infrastructure-bosh-lite.yml
@@ -488,14 +488,6 @@ properties:
     monitor_port: 4221
 
   cc:
-    diego:
-      temporary_local_staging: false
-      temporary_local_tasks: false
-      temporary_local_apps: false
-      temporary_local_sync: false
-      temporary_local_tps: false
-      temporary_cc_uploader_mtls: false
-      temporary_droplet_download_mtls: false
     tls_port: 9023
     mutual_tls:
       ca_cert: |


### PR DESCRIPTION
- Bypassing bridge is the default behavior now.

Equivalent CF Deployment PR: https://github.com/cloudfoundry/cf-deployment/pull/337

CAPI story: https://www.pivotaltracker.com/story/show/152623585
Wait until CAPI 1.46 to merge: https://www.pivotaltracker.com/story/show/152730060

Signed-off-by: Eric Promislow <eric.promislow@suse.com>