### PR TITLE
Set directories_to_backup bosh link to nil

### DIFF
--- a/spec/fixtures/aws/cf-manifest.yml
+++ b/spec/fixtures/aws/cf-manifest.yml
@@ -246,7 +246,9 @@ jobs:
     release: cf
   - name: metron_agent
     release: cf
-  - name: blobstore
+  - consumes:
+      directories_to_backup: nil
+    name: blobstore
     release: cf
   - consumes:
       nats: nil
@@ -286,7 +288,9 @@ jobs:
     release: cf
   - name: metron_agent
     release: cf
-  - name: blobstore
+  - consumes:
+      directories_to_backup: nil
+    name: blobstore
     release: cf
   - consumes:
       nats: nil
@@ -1235,6 +1239,7 @@ properties:
         total_service_keys: 1000
         total_services: 100
     rate_limiter: null
+    release_level_backup: false
     reserved_private_domains: null
     resource_pool:
       blobstore_type: fog

--- a/spec/fixtures/bosh-lite/cf-manifest.yml
+++ b/spec/fixtures/bosh-lite/cf-manifest.yml
@@ -240,7 +240,9 @@ jobs:
     release: cf
   - name: metron_agent
     release: cf
-  - name: blobstore
+  - consumes:
+      directories_to_backup: nil
+    name: blobstore
     release: cf
   - consumes:
       nats: nil
@@ -280,7 +282,9 @@ jobs:
     release: cf
   - name: metron_agent
     release: cf
-  - name: blobstore
+  - consumes:
+      directories_to_backup: nil
+    name: blobstore
     release: cf
   - consumes:
       nats: nil
@@ -3157,6 +3161,7 @@ properties:
         total_service_keys: 1000
         total_services: 100
     rate_limiter: null
+    release_level_backup: false
     reserved_private_domains: null
     resource_pool:
       blobstore_type: webdav

--- a/spec/fixtures/openstack/cf-manifest.yml
+++ b/spec/fixtures/openstack/cf-manifest.yml
@@ -243,6 +243,8 @@ jobs:
     release: cf
   - name: blobstore
     release: cf
+    consumes:
+      directories_to_backup: nil
   - consumes:
       nats: nil
     name: route_registrar
@@ -283,6 +285,8 @@ jobs:
     release: cf
   - name: blobstore
     release: cf
+    consumes:
+      directories_to_backup: nil
   - consumes:
       nats: nil
     name: route_registrar
@@ -1253,6 +1257,7 @@ properties:
         total_service_keys: 1000
         total_services: 100
     rate_limiter: null
+    release_level_backup: false
     reserved_private_domains: null
     resource_pool:
       blobstore_type: webdav

--- a/spec/fixtures/vsphere/cf-manifest.yml
+++ b/spec/fixtures/vsphere/cf-manifest.yml
@@ -250,6 +250,8 @@ jobs:
     release: cf
   - name: blobstore
     release: cf
+    consumes:
+      directories_to_backup: nil
   - consumes:
       nats: nil
     name: route_registrar
@@ -290,6 +292,8 @@ jobs:
     release: cf
   - name: blobstore
     release: cf
+    consumes:
+      directories_to_backup: nil
   - consumes:
       nats: nil
     name: route_registrar
@@ -1241,6 +1245,7 @@ properties:
         total_service_keys: 1000
         total_services: 100
     rate_limiter: null
+    release_level_backup: false
     reserved_private_domains: null
     resource_pool:
       blobstore_type: webdav

--- a/templates/cf.yml
+++ b/templates/cf.yml
@@ -756,6 +756,8 @@ properties:
 
     disable_custom_buildpacks: false
 
+    release_level_backup: false
+
     broker_client_timeout_seconds: 70
     broker_client_default_async_poll_interval_seconds: ~
     broker_client_max_async_poll_duration_minutes: ~
@@ -1374,6 +1376,7 @@ meta:
     release: (( meta.loggregator_release_name ))
   - name: blobstore
     release: (( meta.capi_release_name ))
+    consumes: {directories_to_backup: nil}
   - name: route_registrar
     release: (( meta.routing_release_name ))
     consumes: {nats: nil}
@@ -1388,6 +1391,7 @@ meta:
     release: (( meta.loggregator_release_name ))
   - name: blobstore
     release: (( meta.capi_release_name ))
+    consumes: {directories_to_backup: nil}
   - name: route_registrar
     release: (( meta.routing_release_name ))
     consumes: {nats: nil}


### PR DESCRIPTION
This property is provided by capi-release, but since
bosh links and bbr are not active in cf-release, we will
disable this link for the blobstores that consume it.

[#153883420]

Signed-off-by: Elena Sharma <esharma@pivotal.io>